### PR TITLE
fix: implement cart transform EXPAND operation and refactor SaveBar

### DIFF
--- a/app/assets/bundle-widget-full.js
+++ b/app/assets/bundle-widget-full.js
@@ -2174,30 +2174,60 @@ class BundleWidget {
   }
 
   buildCartItems() {
+    // Shopify Standard Bundle approach: Add the bundle parent variant to cart
+    // Cart transform will EXPAND it into individual components with discount applied
+    // See: https://shopify.dev/docs/apps/build/product-merchandising/bundles/create-bundle-app
+
     const cartItems = [];
-    const bundleInstanceId = this.generateBundleInstanceId();
 
-    this.selectedProducts.forEach((stepSelections, stepIndex) => {
-      const productsInStep = this.stepProductData[stepIndex];
+    // Extract numeric variant ID from GID format
+    const bundleVariantId = this.selectedBundle.bundleVariantId;
+    if (!bundleVariantId) {
+      console.error('[CART] Bundle variant ID not found in configuration');
+      console.error('[CART] Bundle config:', this.selectedBundle);
+      throw new Error('Bundle variant ID not available. Please ensure bundle metafields are synced.');
+    }
 
-      Object.entries(stepSelections).forEach(([variantId, quantity]) => {
-        if (quantity > 0) {
-          const product = productsInStep.find(p => (p.variantId || p.id) === variantId);
-          if (product) {
-            const cartItem = {
-              id: parseInt(variantId),
-              quantity: quantity,
-              properties: {
-                [BUNDLE_WIDGET.CART_PROPERTIES.BUNDLE_ID]: bundleInstanceId,
-                [BUNDLE_WIDGET.CART_PROPERTIES.BUNDLE_CONFIG]: JSON.stringify(this.selectedBundle)
-              }
-            };
+    // Extract numeric ID from GID if needed (e.g., "gid://shopify/ProductVariant/123456" -> 123456)
+    let numericVariantId;
+    if (typeof bundleVariantId === 'string' && bundleVariantId.includes('gid://')) {
+      const match = bundleVariantId.match(/ProductVariant\/(\d+)/);
+      numericVariantId = match ? parseInt(match[1], 10) : null;
+    } else {
+      numericVariantId = parseInt(bundleVariantId, 10);
+    }
 
-            cartItems.push(cartItem);
-          }
-        }
-      });
+    if (!numericVariantId || isNaN(numericVariantId)) {
+      console.error('[CART] Invalid bundle variant ID:', bundleVariantId);
+      throw new Error('Invalid bundle variant ID format');
+    }
+
+    console.log('[CART] Adding bundle parent variant to cart:', {
+      bundleId: this.selectedBundle.id,
+      bundleName: this.selectedBundle.name,
+      bundleVariantId: numericVariantId,
+      originalVariantId: bundleVariantId
     });
+
+    // Add the bundle parent product (quantity = 1)
+    // Cart transform will read component_reference, component_quantities, and price_adjustment metafields
+    // and expand this into individual components with discount applied
+    const cartItem = {
+      id: numericVariantId,
+      quantity: 1,
+      properties: {
+        [BUNDLE_WIDGET.CART_PROPERTIES.BUNDLE_ID]: this.selectedBundle.id,
+        [BUNDLE_WIDGET.CART_PROPERTIES.BUNDLE_CONFIG]: JSON.stringify({
+          bundleId: this.selectedBundle.id,
+          bundleName: this.selectedBundle.name,
+          selectedProducts: this.selectedProducts
+        })
+      }
+    };
+
+    cartItems.push(cartItem);
+
+    console.log('[CART] Cart items to add:', cartItems);
     return cartItems;
   }
 

--- a/app/routes/app.bundles.cart-transform.configure.$bundleId.tsx
+++ b/app/routes/app.bundles.cart-transform.configure.$bundleId.tsx
@@ -53,7 +53,7 @@ import {
   ImageIcon,
 } from "@shopify/polaris-icons";
 import { useAppBridge, SaveBar } from "@shopify/app-bridge-react";
-// Using modern App Bridge contextual save bar with data-save-bar attribute on form
+// Using modern App Bridge SaveBar with declarative 'open' prop for React-friendly state management
 import { authenticate } from "../shopify.server";
 import db from "../db.server";
 import { ThemeTemplateService } from "../services/theme-template.server";
@@ -1809,13 +1809,8 @@ export default function ConfigureBundleFlow() {
     productStatus: loadedBundleProduct?.status || "ACTIVE",
   });
 
-  // Track if there are unsaved changes
+  // Track if there are unsaved changes (controls SaveBar visibility via 'open' prop)
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-
-  // Track previous state to prevent unnecessary SaveBar API calls (prevents flickering)
-  const prevHasUnsavedChanges = useRef(false);
-
-  // NOTE: triggerSaveBar and dismissSaveBar are now provided by formState hook
 
   // Check for changes whenever form values change
   useEffect(() => {
@@ -1875,21 +1870,8 @@ export default function ConfigureBundleFlow() {
     originalValues
   ]);
 
-  // Separate useEffect to control SaveBar visibility only when hasUnsavedChanges actually toggles
-  // Per Shopify App Bridge docs: only call show/hide when state transitions, not on every render
-  // Reference: https://shopify.dev/docs/api/app-bridge-library/apis/save-bar
-  useEffect(() => {
-    // Only call API if state actually changed
-    if (hasUnsavedChanges !== prevHasUnsavedChanges.current) {
-      if (hasUnsavedChanges) {
-        shopify.saveBar.show('bundle-save-bar');
-      } else {
-        shopify.saveBar.hide('bundle-save-bar');
-      }
-      // Update ref for next comparison
-      prevHasUnsavedChanges.current = hasUnsavedChanges;
-    }
-  }, [hasUnsavedChanges, shopify]);
+  // SaveBar visibility is now controlled declaratively via the 'open' prop
+  // No need for manual show/hide API calls - React handles it automatically
 
   // Save handler
   const handleSave = useCallback(async () => {
@@ -2836,7 +2818,7 @@ export default function ConfigureBundleFlow() {
         disabled: !bundleProduct || stepsState.steps.length === 0,
       }}
     >
-      {/* Modern App Bridge contextual save bar using form with data-save-bar */}
+      {/* Modern App Bridge SaveBar with declarative React state management */}
       <form
         onSubmit={(e) => {
           e.preventDefault();
@@ -2847,12 +2829,16 @@ export default function ConfigureBundleFlow() {
           handleDiscard();
         }}
       >
-        {/* SaveBar component - always rendered, visibility controlled by shopify.saveBar.show/hide API */}
-        <SaveBar id="bundle-save-bar">
+        {/* SaveBar component - visibility controlled declaratively via 'open' prop */}
+        <SaveBar
+          id="bundle-save-bar"
+          open={hasUnsavedChanges}
+          discardConfirmation={true}
+        >
           <button
             variant="primary"
             onClick={handleSave}
-            loading={fetcher.state !== "idle" ? "" : undefined}
+            loading={fetcher.state !== "idle"}
             disabled={fetcher.state !== "idle"}
           >
             Save

--- a/app/services/bundles/metafield-sync.server.ts
+++ b/app/services/bundles/metafield-sync.server.ts
@@ -286,6 +286,7 @@ export async function updateBundleProductMetafields(
     status: bundleConfiguration.status || 'active', // Widget needs this for filtering
     bundleType: bundleConfiguration.bundleType || 'product_page', // Widget needs this for selection
     shopifyProductId: bundleConfiguration.shopifyProductId || null, // Product ID for matching
+    bundleVariantId: bundleVariantId, // Bundle parent variant ID for cart transform EXPAND operation
     steps: (bundleConfiguration.steps || []).map((step: any) => ({
       id: step.id,
       name: step.name,


### PR DESCRIPTION
Cart Transform Integration:
- Add bundleVariantId to bundle_ui_config metafield for widget access
- Update widget to add bundle parent variant instead of individual components
- Enable EXPAND operation: parent variant → components + discount
- Cart transform reads component_reference, component_quantities, price_adjustment metafields

SaveBar Improvements:
- Migrate from imperative (show/hide API) to declarative (open prop) approach
- Add discardConfirmation prop to prevent accidental data loss
- Fix loading prop type (string → boolean)
- Remove unnecessary useRef and complex useEffect
- Improve React state management and performance

Technical Details:
- Widget now calls buildCartItems() which adds parent variant (not components)
- Cart transform EXPAND operation triggered automatically
- SaveBar visibility controlled via open={hasUnsavedChanges} prop
- Follows Shopify App Bridge best practices for React components

Deployed as version wolfpack-product-bundles-80