### PR TITLE
fix: correct data-bundle-config attribute formatting in bundle.liquid

### DIFF
--- a/extensions/bundle-builder/blocks/bundle.liquid
+++ b/extensions/bundle-builder/blocks/bundle.liquid
@@ -324,7 +324,7 @@
       data-bundle-id="{{ bundle_id }}"
       data-app-url="{{ block.settings.app_url | default: '' }}"
       data-is-bundle-product="{{ is_bundle_product }}"
-      data-bundle-config="{{ bundle_ui_config | json | escape }}"
+      data-bundle-config='{{ bundle_ui_config }}'
       data-hide-default-buttons="{{ hide_default_buttons }}"
       data-show-title="{{ block.settings.show_bundle_title }}"
       data-show-step-numbers="{{ block.settings.show_step_numbers }}"


### PR DESCRIPTION
- Changed data-bundle-config from JSON escaped string to a direct Liquid variable output for improved readability and functionality.