### PR TITLE
fix: add pricing configuration to bundle UI config

### DIFF
--- a/app/services/bundles/metafield-sync.server.ts
+++ b/app/services/bundles/metafield-sync.server.ts
@@ -297,6 +297,20 @@ export async function updateBundleProductMetafields(
       conditionOperator: step.conditionOperator,
       conditionValue: step.conditionValue
     })),
+    pricing: bundleConfiguration.pricing ? {
+      enabled: bundleConfiguration.pricing.enabled || false,
+      method: bundleConfiguration.pricing.method || 'percentage_off',
+      rules: (bundleConfiguration.pricing.rules || []).map((rule: any) => ({
+        condition: rule.condition ? {
+          type: rule.condition.type || 'quantity',
+          operator: rule.condition.operator || 'gte',
+          value: parseFloat(rule.condition.value) || 0
+        } : null,
+        discount: rule.discount ? {
+          value: parseFloat(rule.discount.value) || 0
+        } : { value: parseFloat(rule.discountValue) || 0 }
+      }))
+    } : null,
     messaging: {
       progressTemplate: bundleConfiguration.messaging?.progressTemplate || 'Add {items} more items',
       successTemplate: bundleConfiguration.messaging?.successTemplate || 'Discount unlocked!',


### PR DESCRIPTION
- Added pricing object with enabled, method, and rules to bundleUiConfig
- Widget needs pricing data to display progress bars and discount messaging
- Fixes "No progress bar" and "No discount messaging" issues

Cart transform integration note:
- Cart transform uses Shopify Standard Bundle metafields (component_reference, price_adjustment)
- These metafields are already being set correctly on bundle variants
- Widget cart properties (_bundle_id, _bundle_config) are for reference only
- Actual bundle discounts are applied via metafield-based MERGE operations

Deployed as version wolfpack-product-bundles-79