### PR TITLE
fix: change productIds to products array with id objects

### DIFF
--- a/app/services/bundles/metafield-sync.server.ts
+++ b/app/services/bundles/metafield-sync.server.ts
@@ -292,7 +292,7 @@ export async function updateBundleProductMetafields(
       position: step.position || 0,
       minQuantity: step.minQuantity || 1,
       maxQuantity: step.maxQuantity || 1,
-      productIds: (step.StepProduct || []).map((sp: any) => sp.productId).filter(Boolean),
+      products: (step.StepProduct || []).map((sp: any) => ({ id: sp.productId })).filter(p => p.id),
       conditionType: step.conditionType,
       conditionOperator: step.conditionOperator,
       conditionValue: step.conditionValue


### PR DESCRIPTION
- Changed step.productIds (array of strings) to step.products (array of objects)
- Widget expects step.products with {id} objects, not productIds strings
- Fixes "Raw products for step 0: 0 products" error where products weren't loading

Deployed as version wolfpack-product-bundles-78