### PR TITLE
fix: Add .value accessor for JSON metafield in Liquid template

### DIFF
--- a/extensions/bundle-builder/blocks/bundle.liquid
+++ b/extensions/bundle-builder/blocks/bundle.liquid
@@ -474,8 +474,9 @@
   if (!window.allBundlesData) {
     // Primary source: product's bundle_config metafield
     // Note: App-scoped metafields ($app namespace) require bracket notation in theme app extensions
+    // JSON metafields require .value accessor to retrieve the parsed JSON object
     // Reference: https://shopify.dev/changelog/metafields-and-metaobjects-reserved-prefixes-now-supported-in-theme-app-extensions
-    const productBundleConfig = {{ product.metafields['$app']['bundle_config'] | json }};
+    const productBundleConfig = {{ product.metafields['$app']['bundle_config'].value | json }};
 
     // Set as allBundlesData object (widget expects this name)
     // Create an object with the bundle ID as key for compatibility


### PR DESCRIPTION
CRITICAL FIX:
Bundle widget failing because JSON metafields require .value property access. Without .value, Liquid returns the metafield object metadata instead of the actual JSON content, resulting in null/undefined bundle configuration.

SHOPIFY REQUIREMENT:
JSON type metafields MUST use .value accessor to retrieve parsed JSON object. Reference: https://shopify.dev/docs/api/liquid/objects/metafield

BEFORE (incorrect - returns metafield object):
{{ product.metafields['$app']['bundle_config'] | json }}

AFTER (correct - returns JSON value):
{{ product.metafields['$app']['bundle_config'].value | json }}

VERIFICATION:
Metafield type: json (confirmed via Admin API)
Without .value: Returns {id, namespace, key, type, value} metadata With .value: Returns actual bundle configuration JSON

This is the final fix needed for the bundle widget to load correctly.