### PR TITLE
fix: Correct Liquid metafield namespace for bundle widget data loading

### DIFF
--- a/extensions/bundle-builder/blocks/bundle.liquid
+++ b/extensions/bundle-builder/blocks/bundle.liquid
@@ -464,8 +464,8 @@
 {% endif %}
 
 <script>
-  // Inject app URL from shop metafield (auto-updated by app server)
-  window.__BUNDLE_APP_URL__ = {{ shop.metafields.app_config.server_url.value | json }};
+  // Inject app URL from shop metafield (auto-synced when merchant accesses app admin)
+  window.__BUNDLE_APP_URL__ = {{ shop.metafields.app_config.server_url | json }};
 </script>
 
 <script>
@@ -473,8 +473,9 @@
   // This is much faster than shop-level metafields and naturally isolated
   if (!window.allBundlesData) {
     // Primary source: product's bundle_config metafield
-    // Note: For json metafields, access directly without .value
-    const productBundleConfig = {{ product.metafields['$app'].bundle_config | json }};
+    // Note: Shopify automatically scopes app metafields - use 'app' namespace in Liquid
+    // The '$app' namespace in Admin API translates to 'app' in Liquid
+    const productBundleConfig = {{ product.metafields.app.bundle_config | json }};
 
     // Set as allBundlesData object (widget expects this name)
     // Create an object with the bundle ID as key for compatibility


### PR DESCRIPTION
ISSUE:
Bundle widget failed with "No bundle data available" error on storefront. Root cause analysis revealed metafield namespace mismatch:
- Liquid template used: product.metafields['$app'].bundle_config
- Shopify stores as: app--{APP_ID}:bundle_config
- Correct Liquid access: product.metafields.app.bundle_config

ANALYSIS PERFORMED:
1. Traced complete bundle data flow from DB → metafield sync → storefront
2. Verified bundle exists in database (ID: cmhv5k32k0001gl3f4l4z50q3)
3. Confirmed metafields ARE set via Shopify Admin API query
4. Identified namespace translation issue between Admin API and Liquid

FIXES:
1. Changed product.metafields['$app'] → product.metafields.app
2. Removed .value accessor for shop metafield (JSON fields don't need it)
3. Added explanatory comments about namespace translation

TECHNICAL DETAILS:
- In Admin API: namespace is "$app" (special reserved namespace)
- Shopify translates to: "app--{APP_ID}" in storage
- In Liquid: access via "app" object (automatic scoping)

REFERENCES:
- Shopify Liquid metafield docs
- App Bridge metafield best practices
- Bundle product ID: gid://shopify/Product/10304540508454