### PR TITLE
fix: Align metafield keys and namespaces with TOML definitions

### DIFF
--- a/app/routes/api.cleanup-metafields.ts
+++ b/app/routes/api.cleanup-metafields.ts
@@ -66,22 +66,22 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       {
         ownerId: productId,
         namespace: "$app",
-        key: "bundle_config"
+        key: "bundleConfig"
       },
       {
         ownerId: productId,
-        namespace: "$app:bundle_isolation",
-        key: "bundle_product_type"
+        namespace: "$app",
+        key: "bundleProductType"
       },
       {
         ownerId: productId,
-        namespace: "$app:bundle_isolation",
-        key: "owns_bundle_id"
+        namespace: "$app",
+        key: "ownsBundleId"
       },
       {
         ownerId: productId,
-        namespace: "$app:bundle_isolation",
-        key: "isolation_created"
+        namespace: "$app",
+        key: "isolationCreated"
       }
     ];
 

--- a/app/routes/app.bundles.cart-transform.configure.$bundleId.tsx
+++ b/app/routes/app.bundles.cart-transform.configure.$bundleId.tsx
@@ -698,43 +698,22 @@ async function handleSaveBundle(admin: any, session: any, bundleId: string, form
         const metafields = [
           {
             ownerId: bundleProductId,
-            namespace: "$app:bundle_isolation",
-            key: "bundle_id",
+            namespace: "$app",
+            key: "ownsBundleId",
             type: "single_line_text_field",
             value: bundleId
           },
           {
             ownerId: bundleProductId,
-            namespace: "$app:bundle_isolation",
-            key: "bundle_type",
-            type: "single_line_text_field",
-            value: "cart_transform"
-          },
-          {
-            ownerId: bundleProductId,
-            namespace: "$app:bundle_isolation",
-            key: "owns_bundle_id",
-            type: "single_line_text_field",
-            value: bundleId
-          },
-          {
-            ownerId: bundleProductId,
-            namespace: "$app:bundle_isolation",
-            key: "bundle_product_type",
+            namespace: "$app",
+            key: "bundleProductType",
             type: "single_line_text_field",
             value: "cart_transform_bundle"
           },
           {
             ownerId: bundleProductId,
-            namespace: "$app:bundle_isolation",
-            key: "auto_injection_enabled",
-            type: "single_line_text_field",
-            value: "true"
-          },
-          {
-            ownerId: bundleProductId,
-            namespace: "$app:bundle_isolation",
-            key: "created_at",
+            namespace: "$app",
+            key: "isolationCreated",
             type: "single_line_text_field",
             value: new Date().toISOString()
           }

--- a/app/services/bundle-product-manager.server.ts
+++ b/app/services/bundle-product-manager.server.ts
@@ -415,43 +415,22 @@ export class BundleProductManagerService {
       const metafields = [
         {
           ownerId: productId,
-          namespace: "$app:bundle_isolation",
-          key: "bundle_id",
+          namespace: "$app",
+          key: "ownsBundleId",
           type: "single_line_text_field",
           value: bundle.id
         },
         {
           ownerId: productId,
-          namespace: "$app:bundle_isolation",
-          key: "bundle_type",
-          type: "single_line_text_field",
-          value: "cart_transform"
-        },
-        {
-          ownerId: productId,
-          namespace: "$app:bundle_isolation",
-          key: "owns_bundle_id",
-          type: "single_line_text_field",
-          value: bundle.id
-        },
-        {
-          ownerId: productId,
-          namespace: "$app:bundle_isolation",
-          key: "bundle_product_type",
+          namespace: "$app",
+          key: "bundleProductType",
           type: "single_line_text_field",
           value: "cart_transform_bundle"
         },
         {
           ownerId: productId,
-          namespace: "$app:bundle_isolation",
-          key: "auto_injection_enabled",
-          type: "single_line_text_field",
-          value: "true"
-        },
-        {
-          ownerId: productId,
-          namespace: "$app:bundle_isolation",
-          key: "created_at",
+          namespace: "$app",
+          key: "isolationCreated",
           type: "single_line_text_field",
           value: new Date().toISOString()
         }

--- a/app/services/bundles/cart-transform-metafield.server.ts
+++ b/app/services/bundles/cart-transform-metafield.server.ts
@@ -113,7 +113,7 @@ export async function deleteCartTransformConfigMetafield(
   const GET_METAFIELD = `
     query GetCartTransformConfig($ownerId: ID!) {
       product(id: $ownerId) {
-        metafield(namespace: "$app", key: "cart_transform_config") {
+        metafield(namespace: "$app", key: "cartTransformConfig") {
           id
         }
       }

--- a/app/services/bundles/metafield-sync.server.ts
+++ b/app/services/bundles/metafield-sync.server.ts
@@ -48,11 +48,13 @@ export async function ensureBundleMetafieldDefinitions(admin: any) {
   `;
 
   // Define metafield definition for cart transform bundles
+  // NOTE: Metafield definitions are now managed via shopify.app.toml
+  // This function is kept for backwards compatibility but definitions should be in TOML
   const definitions = [
     {
       name: "Cart Transform Bundle Config",
-      namespace: "bundle_discounts",
-      key: "cart_transform_config",
+      namespace: "$app",
+      key: "cartTransformConfig",
       description: "Cart transform bundle configuration data",
       type: "json",
       ownerType: "PRODUCT"
@@ -122,8 +124,8 @@ export async function updateBundleProductMetafields(
       metafields: [
         {
           ownerId: bundleProductId,
-          namespace: "bundle_discounts",
-          key: 'cart_transform_config',
+          namespace: "$app",
+          key: 'cartTransformConfig',
           type: "json",
           value: JSON.stringify(bundleConfiguration)
         }
@@ -644,7 +646,7 @@ export async function updateComponentProductMetafields(admin: any, bundleProduct
         {
           ownerId: productId,
           namespace: "$app",
-          key: "cart_transform_config",
+          key: "cartTransformConfig",
           value: JSON.stringify(minimalBundleConfig),
           type: "json"
         },

--- a/extensions/bundle-cart-transform-ts/src/cart-transform-input.graphql
+++ b/extensions/bundle-cart-transform-ts/src/cart-transform-input.graphql
@@ -13,7 +13,7 @@ query Input {
           product {
             id
             # NEW: Read lightweight cart transform config (~500 bytes)
-            cartTransformConfig: metafield(namespace: "$app", key: "cart_transform_config") {
+            cartTransformConfig: metafield(namespace: "$app", key: "cartTransformConfig") {
               value
             }
           }

--- a/tests/e2e/complete-bundle-flow.test.ts
+++ b/tests/e2e/complete-bundle-flow.test.ts
@@ -177,7 +177,7 @@ describe('Complete Bundle Flow E2E Tests', () => {
         .mockResolvedValueOnce(createMockGraphQLResponse({
           metafieldsSet: {
             metafields: [
-              { id: 'gid://shopify/Metafield/1', key: 'bundle_id', namespace: '$app:bundle_isolation' }
+              { id: 'gid://shopify/Metafield/1', key: 'ownsBundleId', namespace: '$app' }
             ],
             userErrors: []
           }

--- a/tests/unit/services/bundle-product-manager.test.ts
+++ b/tests/unit/services/bundle-product-manager.test.ts
@@ -77,7 +77,7 @@ describe('BundleProductManagerService', () => {
         .mockResolvedValueOnce(createMockGraphQLResponse({
           metafieldsSet: {
             metafields: [
-              { id: 'gid://shopify/Metafield/1', key: 'bundle_id', namespace: '$app:bundle_isolation' }
+              { id: 'gid://shopify/Metafield/1', key: 'ownsBundleId', namespace: '$app' }
             ],
             userErrors: []
           }


### PR DESCRIPTION
Critical fixes to resolve production metafield issues:

- Fix metafield key naming mismatch: cart_transform_config → cartTransformConfig
- Replace invalid namespace $app:bundle_isolation with $app
- Remove legacy bundle_discounts namespace usage
- Consolidate duplicate isolation metafields (6 → 3)
- Update metafield keys to match TOML definitions (camelCase):
  - bundle_id → ownsBundleId
  - bundle_product_type → bundleProductType
  - created_at → isolationCreated
- Update cart transform GraphQL query to use correct key names
- Fix all read/write operations to use consistent naming
- Update test mocks to match new metafield structure

This ensures metafields are properly typed and production works consistently with local development environment.