### PR TITLE
fix: Complete metafield flow rewrite following Shopify best practices

### DIFF
--- a/app/assets/bundle-widget-full.js
+++ b/app/assets/bundle-widget-full.js
@@ -952,25 +952,43 @@ class BundleWidget {
     let bundleData = null;
 
     // Source 1: data-bundle-config attribute
-    if (this.container.dataset.bundleConfig) {
+    const configValue = this.container.dataset.bundleConfig;
+    if (configValue && configValue.trim() !== '' && configValue !== 'null' && configValue !== 'undefined') {
       try {
-        const singleBundle = JSON.parse(this.container.dataset.bundleConfig);
-        bundleData = { [singleBundle.id]: singleBundle };
+        const singleBundle = JSON.parse(configValue);
+        // Additional validation: ensure parsed result is a valid object with an id
+        if (singleBundle && typeof singleBundle === 'object' && singleBundle.id) {
+          bundleData = { [singleBundle.id]: singleBundle };
+          console.log('[WIDGET_INIT] ✅ Loaded bundle data from data-bundle-config:', singleBundle.id);
+        } else {
+          console.warn('[WIDGET_INIT] ⚠️ Parsed bundle config is invalid (missing id):', singleBundle);
+        }
       } catch (error) {
-        console.error('[WIDGET_INIT] Failed to parse data-bundle-config:', error);
+        console.error('[WIDGET_INIT] ❌ Failed to parse data-bundle-config:', error, 'Value:', configValue.substring(0, 100));
       }
+    } else {
+      console.warn('[WIDGET_INIT] ⚠️ data-bundle-config is empty, null, or undefined:', configValue);
     }
 
     // Source 2: window.allBundlesData
-    if (!bundleData && window.allBundlesData) {
+    if (!bundleData && window.allBundlesData && typeof window.allBundlesData === 'object') {
       bundleData = window.allBundlesData;
+      console.log('[WIDGET_INIT] ✅ Loaded bundle data from window.allBundlesData:', Object.keys(bundleData));
     }
 
-    if (!bundleData) {
-      throw new Error('No bundle data available');
+    if (!bundleData || (typeof bundleData === 'object' && Object.keys(bundleData).length === 0)) {
+      const errorMsg = 'No valid bundle data available. Ensure bundle is saved in admin and metafields have storefront access.';
+      console.error('[WIDGET_INIT] ❌', errorMsg);
+      console.error('[WIDGET_INIT] 🔍 Debug info:', {
+        configValue: configValue?.substring(0, 100),
+        windowData: window.allBundlesData,
+        containerDataset: this.container.dataset
+      });
+      throw new Error(errorMsg);
     }
 
     this.bundleData = bundleData;
+    console.log('[WIDGET_INIT] ✅ Bundle data loaded successfully');
   }
 
   selectBundle() {

--- a/app/services/bundles/standard-metafields.server.ts
+++ b/app/services/bundles/standard-metafields.server.ts
@@ -331,7 +331,10 @@ export async function ensureStandardMetafieldDefinitions(admin: any) {
       name: "Component Reference",
       description: "Bundle component variant IDs",
       type: "list.product_reference",
-      ownerType: "PRODUCT"
+      ownerType: "PRODUCT",
+      access: {
+        storefront: "PUBLIC_READ"
+      }
     },
     {
       namespace: "$app",
@@ -339,7 +342,10 @@ export async function ensureStandardMetafieldDefinitions(admin: any) {
       name: "Component Quantities",
       description: "Bundle component quantities",
       type: "list.number_integer",
-      ownerType: "PRODUCT"
+      ownerType: "PRODUCT",
+      access: {
+        storefront: "PUBLIC_READ"
+      }
     },
     {
       namespace: "$app",
@@ -347,7 +353,10 @@ export async function ensureStandardMetafieldDefinitions(admin: any) {
       name: "Component Parents",
       description: "Bundle parent configurations",
       type: "json",
-      ownerType: "PRODUCT"
+      ownerType: "PRODUCT",
+      access: {
+        storefront: "PUBLIC_READ"
+      }
     },
     {
       namespace: "$app",
@@ -355,7 +364,10 @@ export async function ensureStandardMetafieldDefinitions(admin: any) {
       name: "Price Adjustment",
       description: "Bundle price adjustment configuration",
       type: "number_decimal",
-      ownerType: "PRODUCT"
+      ownerType: "PRODUCT",
+      access: {
+        storefront: "PUBLIC_READ"
+      }
     }
   ];
 

--- a/extensions/bundle-builder/blocks/bundle.liquid
+++ b/extensions/bundle-builder/blocks/bundle.liquid
@@ -275,15 +275,16 @@
 {% comment %} PRIMARY CHECK: Is this product a designated bundle container? {% endcomment %}
 {% comment %} Access app-owned metafields using $app:namespace syntax (Shopify best practice for theme app extensions) {% endcomment %}
 {% comment %} Reference: https://shopify.dev/docs/apps/build/online-store/theme-app-extensions/configuration {% endcomment %}
-{% assign bundle_product_type = product.metafields["$app:bundle_isolation"].bundle_product_type.value %}
-{% assign owns_bundle_id = product.metafields["$app:bundle_isolation"].owns_bundle_id.value %}
+{% comment %} IMPORTANT: Use bracket notation for both namespace AND key, then chain .value accessor {% endcomment %}
+{% assign bundle_product_type = product.metafields["$app:bundle_isolation"]["bundle_product_type"].value %}
+{% assign owns_bundle_id = product.metafields["$app:bundle_isolation"]["owns_bundle_id"].value %}
 
 {% if bundle_product_type == 'cart_transform_bundle' %}
   {% assign is_container_product = true %}
   {% assign container_bundle_id = owns_bundle_id %}
   {% assign auto_display_mode = true %}
   {% comment %} Load bundle configuration from $app namespace (JSON type requires .value) {% endcomment %}
-  {% assign bundle_config = product.metafields["$app"].bundle_config.value %}
+  {% assign bundle_config = product.metafields["$app"]["bundle_config"].value %}
 {% endif %}
 
 {% comment %} SECONDARY CHECK: Widget configured with specific bundle ID (theme editor) {% endcomment %}
@@ -329,16 +330,16 @@
 
       // 🔍 Enhanced debugging for metafield access
       console.log('🔍 [THEME_DEBUG] Product Metafields Check:', {
-        // App-owned metafields with $app:namespace syntax
+        // App-owned metafields with $app:namespace syntax (using bracket notation)
         bundleProductType: {{ bundle_product_type | json }},
         ownsBundleId: {{ owns_bundle_id | json }},
         // Bundle config from $app namespace
-        bundleConfigRaw: {{ product.metafields["$app"].bundle_config | json }},
-        bundleConfigValue: {{ product.metafields["$app"].bundle_config.value | json }},
+        bundleConfigRaw: {{ product.metafields["$app"]["bundle_config"] | json }},
+        bundleConfigValue: {{ product.metafields["$app"]["bundle_config"].value | json }},
         bundleConfigVariable: {{ bundle_config | json }},
         // Check if metafield objects exist
         hasIsolationMetafield: {{ product.metafields["$app:bundle_isolation"] | json }},
-        hasBundleConfigMetafield: {{ product.metafields["$app"].bundle_config | json }}
+        hasBundleConfigMetafield: {{ product.metafields["$app"]["bundle_config"] | json }}
       });
 
       // 🔍 Debug the Liquid template bundle ID selection logic
@@ -502,10 +503,10 @@
   // This is much faster than shop-level metafields and naturally isolated
   if (!window.allBundlesData) {
     // Primary source: product's bundle_config metafield
-    // Note: App-scoped metafields ($app namespace) use dot notation for keys
+    // Note: App-scoped metafields ($app namespace) use bracket notation for both namespace AND key
     // JSON metafields require .value accessor to retrieve the parsed JSON object
     // Reference: https://shopify.dev/docs/apps/build/online-store/theme-app-extensions/configuration
-    const productBundleConfig = {{ product.metafields["$app"].bundle_config.value | json }};
+    const productBundleConfig = {{ product.metafields["$app"]["bundle_config"].value | json }};
 
     console.log('📦 [BUNDLE_DATA] Loading bundle config:', {
       productBundleConfig,


### PR DESCRIPTION
- Fix Liquid metafield access syntax using consistent bracket notation
- Add storefront access (PUBLIC_READ) to all metafield definitions
- Improve widget null handling with comprehensive validation
- Add detailed error messages for debugging

Changes:
1. extensions/bundle-builder/blocks/bundle.liquid
   - Use bracket notation: product.metafields[":bundle_isolation"]["key"].value
   - Fix PRIMARY CHECK metafield access (lines 279-287)
   - Update debug logging (lines 337-342)
   - Fix window.allBundlesData loading (line 509)

2. app/services/bundles/standard-metafields.server.ts
   - Add storefront access to 4 missing metafield definitions
   - component_reference, component_quantities, component_parents, price_adjustment

3. app/assets/bundle-widget-full.js
   - Improve loadBundleData() validation
   - Check for 'null' string, empty string, undefined
   - Add detailed error logging with debug info
   - Validate parsed objects have required properties