### PR TITLE
fix: Add proper metafield definitions with storefront access

### DIFF
--- a/app/services/bundle-isolation.server.ts
+++ b/app/services/bundle-isolation.server.ts
@@ -3,7 +3,6 @@
 // Uses product-level metafields for optimal performance
 
 import { AppLogger } from "../lib/logger";
-import { ensureStandardMetafieldDefinitions } from "./bundles/standard-metafields.server";
 
 export class BundleIsolationService {
 
@@ -12,14 +11,12 @@ export class BundleIsolationService {
    * Stores bundle config on the bundle product itself for fast, isolated access
    */
   static async updateBundleProductMetafield(admin: any, bundleProductId: string, bundleConfig: any) {
-    AppLogger.info('Updating bundle product metafield', {
-      component: 'isolation',
+    AppLogger.info('Updating bundle product metafield', { 
+      component: 'isolation', 
       operation: 'update-metafield'
     }, { bundleProductId });
 
     try {
-      // Ensure bundle_config metafield definition exists with storefront access
-      await ensureStandardMetafieldDefinitions(admin);
       // Helper function to safely parse JSON
       const safeJsonParse = (value: any, defaultValue: any = []) => {
         if (!value) return defaultValue;
@@ -132,42 +129,23 @@ export class BundleIsolationService {
         }
       `;
 
-      AppLogger.info('Setting bundle_config metafield', {
-        component: 'isolation',
-        operation: 'set-metafield'
-      }, {
-        bundleProductId,
-        bundleId: bundleMetafieldData.id,
-        bundleName: bundleMetafieldData.name,
-        valuePreview: JSON.stringify(bundleMetafieldData).substring(0, 200)
-      });
-
       const response = await admin.graphql(SET_BUNDLE_CONFIG_METAFIELD, {
         variables: {
           metafields: [
             {
               ownerId: bundleProductId,
               namespace: "$app",
-              key: "bundle_config",
+              key: "bundleConfig",
               type: "json",
               value: JSON.stringify(bundleMetafieldData)
-              // Note: access/storefront visibility must be configured on the metafield DEFINITION,
-              // not on individual metafield values. See ensureStandardMetafieldDefinitions()
+              // Note: access.storefront is set in metafield definition (shopify.app.toml)
+              // [product.metafields.app.bundleConfig] in TOML = namespace "$app", key "bundleConfig"
             }
           ]
         }
       });
 
       const data = await response.json();
-
-      AppLogger.info('Set bundle_config metafield response', {
-        component: 'isolation',
-        operation: 'set-metafield-response'
-      }, {
-        success: !data.data?.metafieldsSet?.userErrors?.length,
-        metafieldId: data.data?.metafieldsSet?.metafields?.[0]?.id,
-        userErrors: data.data?.metafieldsSet?.userErrors || []
-      });
 
       if (data.data?.metafieldsSet?.userErrors?.length > 0) {
         const error = data.data.metafieldsSet.userErrors[0];
@@ -208,7 +186,7 @@ export class BundleIsolationService {
         query GetBundleConfig($id: ID!) {
           product(id: $id) {
             id
-            bundleConfig: metafield(namespace: "$app", key: "bundle_config") {
+            bundleConfig: metafield(namespace: "$app", key: "bundleConfig") {
               value
             }
           }
@@ -261,22 +239,22 @@ export class BundleIsolationService {
       const metafields = [
         {
           ownerId: bundleProductId,
-          namespace: "$app:bundle_isolation",
-          key: "owns_bundle_id",
+          namespace: "$app",
+          key: "ownsBundleId",
           type: "single_line_text_field",
           value: bundleId
         },
         {
           ownerId: bundleProductId,
-          namespace: "$app:bundle_isolation",
-          key: "bundle_product_type",
+          namespace: "$app",
+          key: "bundleProductType",
           type: "single_line_text_field",
           value: "cart_transform_bundle"
         },
         {
           ownerId: bundleProductId,
-          namespace: "$app:bundle_isolation",
-          key: "isolation_created",
+          namespace: "$app",
+          key: "isolationCreated",
           type: "single_line_text_field",
           value: new Date().toISOString()
         }
@@ -343,18 +321,18 @@ export class BundleIsolationService {
       const metafieldsToDelete = [
         {
           ownerId: bundleProductId,
-          namespace: "$app:bundle_isolation",
-          key: "owns_bundle_id"
+          namespace: "$app",
+          key: "ownsBundleId"
         },
         {
           ownerId: bundleProductId,
-          namespace: "$app:bundle_isolation",
-          key: "bundle_product_type"
+          namespace: "$app",
+          key: "bundleProductType"
         },
         {
           ownerId: bundleProductId,
-          namespace: "$app:bundle_isolation",
-          key: "isolation_created"
+          namespace: "$app",
+          key: "isolationCreated"
         }
       ];
 

--- a/app/services/metafield-cleanup.server.ts
+++ b/app/services/metafield-cleanup.server.ts
@@ -59,33 +59,33 @@ export class MetafieldCleanupService {
       : `gid://shopify/Product/${shopifyProductId}`;
 
     const metafieldsToDelete = [
-      // Widget configuration metafield
+      // Widget configuration metafield (defined in shopify.app.toml)
       {
         ownerId: productGid,
         namespace: "$app",
-        key: "bundle_config"
+        key: "bundleConfig"
       },
-      // NEW: Cart transform configuration metafield (Hybrid Architecture)
+      // Cart transform configuration metafield
       {
         ownerId: productGid,
         namespace: "$app",
-        key: "cart_transform_config"
+        key: "cartTransformConfig"
       },
       // Bundle isolation metafields
       {
         ownerId: productGid,
-        namespace: "$app:bundle_isolation",
-        key: "owns_bundle_id"
+        namespace: "$app",
+        key: "ownsBundleId"
       },
       {
         ownerId: productGid,
-        namespace: "$app:bundle_isolation",
-        key: "bundle_product_type"
+        namespace: "$app",
+        key: "bundleProductType"
       },
       {
         ownerId: productGid,
-        namespace: "$app:bundle_isolation",
-        key: "isolation_created"
+        namespace: "$app",
+        key: "isolationCreated"
       }
     ];
 

--- a/extensions/bundle-builder/blocks/bundle.liquid
+++ b/extensions/bundle-builder/blocks/bundle.liquid
@@ -273,18 +273,14 @@
 {% assign auto_display_mode = false %}
 
 {% comment %} PRIMARY CHECK: Is this product a designated bundle container? {% endcomment %}
-{% comment %} Access app-owned metafields using $app:namespace syntax (Shopify best practice for theme app extensions) {% endcomment %}
-{% comment %} Reference: https://shopify.dev/docs/apps/build/online-store/theme-app-extensions/configuration {% endcomment %}
-{% comment %} IMPORTANT: Use bracket notation for both namespace AND key, then chain .value accessor {% endcomment %}
-{% assign bundle_product_type = product.metafields["$app:bundle_isolation"]["bundle_product_type"].value %}
-{% assign owns_bundle_id = product.metafields["$app:bundle_isolation"]["owns_bundle_id"].value %}
-
-{% if bundle_product_type == 'cart_transform_bundle' %}
+{% if product.metafields.app.bundleProductType == 'cart_transform_bundle' %}
   {% assign is_container_product = true %}
-  {% assign container_bundle_id = owns_bundle_id %}
+  {% assign container_bundle_id = product.metafields.app.ownsBundleId %}
   {% assign auto_display_mode = true %}
-  {% comment %} Load bundle configuration from $app namespace (JSON type requires .value) {% endcomment %}
-  {% assign bundle_config = product.metafields["$app"]["bundle_config"].value %}
+  {% comment %} Load bundle configuration from container metafields {% endcomment %}
+  {% if product.metafields.app.bundleConfig %}
+    {% assign bundle_config = product.metafields.app.bundleConfig %}
+  {% endif %}
 {% endif %}
 
 {% comment %} SECONDARY CHECK: Widget configured with specific bundle ID (theme editor) {% endcomment %}
@@ -328,18 +324,11 @@
         urlParams: new URLSearchParams(window.location.search).toString()
       });
 
-      // 🔍 Enhanced debugging for metafield access
+      // 🔍 Enhanced debugging for custom template pages
       console.log('🔍 [THEME_DEBUG] Product Metafields Check:', {
-        // App-owned metafields with $app:namespace syntax (using bracket notation)
-        bundleProductType: {{ bundle_product_type | json }},
-        ownsBundleId: {{ owns_bundle_id | json }},
-        // Bundle config from $app namespace
-        bundleConfigRaw: {{ product.metafields["$app"]["bundle_config"] | json }},
-        bundleConfigValue: {{ product.metafields["$app"]["bundle_config"].value | json }},
-        bundleConfigVariable: {{ bundle_config | json }},
-        // Check if metafield objects exist
-        hasIsolationMetafield: {{ product.metafields["$app:bundle_isolation"] | json }},
-        hasBundleConfigMetafield: {{ product.metafields["$app"]["bundle_config"] | json }}
+        bundleIsolationType: {{ product.metafields.app.bundleProductType | json }},
+        ownsBundleId: {{ product.metafields.app.ownsBundleId | json }},
+        cartTransformConfig: {{ product.metafields.app.bundleConfig | json }}
       });
 
       // 🔍 Debug the Liquid template bundle ID selection logic
@@ -392,7 +381,7 @@
       data-is-container-product="{{ is_container_product }}"
       data-container-bundle-id="{{ container_bundle_id }}"
       data-auto-display-mode="{{ auto_display_mode }}"
-      data-bundle-config="{{ bundle_config | json | escape }}"
+      data-bundle-config="{{ bundle_config | escape }}"
       data-hide-default-buttons="{{ hide_default_buttons }}"
       data-show-title="{{ block.settings.show_bundle_title }}"
       data-show-step-numbers="{{ block.settings.show_step_numbers }}"
@@ -472,47 +461,23 @@
       </div>
       {% endif %}
     </div>
-
-    <script>
-      // Debug: Check data attributes on widget container
-      (function() {
-        const container = document.getElementById('bundle-builder-app');
-        if (container) {
-          console.log('📋 [DATA_ATTRIBUTES] Widget container found:', {
-            bundleId: container.dataset.bundleId,
-            isContainerProduct: container.dataset.isContainerProduct,
-            containerBundleId: container.dataset.containerBundleId,
-            bundleConfigExists: !!container.dataset.bundleConfig,
-            bundleConfigLength: container.dataset.bundleConfig?.length || 0,
-            bundleConfigPreview: container.dataset.bundleConfig?.substring(0, 100)
-          });
-        } else {
-          console.error('❌ [DATA_ATTRIBUTES] Widget container not found!');
-        }
-      })();
-    </script>
 {% endif %}
 
 <script>
   // Inject app URL from shop metafield (auto-synced when merchant accesses app admin)
-  window.__BUNDLE_APP_URL__ = {{ shop.metafields.app_config.server_url | json }};
+  window.__BUNDLE_APP_URL__ = {{ shop.metafields.appconfig.serverUrl | json }};
 </script>
 
 <script>
   // Load bundle configuration directly from product metafield
   // This is much faster than shop-level metafields and naturally isolated
   if (!window.allBundlesData) {
-    // Primary source: product's bundle_config metafield
-    // Note: App-scoped metafields ($app namespace) use bracket notation for both namespace AND key
+    // Primary source: product's bundleConfig metafield
+    // Note: App-scoped metafields declared in shopify.app.toml are accessed via .app namespace
+    // The metafield.app.bundleConfig syntax accesses metafields defined as [product.metafields.app.bundleConfig]
     // JSON metafields require .value accessor to retrieve the parsed JSON object
-    // Reference: https://shopify.dev/docs/apps/build/online-store/theme-app-extensions/configuration
-    const productBundleConfig = {{ product.metafields["$app"]["bundle_config"].value | json }};
-
-    console.log('📦 [BUNDLE_DATA] Loading bundle config:', {
-      productBundleConfig,
-      hasId: !!(productBundleConfig && productBundleConfig.id),
-      bundleId: productBundleConfig?.id
-    });
+    // Reference: https://shopify.dev/docs/storefronts/themes/architecture/settings/input-settings#access-app-owned-metafields
+    const productBundleConfig = {{ product.metafields.app.bundleConfig.value | json }};
 
     // Set as allBundlesData object (widget expects this name)
     // Create an object with the bundle ID as key for compatibility
@@ -520,10 +485,8 @@
       window.allBundlesData = {
         [productBundleConfig.id]: productBundleConfig
       };
-      console.log('✅ [BUNDLE_DATA] window.allBundlesData set successfully');
     } else {
       window.allBundlesData = null;
-      console.error('❌ [BUNDLE_DATA] No valid bundle config found - window.allBundlesData set to null');
     }
 
     window.currentProductId = {{ product.id | json }};

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -29,3 +29,114 @@ redirect_urls = [
 
 [pos]
 embedded = false
+
+# ==============================================================================
+# METAFIELD DEFINITIONS - Declarative Custom Data
+# ==============================================================================
+# These definitions ensure metafields have proper structure, validation,
+# and access controls. Declared in app-reserved namespace ($app).
+# See: https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions
+
+[metafields]
+api_version = "2025-01"
+
+# Bundle Widget Configuration
+# Primary metafield that stores complete bundle configuration for storefront widget
+[product.metafields.app.bundleConfig]
+type = "json"
+name = "Bundle Configuration"
+description = "Complete bundle configuration data for widget display on storefront"
+access.admin = "merchant_read"
+access.storefront = "public_read"  # CRITICAL: Enable Liquid template access
+capabilities.admin_filterable = false
+
+# Cart Transform Configuration
+# Stores bundle configuration for cart transform function
+[product.metafields.app.cartTransformConfig]
+type = "json"
+name = "Cart Transform Configuration"
+description = "Bundle configuration for cart transform discount function"
+access.admin = "merchant_read"
+access.storefront = "none"
+capabilities.admin_filterable = false
+
+# Bundle Isolation Tracking
+# Metafields that track bundle ownership and product type
+[product.metafields.app.ownsBundleId]
+type = "single_line_text_field"
+name = "Bundle Owner ID"
+description = "ID of the bundle that owns this container product"
+access.admin = "merchant_read"
+access.storefront = "public_read"
+capabilities.admin_filterable = true
+
+[product.metafields.app.bundleProductType]
+type = "single_line_text_field"
+name = "Bundle Product Type"
+description = "Type marker for bundle product (cart_transform_bundle)"
+access.admin = "merchant_read"
+access.storefront = "public_read"
+capabilities.admin_filterable = true
+validations.choices = ["cart_transform_bundle", "standalone_bundle"]
+
+[product.metafields.app.isolationCreated]
+type = "single_line_text_field"
+name = "Isolation Created Timestamp"
+description = "ISO timestamp when bundle isolation was created"
+access.admin = "merchant_read"
+access.storefront = "none"
+capabilities.admin_filterable = false
+
+# Standard Shopify Metafields (for Shopify-native bundle features)
+[product.metafields.app.componentReference]
+type = "list.product_reference"
+name = "Bundle Component Products"
+description = "List of product variant IDs that make up this bundle"
+access.admin = "merchant_read"
+access.storefront = "public_read"
+capabilities.admin_filterable = false
+
+[product.metafields.app.componentQuantities]
+type = "list.number_integer"
+name = "Component Quantities"
+description = "Quantity of each component in the bundle (matches component_reference order)"
+access.admin = "merchant_read"
+access.storefront = "public_read"
+capabilities.admin_filterable = false
+validations.min = 1
+validations.max = 100
+
+[product.metafields.app.componentParents]
+type = "json"
+name = "Component Parent Configuration"
+description = "Parent bundle configuration for component products"
+access.admin = "merchant_read"
+access.storefront = "none"
+capabilities.admin_filterable = false
+
+[product.metafields.app.priceAdjustment]
+type = "number_decimal"
+name = "Bundle Price Adjustment"
+description = "Price adjustment/discount for this bundle"
+access.admin = "merchant_read"
+access.storefront = "public_read"
+capabilities.admin_filterable = false
+
+# Shop-Level Bundle Index
+# Global list of all bundles for cart transform function
+[shop.metafields.custom.bundleIndex]
+type = "json"
+name = "Bundle Index"
+description = "Global index of all active bundles for cart transform lookups"
+
+# App Configuration
+# Shop-level app settings
+[shop.metafields.appconfig.serverUrl]
+type = "single_line_text_field"
+name = "App Server URL"
+description = "URL of the app server for widget API calls"
+
+[shop.metafields.appconfig.lastSync]
+type = "single_line_text_field"
+name = "Last Sync Timestamp"
+description = "ISO timestamp of last successful sync with app server"


### PR DESCRIPTION
Problem:
- Widget failing with "No valid bundle data available" error
- Metafields created before definitions = unstructured metafields
- Unstructured metafields lack storefront access for Liquid templates

Solution:
1. Added declarative metafield definitions in shopify.app.toml
   - All metafields now properly defined with api_version 2025-01
   - bundleConfig has access.storefront = "public_read" (critical!)
   - Added validations: choices for bundleProductType, min/max for componentQuantities
   - Added proper access controls (merchant_read) for all fields

2. Updated to camelCase keys (no underscores/hyphens allowed)
   - bundle_config → bundleConfig
   - cart_transform_config → cartTransformConfig
   - owns_bundle_id → ownsBundleId
   - bundle_product_type → bundleProductType
   - isolation_created → isolationCreated

3. Updated all code references:
   - Liquid template: product.metafields.app.bundleConfig.value
   - Backend: namespace "$app", key "bundleConfig"
   - Cleanup service: updated all metafield references

4. Fixed namespace structure:
   - OLD: Mixed namespaces ($app:bundle, $app:bundle_isolation)
   - NEW: Consistent $app namespace with camelCase keys

Benefits:
- Widget can now access bundle data on storefront
- Proper validation ensures data integrity
- Merchant-friendly in Shopify admin (filterable, readable)
- Future-proof with declarative definitions

Next Steps:
1. Deploy app to push definitions
2. Delete old unstructured metafields from test products
3. Re-save bundles to write metafields with new definitions
4. Test widget on storefront