### PR TITLE
chore: update API version to 2025-10 across configuration files

### DIFF
--- a/app/shopify.server.ts
+++ b/app/shopify.server.ts
@@ -14,7 +14,7 @@ import { CartTransformService } from "./services/cart-transform-service.server";
 const shopify = shopifyApp({
   apiKey: process.env.SHOPIFY_API_KEY,
   apiSecretKey: process.env.SHOPIFY_API_SECRET || "",
-  apiVersion: LATEST_API_VERSION,
+  apiVersion: ApiVersion.October25, // 2025-10: Required for functionHandle support in cart transforms
   scopes: process.env.SCOPES?.split(","),
   appUrl: process.env.SHOPIFY_APP_URL || "",
   authPathPrefix: "/auth",
@@ -81,7 +81,7 @@ const shopify = shopifyApp({
 });
 
 export default shopify;
-export const apiVersion = ApiVersion.January25;
+export const apiVersion = ApiVersion.October25; // Match the runtime API version
 export const addDocumentResponseHeaders = shopify.addDocumentResponseHeaders;
 export const authenticate = shopify.authenticate;
 export const unauthenticated = shopify.unauthenticated;

--- a/extensions/bundle-cart-transform-ts/shopify.extension.toml
+++ b/extensions/bundle-cart-transform-ts/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2025-04"
+api_version = "2025-10"
 
 [[extensions]]
 name = "Bundle Cart Transform"

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -10,7 +10,7 @@ embedded = true
 automatically_update_urls_on_dev = false
 
 [webhooks]
-api_version = "2025-04"
+api_version = "2025-10"
 
   [[webhooks.subscriptions]]
   uri = "pubsub://light-quest-455608-i3:wolfpack-only-bundles"
@@ -43,7 +43,7 @@ prefix = "apps"
 # See: https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions
 
 [metafields]
-api_version = "2025-01"
+api_version = "2025-10"
 
 # ==============================================================================
 # VARIANT-LEVEL BUNDLE METAFIELDS (Shopify Standard - Approach 1: Hybrid)


### PR DESCRIPTION
- Updated api_version in shopify.app.toml, shopify.server.ts, and shopify.extension.toml to reflect the latest API version.
- Ensured compatibility with new features and improvements in the Shopify API for October 2025.