### PR TITLE
fix: Enable storefront access for bundle_config metafield to fix widget loading

### DIFF
--- a/app/services/bundle-isolation.server.ts
+++ b/app/services/bundle-isolation.server.ts
@@ -3,6 +3,7 @@
 // Uses product-level metafields for optimal performance
 
 import { AppLogger } from "../lib/logger";
+import { ensureStandardMetafieldDefinitions } from "./bundles/standard-metafields.server";
 
 export class BundleIsolationService {
 
@@ -11,12 +12,14 @@ export class BundleIsolationService {
    * Stores bundle config on the bundle product itself for fast, isolated access
    */
   static async updateBundleProductMetafield(admin: any, bundleProductId: string, bundleConfig: any) {
-    AppLogger.info('Updating bundle product metafield', { 
-      component: 'isolation', 
+    AppLogger.info('Updating bundle product metafield', {
+      component: 'isolation',
       operation: 'update-metafield'
     }, { bundleProductId });
 
     try {
+      // Ensure bundle_config metafield definition exists with storefront access
+      await ensureStandardMetafieldDefinitions(admin);
       // Helper function to safely parse JSON
       const safeJsonParse = (value: any, defaultValue: any = []) => {
         if (!value) return defaultValue;
@@ -137,10 +140,9 @@ export class BundleIsolationService {
               namespace: "$app",
               key: "bundle_config",
               type: "json",
-              value: JSON.stringify(bundleMetafieldData),
-              access: {
-                storefront: "PUBLIC_READ"
-              }
+              value: JSON.stringify(bundleMetafieldData)
+              // Note: access/storefront visibility must be configured on the metafield DEFINITION,
+              // not on individual metafield values. See ensureStandardMetafieldDefinitions()
             }
           ]
         }

--- a/app/services/bundles/standard-metafields.server.ts
+++ b/app/services/bundles/standard-metafields.server.ts
@@ -281,6 +281,17 @@ export async function ensureStandardMetafieldDefinitions(admin: any) {
   // Use app-reserved namespace to avoid type conflicts with existing custom namespace definitions
   const standardDefinitions = [
     {
+      namespace: "$app",
+      key: "bundle_config",
+      name: "Bundle Configuration",
+      description: "Complete bundle configuration for storefront display",
+      type: "json",
+      ownerType: "PRODUCT",
+      access: {
+        storefront: "PUBLIC_READ"
+      }
+    },
+    {
       namespace: "$app", // App-reserved namespace avoids conflicts
       key: "component_reference",
       name: "Component Reference",

--- a/app/shopify.server.ts
+++ b/app/shopify.server.ts
@@ -10,6 +10,7 @@ import { PrismaSessionStorage } from "@shopify/shopify-app-session-storage-prism
 import prisma from "./db.server";
 import { createStorefrontAccessToken } from "./services/storefront-token.server";
 import { CartTransformService } from "./services/cart-transform-service.server";
+import { ensureStandardMetafieldDefinitions } from "./services/bundles/standard-metafields.server";
 
 const shopify = shopifyApp({
   apiKey: process.env.SHOPIFY_API_KEY,
@@ -27,6 +28,16 @@ const shopify = shopifyApp({
   hooks: {
     afterAuth: async ({ session, admin }) => {
       console.log("[SHOPIFY] afterAuth hook triggered for shop:", session.shop);
+
+      // Ensure metafield definitions exist with proper storefront access
+      try {
+        console.log("[SHOPIFY] Ensuring metafield definitions...");
+        await ensureStandardMetafieldDefinitions(admin);
+        console.log("[SHOPIFY] ✅ Metafield definitions verified");
+      } catch (error: any) {
+        console.error("[SHOPIFY] ⚠️ Failed to ensure metafield definitions:", error?.message || error);
+        console.error("[SHOPIFY] ℹ️ This is non-critical. Definitions will be created when bundles are saved.");
+      }
 
       // Create storefront access token after successful auth
       // This is optional - the app will work without it, but product fetching will be slower


### PR DESCRIPTION
Root Cause:
- Bundle widget failing with "No bundle data available" error on production
- bundle_config metafield in $app namespace was not accessible from Liquid templates
- App-reserved metafields require explicit storefront access configuration

Changes:
- Add bundle_config to standard metafield definitions with PUBLIC_READ storefront access
- Ensure metafield definitions are created during app installation (afterAuth hook)
- Call ensureStandardMetafieldDefinitions before setting bundle config metafields
- Remove invalid access parameter from metafieldsSet mutation (must be set on definition)

Technical Details:
- Storefront access must be configured on metafield DEFINITION, not individual values
- Liquid template uses product.metafields['$app']['bundle_config'].value
- This requires the definition to have access.storefront = "PUBLIC_READ"
- Follows Shopify best practices for app metafield storefront visibility

Impact:
- Bundle widget will now load configuration data correctly on production storefronts
- Fixes "No bundle data available" error displayed to customers
- Ensures bundle products display properly with the bundle builder interface