### PR TITLE
refactor: Update bundle types and remove cart_transform references

### DIFF
--- a/app/assets/bundle-widget-full.js
+++ b/app/assets/bundle-widget-full.js
@@ -33,9 +33,10 @@ const BUNDLE_WIDGET = {
     BUNDLE_CONFIG: '_bundle_config'
   },
 
-  // Bundle Types
+  // Bundle Types (Display Modes)
   BUNDLE_TYPES: {
-    CART_TRANSFORM: 'cart_transform'
+    PRODUCT_PAGE: 'product_page',  // Widget embedded in product page
+    FULL_PAGE: 'full_page'         // Dedicated bundle page (future)
   },
 
   // Step Condition Operators
@@ -237,9 +238,10 @@ class BundleDataManager {
       return null;
     }
 
-    // Selection priority for cart transform bundles
+    // Selection priority for bundles (both product-page and full-page types)
     for (const bundle of bundles) {
-      if (bundle.bundleType === BUNDLE_WIDGET.BUNDLE_TYPES.CART_TRANSFORM) {
+      if (bundle.bundleType === BUNDLE_WIDGET.BUNDLE_TYPES.PRODUCT_PAGE ||
+          bundle.bundleType === BUNDLE_WIDGET.BUNDLE_TYPES.FULL_PAGE) {
         // Priority 1: Manual bundle ID
         if (config.bundleId && bundle.id === config.bundleId) {
           return bundle;

--- a/app/routes/app.bundles.cart-transform.configure.$bundleId.tsx
+++ b/app/routes/app.bundles.cart-transform.configure.$bundleId.tsx
@@ -128,7 +128,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     where: {
       id: bundleId,
       shopId: session.shop,
-      bundleType: 'cart_transform'
+      // Note: bundleType filter removed - not needed for single bundle lookup
     },
     include: {
       steps: {
@@ -1859,20 +1859,17 @@ export default function ConfigureBundleFlow() {
 
     setHasUnsavedChanges(hasChanges);
 
-    // Simplified save bar management - no timeout
-    // Note: SaveBar visibility is now controlled by hasUnsavedChanges state in render
-    // if (hasChanges) {
-    //   formState.triggerSaveBar();
-    // } else {
-    //   formState.dismissSaveBar();
-    // }
+    // Control SaveBar visibility using App Bridge API
+    if (hasChanges) {
+      shopify.saveBar.show('bundle-save-bar');
+    } else {
+      shopify.saveBar.hide('bundle-save-bar');
+    }
   }, [
     formState.bundleStatus,
     formState.bundleName,
     formState.bundleDescription,
     formState.templateName,
-    formState.triggerSaveBar,
-    formState.dismissSaveBar,
     stepsState.steps,
     pricingState.discountEnabled,
     pricingState.discountType,
@@ -1885,7 +1882,8 @@ export default function ConfigureBundleFlow() {
     conditionsState.stepConditions,
     bundleProduct,
     productStatus,
-    originalValues
+    originalValues,
+    shopify
   ]);
 
   // Save handler
@@ -2020,6 +2018,8 @@ export default function ConfigureBundleFlow() {
             productStatus: productStatus,
           });
 
+          // Hide the save bar after successful save
+          shopify.saveBar.hide('bundle-save-bar');
           shopify.toast.show(('message' in result ? result.message : null) || "Changes saved successfully", { isError: false });
         } else if ('productId' in result && result.productId) {
           // This is a sync product response
@@ -2110,6 +2110,8 @@ export default function ConfigureBundleFlow() {
       setBundleProduct(originalValues.bundleProduct || loadedBundleProduct || null);
       setProductStatus(originalValues.productStatus);
 
+      // Hide the save bar after discarding
+      shopify.saveBar.hide('bundle-save-bar');
       shopify.toast.show("Changes discarded", { isError: false });
     } catch (error) {
       AppLogger.error("Error discarding changes:", {}, error as any);
@@ -2783,25 +2785,23 @@ export default function ConfigureBundleFlow() {
           handleDiscard();
         }}
       >
-        {/* SaveBar component for manual control over loading state */}
-        {(hasUnsavedChanges || fetcher.state !== "idle") && (
-          <SaveBar id="bundle-save-bar">
-            <button
-              variant="primary"
-              onClick={handleSave}
-              loading={fetcher.state !== "idle"}
-              disabled={fetcher.state !== "idle"}
-            >
-              Save
-            </button>
-            <button
-              onClick={handleDiscard}
-              disabled={fetcher.state !== "idle"}
-            >
-              Discard
-            </button>
-          </SaveBar>
-        )}
+        {/* SaveBar component - controlled via App Bridge API show/hide methods */}
+        <SaveBar id="bundle-save-bar">
+          <button
+            variant="primary"
+            onClick={handleSave}
+            loading={fetcher.state !== "idle" ? "" : undefined}
+            disabled={fetcher.state !== "idle"}
+          >
+            Save
+          </button>
+          <button
+            onClick={handleDiscard}
+            disabled={fetcher.state !== "idle"}
+          >
+            Discard
+          </button>
+        </SaveBar>
         {/* Hidden inputs for form submission - values will be updated by React state changes */}
         <input type="hidden" name="bundleName" value={formState.bundleName} />
         <input type="hidden" name="bundleDescription" value={formState.bundleDescription} />

--- a/app/routes/app.bundles.cart-transform.tsx
+++ b/app/routes/app.bundles.cart-transform.tsx
@@ -27,11 +27,11 @@ import { BundleSetupInstructions } from "../components/BundleSetupInstructions";
 export async function loader({ request }: LoaderFunctionArgs) {
   const { session } = await authenticate.admin(request);
   
-  // Get cart transform bundles only (exclude archived)
+  // Get all bundles (exclude archived)
   const cartTransformBundles = await db.bundle.findMany({
     where: {
       shopId: session.shop,
-      bundleType: "cart_transform",
+      // Note: bundleType filter removed - showing all bundle display types
       status: {
         in: ['active', 'draft'] // Only show active and draft bundles, exclude archived
       }
@@ -45,7 +45,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   return json({
     bundles: cartTransformBundles,
-    bundleType: "cart_transform",
+    bundleType: "product_page", // Default display mode
   });
 }
 
@@ -136,7 +136,7 @@ export async function action({ request }: ActionFunctionArgs) {
           name: clonedBundleName,
           description: originalBundle.description,
           shopId: shop,
-          bundleType: 'cart_transform',
+          bundleType: 'product_page', // Default to product-page bundle
           status: 'draft',
           active: false,
           shopifyProductId: shopifyProductId,
@@ -342,7 +342,7 @@ export async function action({ request }: ActionFunctionArgs) {
         name: bundleName,
         description: typeof description === 'string' ? description : null,
         shopId: shop,
-        bundleType: 'cart_transform',
+        bundleType: 'product_page', // Default to product-page bundle
         status: 'draft',
         active: false,
         shopifyProductId: shopifyProductId, // Link the Shopify product

--- a/app/routes/app.dashboard.tsx
+++ b/app/routes/app.dashboard.tsx
@@ -25,7 +25,7 @@ interface Bundle {
   description?: string | null;
   shopId: string;
   shopifyProductId?: string | null;
-  bundleType: 'cart_transform';
+  bundleType: 'product_page' | 'full_page'; // Display mode
   status: 'draft' | 'active' | 'archived';
   active: boolean;
   publishedAt?: Date | string | null;

--- a/app/routes/apps.product-bundles.api.bundle.$bundleId.json.tsx
+++ b/app/routes/apps.product-bundles.api.bundle.$bundleId.json.tsx
@@ -37,7 +37,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
       where: {
         id: bundleId,
         shopId: session.shop,
-        bundleType: 'cart_transform',
+        // Note: bundleType filter removed - not needed for single bundle lookup
         status: 'active'
       },
       include: {

--- a/app/routes/apps.product-bundles.api.bundles.json.tsx
+++ b/app/routes/apps.product-bundles.api.bundles.json.tsx
@@ -21,11 +21,11 @@ export const loader: LoaderFunction = async ({ request }) => {
 
     AppLogger.info("Fetching fresh bundle data", { component: "apps.product-bundles.api.bundles.json", operation: "loader", shop: session.shop });
 
-    // Get all active cart transform bundles from database
+    // Get all active bundles from database
     const allBundles = await db.bundle.findMany({
       where: {
         shopId: session.shop,
-        bundleType: 'cart_transform',
+        // Note: bundleType filter removed - returning all active bundles regardless of display mode
         status: 'active'
       },
       include: {

--- a/app/services/bundle-auto-injection.server.ts
+++ b/app/services/bundle-auto-injection.server.ts
@@ -195,7 +195,8 @@ export class BundleAutoInjectionService {
         where: {
           shopId: shopId,
           status: 'active',
-          bundleType: 'cart_transform',
+          // Note: bundleType filter removed - all bundles use cart transform implementation
+          // bundleType only indicates display mode (product_page vs full_page)
           shopifyProductId: { not: null }
         },
         select: {

--- a/app/services/bundle-isolation.server.ts
+++ b/app/services/bundle-isolation.server.ts
@@ -66,13 +66,15 @@ export class BundleIsolationService {
         conditionValue: step.conditionValue
       }));
 
-      // MINIMAL bundleConfig for widget - only what widget needs
+      // bundleConfig for widget - includes all required fields for validation and rendering
       // Widget fetches full product data via Storefront API (/api/storefront-products)
-      // So we only store: bundle ID, name, step structure, pricing display settings
-      // This reduces metafield size from ~5KB to ~500 bytes
+      // Must include: id, name, status, bundleType, steps (required by widget validation)
+      // Must include: pricing.method and pricing.rules (required for price calculations)
       const bundleMetafieldData = {
         id: bundleConfig.id,
         name: bundleConfig.name,
+        status: bundleConfig.status,           // Required by widget validation
+        bundleType: bundleConfig.bundleType,   // Required by widget validation
         steps: steps.map((step: any) => ({
           id: step.id,
           name: step.name,
@@ -85,9 +87,11 @@ export class BundleIsolationService {
             productId: sp.productId
           }))
         })),
-        // Pricing display settings only (rules stored in cartTransformConfig)
+        // Complete pricing configuration including rules for price calculations
         pricing: bundleConfig.pricing ? {
           enabled: bundleConfig.pricing.enabled,
+          method: bundleConfig.pricing.method,                           // Required for price calculations
+          rules: ensureStandardizedRules(safeJsonParse(bundleConfig.pricing.rules, [])), // Required for price calculations
           showFooter: bundleConfig.pricing.showFooter,
           showProgressBar: bundleConfig.pricing.showProgressBar,
           messages: safeJsonParse(bundleConfig.pricing.messages, {})
@@ -499,7 +503,8 @@ export class BundleIsolationService {
         timestamp: new Date().toISOString(),
         database: {
           totalBundles: dbBundles.length,
-          cartTransformBundles: dbBundles.filter(b => b.bundleType === 'cart_transform').length,
+          productPageBundles: dbBundles.filter(b => b.bundleType === 'product_page').length,
+          fullPageBundles: dbBundles.filter(b => b.bundleType === 'full_page').length,
           bundlesWithProducts: dbBundles.filter(b => b.shopifyProductId).length,
           bundlesWithoutProducts: dbBundles.filter(b => !b.shopifyProductId).length
         },

--- a/app/services/bundles/bundle-index.server.ts
+++ b/app/services/bundles/bundle-index.server.ts
@@ -52,11 +52,11 @@ export async function updateBundleIndex(
       throw new Error('Failed to get shop global ID');
     }
 
-    // Get all cart_transform bundles with shopifyProductId
+    // Get all bundles with shopifyProductId
     const bundles = await db.bundle.findMany({
       where: {
         shopId: shopId,
-        bundleType: 'cart_transform',
+        // Note: bundleType filter removed - all bundles use cart transform implementation
         shopifyProductId: { not: null }  // Only bundles with products
       },
       select: {

--- a/prisma/migrations/20251122192221_update_bundle_type_to_display_mode/migration.sql
+++ b/prisma/migrations/20251122192221_update_bundle_type_to_display_mode/migration.sql
@@ -1,0 +1,36 @@
+-- AlterEnum: Update BundleType enum from cart_transform to product_page/full_page
+-- This migration changes bundleType from indicating implementation type to display mode
+
+-- Step 1: Add new enum values (product_page and full_page)
+ALTER TYPE "BundleType" ADD VALUE IF NOT EXISTS 'product_page';
+ALTER TYPE "BundleType" ADD VALUE IF NOT EXISTS 'full_page';
+
+-- Step 2: Migrate existing data from 'cart_transform' to 'product_page'
+-- All existing bundles are product-page bundles (widget embedded in product page)
+UPDATE "Bundle"
+SET "bundleType" = 'product_page'::public."BundleType"
+WHERE "bundleType" = 'cart_transform'::public."BundleType";
+
+-- Step 3: Create a new enum without cart_transform
+CREATE TYPE "BundleType_new" AS ENUM ('product_page', 'full_page');
+
+-- Step 4: Alter the column to use the new enum
+ALTER TABLE "Bundle" ALTER COLUMN "bundleType" DROP DEFAULT;
+ALTER TABLE "Bundle" ALTER COLUMN "bundleType" TYPE "BundleType_new" USING ("bundleType"::text::"BundleType_new");
+ALTER TABLE "Bundle" ALTER COLUMN "bundleType" SET DEFAULT 'product_page';
+
+-- Step 5: Drop the old enum and rename the new one
+DROP TYPE "BundleType";
+ALTER TYPE "BundleType_new" RENAME TO "BundleType";
+
+-- Verification: Check that all bundles now have valid bundleType values
+-- This SELECT will error if any bundles have invalid values
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM "Bundle"
+    WHERE "bundleType" NOT IN ('product_page', 'full_page')
+  ) THEN
+    RAISE EXCEPTION 'Migration failed: Some bundles still have invalid bundleType values';
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,7 +48,8 @@ enum DiscountImplementationType {
 }
 
 enum BundleType {
-  cart_transform
+  product_page  // Widget embedded in product page (current implementation)
+  full_page     // Dedicated bundle page (future feature)
 }
 
 model Session {
@@ -81,7 +82,7 @@ model Bundle {
   shopId           String
   shopifyProductId String? // New field to store the Shopify Product ID (GID)
   templateName     String? // Template name for bundle container (e.g., "cart-transform", "product")
-  bundleType       BundleType        @default(cart_transform)
+  bundleType       BundleType        @default(product_page)
   status           BundleStatus      @default(draft)
   active           Boolean           @default(false)
   publishedAt      DateTime?


### PR DESCRIPTION
Changes:
- Renamed bundle types to include 'product_page' and 'full_page' for better clarity.
- Removed all instances of 'cart_transform' from the codebase, transitioning to a more flexible bundle type system.
- Updated related logic to accommodate the new bundle types, ensuring compatibility across various components and services.
- Enhanced SaveBar management to utilize App Bridge API for improved user experience.