### PR TITLE
fix: Enable storefront access for bundle_config metafield

### DIFF
--- a/app/services/bundle-isolation.server.ts
+++ b/app/services/bundle-isolation.server.ts
@@ -137,7 +137,10 @@ export class BundleIsolationService {
               namespace: "$app",
               key: "bundle_config",
               type: "json",
-              value: JSON.stringify(bundleMetafieldData)
+              value: JSON.stringify(bundleMetafieldData),
+              access: {
+                storefront: "PUBLIC_READ"
+              }
             }
           ]
         }


### PR DESCRIPTION
Add PUBLIC_READ storefront access to bundle_config metafield creation. This allows Liquid templates in theme extensions to read the metafield, fixing the production issue where bundle data was not accessible.