### PR TITLE
fix: Use correct bracket notation for $app metafield access in Liquid

### DIFF
--- a/extensions/bundle-builder/blocks/bundle.liquid
+++ b/extensions/bundle-builder/blocks/bundle.liquid
@@ -473,9 +473,9 @@
   // This is much faster than shop-level metafields and naturally isolated
   if (!window.allBundlesData) {
     // Primary source: product's bundle_config metafield
-    // Note: Shopify automatically scopes app metafields - use 'app' namespace in Liquid
-    // The '$app' namespace in Admin API translates to 'app' in Liquid
-    const productBundleConfig = {{ product.metafields.app.bundle_config | json }};
+    // Note: App-scoped metafields ($app namespace) require bracket notation in theme app extensions
+    // Reference: https://shopify.dev/changelog/metafields-and-metaobjects-reserved-prefixes-now-supported-in-theme-app-extensions
+    const productBundleConfig = {{ product.metafields['$app']['bundle_config'] | json }};
 
     // Set as allBundlesData object (widget expects this name)
     // Create an object with the bundle ID as key for compatibility


### PR DESCRIPTION
ISSUE:
Bundle widget still failing with "No bundle data available" after initial fix. Previous attempt used dot notation (product.metafields.app.bundle_config) which doesn't work for reserved $app namespace in theme app extensions.

ROOT CAUSE:
As of August 2024, Shopify supports $app reserved prefix in theme app extensions, but it requires bracket notation, not dot notation.

SHOPIFY DOCUMENTATION:
- Reserved prefixes in theme extensions: https://shopify.dev/changelog/metafields-and-metaobjects-reserved-prefixes-now-supported-in-theme-app-extensions
- Correct syntax: product.metafields['$app']['key']
- Incorrect syntax: product.metafields.app.key OR product.metafields.$app.key

FIX APPLIED:
Changed from: product.metafields.app.bundle_config
Changed to:   product.metafields['$app']['bundle_config']

VERIFICATION:
- Metafield confirmed exists via Admin API query
- Namespace: $app (stored as app--261615583233 internally)
- Key: bundle_config
- Type: json
- Contains: Bundle config with 3 steps and pricing

ARCHITECTURE NOTE:
This follows Shopify's recommended approach for theme app extensions to avoid hardcoding app IDs and work across different environments.

🤖 Generated with Claude Code