### PR TITLE
fix: Update bundleType values in test files and improve error messages

### DIFF
--- a/app/routes/app.bundles.cart-transform.tsx
+++ b/app/routes/app.bundles.cart-transform.tsx
@@ -309,34 +309,40 @@ export async function action({ request }: ActionFunctionArgs) {
       }
     `;
 
-    // Get app URL for default bundle image
-    const appUrl = process.env.SHOPIFY_APP_URL || `https://${shop}`;
-    const defaultBundleImageUrl = `${appUrl}/bundle.png`;
+    // Get app URL for default bundle image (optional - only if accessible)
+    const appUrl = process.env.SHOPIFY_APP_URL;
+    const productInput: any = {
+      title: bundleName,
+      descriptionHtml: description || `<h2>${bundleName}</h2><p>${description || 'Complete bundle package with curated products.'}</p><p>Build your perfect bundle by selecting from our hand-picked collection of products.</p>`,
+      productType: "Bundle",
+      vendor: "Bundle Builder",
+      status: "ACTIVE",
+      tags: ["bundle", "cart-transform"],
+    };
+
+    // Only add image if app URL is configured (optional to avoid errors in dev)
+    if (appUrl) {
+      productInput.images = [
+        {
+          src: `${appUrl}/bundle.png`,
+          altText: `${bundleName} - Bundle`
+        }
+      ];
+    }
 
     const productResponse = await admin.graphql(CREATE_BUNDLE_PRODUCT, {
       variables: {
-        input: {
-          title: bundleName,
-          descriptionHtml: description || `<h2>${bundleName}</h2><p>${description || 'Complete bundle package with curated products.'}</p><p>Build your perfect bundle by selecting from our hand-picked collection of products.</p>`,
-          productType: "Bundle",
-          vendor: "Bundle Builder",
-          status: "ACTIVE",
-          tags: ["bundle", "cart-transform"],
-          images: [
-            {
-              src: defaultBundleImageUrl,
-              altText: `${bundleName} - Bundle`
-            }
-          ]
-        }
+        input: productInput
       }
     });
 
     const productData = await productResponse.json();
 
     if (productData.data?.productCreate?.userErrors?.length > 0) {
-      AppLogger.error("Product creation failed", { component: "app.bundles.cart-transform", operation: "create-bundle" }, { errors: productData.data.productCreate.userErrors });
-      return json({ error: 'Failed to create bundle product in Shopify' }, { status: 500 });
+      const errors = productData.data.productCreate.userErrors;
+      const errorMessages = errors.map((e: any) => e.message).join(', ');
+      AppLogger.error("Product creation failed", { component: "app.bundles.cart-transform", operation: "create-bundle" }, { errors });
+      return json({ error: `Shopify API error: ${errorMessages}` }, { status: 500 });
     }
 
     const shopifyProductId = productData.data?.productCreate?.product?.id;
@@ -369,8 +375,9 @@ export async function action({ request }: ActionFunctionArgs) {
     });
 
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     AppLogger.error("Failed to create cart transform bundle", { component: "app.bundles.cart-transform", operation: "create-bundle" }, error);
-    return json({ error: 'Failed to create cart transform bundle' }, { status: 500 });
+    return json({ error: `Failed to create bundle: ${errorMessage}` }, { status: 500 });
   }
 }
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -100,7 +100,7 @@ export const createMockBundle = (overrides = {}) => ({
   description: 'A test bundle for unit testing',
   shopId: 'test-shop.myshopify.com',
   shopifyProductId: null,
-  bundleType: 'cart_transform',
+  bundleType: 'product_page',
   status: 'active',
   active: true,
   createdAt: new Date(),

--- a/tests/unit/assets/bundle-widget.test.ts
+++ b/tests/unit/assets/bundle-widget.test.ts
@@ -75,8 +75,8 @@ describe('Bundle Widget JavaScript', () => {
           BUNDLE_CONFIG: '_bundle_config'
         },
         BUNDLE_TYPES: {
-          CART_TRANSFORM: 'cart_transform',
-          DISCOUNT_FUNCTION: 'discount_function'
+          PRODUCT_PAGE: 'product_page',
+          FULL_PAGE: 'full_page'
         }
       };
 
@@ -157,7 +157,7 @@ describe('Bundle Widget JavaScript', () => {
         id: 'test-bundle-1',
         name: 'Test Bundle',
         status: 'active',
-        bundleType: 'cart_transform',
+        bundleType: 'product_page',
         steps: [
           {
             id: 'step-1',
@@ -194,7 +194,7 @@ describe('Bundle Widget JavaScript', () => {
           id: 'bundle-1',
           name: 'Product Bundle',
           status: 'active',
-          bundleType: 'cart_transform',
+          bundleType: 'product_page',
           shopifyProductId: 'gid://shopify/Product/123',
           steps: [{ id: 'step-1', name: 'Step 1' }]
         },
@@ -219,12 +219,12 @@ describe('Bundle Widget JavaScript', () => {
         );
 
         for (const bundle of bundles) {
-          if (bundle.bundleType === 'cart_transform') {
+          if (bundle.bundleType === 'product_page') {
             if (config.currentProductId) {
               const productIdStr = config.currentProductId.toString();
-              const bundleProductId = bundle.shopifyProductId ? 
+              const bundleProductId = bundle.shopifyProductId ?
                 bundle.shopifyProductId.split('/').pop() : null;
-              
+
               if (bundleProductId === productIdStr) {
                 return bundle;
               }


### PR DESCRIPTION
Updated test files to use correct bundleType values:
- Changed 'cart_transform' to 'product_page' in all test files
- Updated BUNDLE_TYPES constants from cart_transform/discount_function to product_page/full_page
- Tests now match the current Prisma schema enum

Improved error handling in bundle creation:
- Show specific Shopify API error messages instead of generic errors
- Made bundle image optional (won't fail if SHOPIFY_APP_URL not set)
- Better error context for debugging

Files updated:
- tests/setup.ts: Updated createMockBundle bundleType
- tests/unit/assets/bundle-widget.test.ts: Updated all bundleType references and constants
- app/routes/app.bundles.cart-transform.tsx: Better error messages

This ensures tests use the same bundleType values as the application code.