### PR TITLE
fix: add status, bundleType, and shopifyProductId fields to bundle co…

### DIFF
--- a/app/services/bundles/metafield-sync.server.ts
+++ b/app/services/bundles/metafield-sync.server.ts
@@ -283,6 +283,9 @@ export async function updateBundleProductMetafields(
     bundleId: bundleConfiguration.id || bundleConfiguration.bundleId, // Keep for backwards compatibility
     name: bundleConfiguration.name,
     description: bundleConfiguration.description || '',
+    status: bundleConfiguration.status || 'active', // Widget needs this for filtering
+    bundleType: bundleConfiguration.bundleType || 'product_page', // Widget needs this for selection
+    shopifyProductId: bundleConfiguration.shopifyProductId || null, // Product ID for matching
     steps: (bundleConfiguration.steps || []).map((step: any) => ({
       id: step.id,
       name: step.name,


### PR DESCRIPTION
…nfig

- Added status field (defaults to 'active') for widget filtering
- Added bundleType field (defaults to 'product_page') for widget selection logic
- Added shopifyProductId field for product matching
- Fixes "No active bundles found" error where widget couldn't select bundle

Note: Existing bundles need to be re-saved in admin to update metafields

Deployed as version wolfpack-product-bundles-77