### PR TITLE
fix: Add proper metafield definitions with storefront access

### DIFF
--- a/app/services/bundles/cart-transform-metafield.server.ts
+++ b/app/services/bundles/cart-transform-metafield.server.ts
@@ -81,7 +81,7 @@ export async function updateCartTransformConfigMetafield(
         {
           ownerId: bundleProductId,
           namespace: "$app",
-          key: "cart_transform_config",
+          key: "cartTransformConfig",
           type: "json",
           value: configJson
         }

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -128,6 +128,8 @@ capabilities.admin_filterable = false
 type = "json"
 name = "Bundle Index"
 description = "Global index of all active bundles for cart transform lookups"
+access.admin = "merchant_read_write"
+access.storefront = "none"
 
 # App Configuration
 # Shop-level app settings
@@ -135,8 +137,12 @@ description = "Global index of all active bundles for cart transform lookups"
 type = "single_line_text_field"
 name = "App Server URL"
 description = "URL of the app server for widget API calls"
+access.admin = "merchant_read_write"
+access.storefront = "public_read"
 
 [shop.metafields.appconfig.lastSync]
 type = "single_line_text_field"
 name = "Last Sync Timestamp"
 description = "ISO timestamp of last successful sync with app server"
+access.admin = "merchant_read"
+access.storefront = "none"


### PR DESCRIPTION
Critical fixes for metafield propagation:
- Fixed cartTransformConfig key mismatch (cart_transform_config → cartTransformConfig)
- Added access controls to shop.metafields.custom.bundleIndex
- Added access controls to shop.metafields.appconfig.serverUrl
- Added access controls to shop.metafields.appconfig.lastSync
- All metafield keys now match shopify.app.toml definitions exactly