### PR TITLE
fix: Add storefront access for bundle_isolation metafields

### DIFF
--- a/app/services/bundles/standard-metafields.server.ts
+++ b/app/services/bundles/standard-metafields.server.ts
@@ -291,6 +291,40 @@ export async function ensureStandardMetafieldDefinitions(admin: any) {
         storefront: "PUBLIC_READ"
       }
     },
+    // Bundle isolation metafields - MUST have storefront access for Liquid template to read them
+    {
+      namespace: "$app:bundle_isolation",
+      key: "bundle_product_type",
+      name: "Bundle Product Type",
+      description: "Identifies the type of bundle product (cart_transform_bundle)",
+      type: "single_line_text_field",
+      ownerType: "PRODUCT",
+      access: {
+        storefront: "PUBLIC_READ"
+      }
+    },
+    {
+      namespace: "$app:bundle_isolation",
+      key: "owns_bundle_id",
+      name: "Owns Bundle ID",
+      description: "The ID of the bundle this product owns/contains",
+      type: "single_line_text_field",
+      ownerType: "PRODUCT",
+      access: {
+        storefront: "PUBLIC_READ"
+      }
+    },
+    {
+      namespace: "$app:bundle_isolation",
+      key: "isolation_created",
+      name: "Isolation Created Timestamp",
+      description: "Timestamp when bundle isolation was set up",
+      type: "single_line_text_field",
+      ownerType: "PRODUCT",
+      access: {
+        storefront: "PUBLIC_READ"
+      }
+    },
     {
       namespace: "$app", // App-reserved namespace avoids conflicts
       key: "component_reference",


### PR DESCRIPTION
CRITICAL FIX: The bundle widget was not appearing because the Liquid template couldn't read bundle_isolation metafields on the storefront.

Root Cause:
- bundle_config metafield had PUBLIC_READ storefront access
- bundle_isolation metafields (bundle_product_type, owns_bundle_id, isolation_created) had NO metafield definitions with storefront access
- Liquid template line 276 check failed: product.metafields['$app:bundle_isolation'].bundle_product_type == 'cart_transform_bundle'
- This prevented widget container from rendering entirely

Changes:
- Added metafield definitions for all bundle_isolation keys with PUBLIC_READ access
- Ensures Liquid template can access these metafields on storefront

Impact:
- Widget container will now render correctly when bundle products are viewed
- After this deploys, merchants may need to re-save existing bundles to trigger metafield definition updates via afterAuth hook

Related Issue: Widget showing "Container NOT FOUND" error