### PR TITLE
fix(bundle-builder): correct Liquid variable name from bundle_config to bundle_ui_config

### DIFF
--- a/extensions/bundle-builder/blocks/bundle.liquid
+++ b/extensions/bundle-builder/blocks/bundle.liquid
@@ -498,7 +498,7 @@
     window.bundleWidgetContext = true;
 
     // Enhanced debugging for bundle data loading
-    const productBundleConfig = {{ bundle_config | json }};
+    const productBundleConfig = {{ bundle_ui_config | json }};
     console.log('🎯 [BUNDLE_DATA] Product ID:', {{ product.id | json }});
     console.log('🎯 [BUNDLE_DATA] Has bundle config metafield:', !!productBundleConfig);
 


### PR DESCRIPTION
- Fixed undefined object warning in bundle.liquid line 501
- Changed {{ bundle_config | json }} to {{ bundle_ui_config | json }}
- bundle_ui_config is the correct variable name defined at line 276
- Resolves Shopify build warning: 'Unknown object bundle_config used'