### PR TITLE
fix: add id field to bundle_ui_config for widget compatibility

### DIFF
--- a/app/services/bundles/metafield-sync.server.ts
+++ b/app/services/bundles/metafield-sync.server.ts
@@ -279,7 +279,8 @@ export async function updateBundleProductMetafields(
 
   // Build bundle_ui_config for widget
   const bundleUiConfig = {
-    bundleId: bundleConfiguration.id || bundleConfiguration.bundleId,
+    id: bundleConfiguration.id || bundleConfiguration.bundleId, // Widget expects 'id' field
+    bundleId: bundleConfiguration.id || bundleConfiguration.bundleId, // Keep for backwards compatibility
     name: bundleConfiguration.name,
     description: bundleConfiguration.description || '',
     steps: (bundleConfiguration.steps || []).map((step: any) => ({


### PR DESCRIPTION
The bundle widget expects an 'id' field in the bundle config object, but only 'bundleId' was being set. This caused the widget validation to fail with "Parsed bundle config is invalid (missing id)" error.

Changes:
- Added 'id' field to bundleUiConfig in metafield-sync.server.ts
- Kept 'bundleId' field for backwards compatibility
- Widget now successfully validates bundle configuration

Fixes widget initialization error on storefront.