### PR TITLE
fix: Add .value accessor for JSON metafield in Liquid template

### DIFF
--- a/extensions/bundle-builder/blocks/bundle.liquid
+++ b/extensions/bundle-builder/blocks/bundle.liquid
@@ -279,7 +279,7 @@
   {% assign auto_display_mode = true %}
   {% comment %} Load bundle configuration from container metafields {% endcomment %}
   {% if product.metafields['$app'].bundle_config %}
-    {% assign bundle_config = product.metafields['$app'].bundle_config %}
+    {% assign bundle_config = product.metafields['$app'].bundle_config.value %}
   {% endif %}
 {% endif %}
 
@@ -381,7 +381,7 @@
       data-is-container-product="{{ is_container_product }}"
       data-container-bundle-id="{{ container_bundle_id }}"
       data-auto-display-mode="{{ auto_display_mode }}"
-      data-bundle-config="{{ bundle_config | escape }}"
+      data-bundle-config="{{ bundle_config | json | escape }}"
       data-hide-default-buttons="{{ hide_default_buttons }}"
       data-show-title="{{ block.settings.show_bundle_title }}"
       data-show-step-numbers="{{ block.settings.show_step_numbers }}"


### PR DESCRIPTION
Problem:
- Bundle widget failed with "No bundle data available" error
- window.allBundlesData was null on storefront
- data-bundle-config attribute wasn't properly populated

Root Cause:
Line 282: product.metafields['$app'].bundle_config returned metafield object instead of parsed JSON value

Line 384: Missing json filter prevented proper string conversion for data attribute

Solution:
- Line 282: Added .value accessor to get parsed JSON from metafield
- Line 384: Added | json filter to convert object to JSON string

Impact:
Enables JavaScript widget's Source 1 data loading approach: JSON.parse(container.dataset.bundleConfig) now works correctly

Related to bundle_config metafield storefront access fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)