### PR TITLE
fix: Replace invalid unauthenticated_read_products scope with unauthenticated_read_content

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -19,7 +19,7 @@ api_version = "2025-04"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "read_content,read_product_listings,read_products,read_themes,write_themes,write_cart_transforms,write_discounts,write_products,write_themes,unauthenticated_read_product_listings,unauthenticated_read_products"
+scopes = "read_content,read_product_listings,read_products,read_themes,write_themes,write_cart_transforms,write_discounts,write_products,write_themes,unauthenticated_read_product_listings,unauthenticated_read_content"
 
 [auth]
 redirect_urls = [


### PR DESCRIPTION
The scope unauthenticated_read_products is not valid. The correct unauthenticated scopes for product data are:
- unauthenticated_read_product_listings (already present)
- unauthenticated_read_content (for storefront content)

This fixes the app version deployment error.