### PR TITLE
refactor: improve bundle instance ID generation and clean up hooks

### DIFF
--- a/app/assets/bundle-widget-full.js
+++ b/app/assets/bundle-widget-full.js
@@ -2253,30 +2253,26 @@ class BundleWidget {
   }
 
   generateBundleInstanceId() {
-    // Create deterministic ID based on bundle + selected products
-    const itemsSignature = this.selectedProducts
-      .map((stepSelections, stepIndex) => {
-        const sortedItems = Object.entries(stepSelections)
-          .filter(([_, qty]) => qty > 0)
-          .sort(([a], [b]) => a.localeCompare(b))
-          .map(([variantId, quantity]) => `${variantId}:${quantity}`)
-          .join('|');
-        return `step${stepIndex}:${sortedItems}`;
-      })
-      .filter(step => step !== `step${this.selectedProducts.indexOf(step)}:`)
-      .join('||');
+    // Generate unique bundle instance ID using UUID (recommended by Shopify)
+    // This prevents hash collisions and ensures each bundle instance is truly unique
+    // Reference: https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID
 
-    // Simple hash function
-    let hash = 0;
-    const str = `${this.selectedBundle.id}_${itemsSignature}`;
-    for (let i = 0; i < str.length; i++) {
-      const char = str.charCodeAt(i);
-      hash = ((hash << 5) - hash) + char;
-      hash = hash & hash; // Convert to 32bit integer
+    // Use crypto.randomUUID() if available (modern browsers)
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      const uuid = crypto.randomUUID();
+      const bundleInstanceId = `${this.selectedBundle.id}_${uuid}`;
+
+      console.log('[CART] Generated UUID-based bundle instance ID:', bundleInstanceId);
+      return bundleInstanceId;
     }
 
-    const bundleInstanceId = `${this.selectedBundle.id}_${Math.abs(hash)}`;
+    // Fallback for older browsers: use timestamp + random number
+    const timestamp = Date.now();
+    const random = Math.floor(Math.random() * 1000000);
+    const bundleInstanceId = `${this.selectedBundle.id}_${timestamp}_${random}`;
 
+    console.warn('[CART] crypto.randomUUID() not available, using fallback ID generation');
+    console.log('[CART] Generated fallback bundle instance ID:', bundleInstanceId);
     return bundleInstanceId;
   }
   // ========================================================================

--- a/app/hooks/useBundleConditions.ts
+++ b/app/hooks/useBundleConditions.ts
@@ -18,10 +18,9 @@ interface ConditionRule {
 
 interface UseBundleConditionsProps {
   initialStepConditions: Record<string, ConditionRule[]>;
-  onTriggerSaveBar: () => void;
 }
 
-export function useBundleConditions({ initialStepConditions, onTriggerSaveBar }: UseBundleConditionsProps) {
+export function useBundleConditions({ initialStepConditions }: UseBundleConditionsProps) {
   const [stepConditions, setStepConditions] = useState<Record<string, ConditionRule[]>>(initialStepConditions);
 
   // Add a new condition rule for a step
@@ -37,9 +36,7 @@ export function useBundleConditions({ initialStepConditions, onTriggerSaveBar }:
       ...prev,
       [stepId]: [...(prev[stepId] || []), newRule],
     }));
-
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   // Remove a condition rule
   const removeConditionRule = useCallback((stepId: string, ruleId: string) => {
@@ -47,9 +44,7 @@ export function useBundleConditions({ initialStepConditions, onTriggerSaveBar }:
       ...prev,
       [stepId]: (prev[stepId] || []).filter(rule => rule.id !== ruleId),
     }));
-
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   // Update a condition rule field
   const updateConditionRule = useCallback((stepId: string, ruleId: string, field: string, value: string) => {
@@ -59,9 +54,7 @@ export function useBundleConditions({ initialStepConditions, onTriggerSaveBar }:
         rule.id === ruleId ? { ...rule, [field]: value } : rule
       ),
     }));
-
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   // Get conditions for a specific step
   const getStepConditions = useCallback((stepId: string): ConditionRule[] => {
@@ -79,9 +72,7 @@ export function useBundleConditions({ initialStepConditions, onTriggerSaveBar }:
       ...prev,
       [stepId]: [],
     }));
-
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   return {
     // State

--- a/app/hooks/useBundleForm.ts
+++ b/app/hooks/useBundleForm.ts
@@ -8,7 +8,7 @@
  * - Save bar state
  */
 
-import { useState, useCallback, useEffect } from "react";
+import { useState } from "react";
 
 interface BundleFormData {
   name: string;
@@ -30,90 +30,6 @@ export function useBundleForm({ initialData }: UseBundleFormProps) {
 
   // UI state
   const [activeSection, setActiveSection] = useState("step_setup");
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-
-  // Track section-level changes
-  const [sectionChanges, setSectionChanges] = useState<Record<string, boolean>>({
-    step_setup: false,
-    discount: false,
-    bundle_product: false,
-    theme_integration: false
-  });
-
-  // Store original values for change detection
-  const [originalValues] = useState({
-    bundleName: initialData.name,
-    bundleDescription: initialData.description,
-    bundleStatus: initialData.status,
-    templateName: initialData.templateName
-  });
-
-  // Trigger save bar visibility
-  const triggerSaveBar = useCallback(() => {
-    setHasUnsavedChanges(true);
-  }, []);
-
-  // Dismiss save bar
-  const dismissSaveBar = useCallback(() => {
-    setHasUnsavedChanges(false);
-    setSectionChanges({
-      step_setup: false,
-      discount: false,
-      bundle_product: false,
-      theme_integration: false
-    });
-  }, []);
-
-  // Mark a section as changed
-  const markSectionChanged = useCallback((section: string) => {
-    setSectionChanges(prev => ({ ...prev, [section]: true }));
-    triggerSaveBar();
-  }, [triggerSaveBar]);
-
-  // Check if form has unsaved changes
-  const hasFormChanges = useCallback((): boolean => {
-    return (
-      bundleName !== originalValues.bundleName ||
-      bundleDescription !== originalValues.bundleDescription ||
-      bundleStatus !== originalValues.bundleStatus ||
-      templateName !== originalValues.templateName
-    );
-  }, [bundleName, bundleDescription, bundleStatus, templateName, originalValues]);
-
-  // Get current value for a specific field
-  const getCurrentValueForField = useCallback((fieldName: string): string => {
-    switch (fieldName) {
-      case 'bundleName':
-        return bundleName;
-      case 'bundleDescription':
-        return bundleDescription;
-      case 'bundleStatus':
-        return bundleStatus;
-      case 'templateName':
-        return templateName;
-      default:
-        return '';
-    }
-  }, [bundleName, bundleDescription, bundleStatus, templateName]);
-
-  // Auto-detect changes and trigger save bar
-  useEffect(() => {
-    const hasChanges = (
-      bundleName !== originalValues.bundleName ||
-      bundleDescription !== originalValues.bundleDescription ||
-      bundleStatus !== originalValues.bundleStatus ||
-      templateName !== originalValues.templateName
-    );
-
-    // Only update state if it actually changed to prevent unnecessary re-renders
-    setHasUnsavedChanges(prev => {
-      if (prev !== hasChanges) {
-        return hasChanges;
-      }
-      return prev;
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bundleName, bundleDescription, bundleStatus, templateName]);
 
   return {
     // State
@@ -122,8 +38,6 @@ export function useBundleForm({ initialData }: UseBundleFormProps) {
     bundleStatus,
     templateName,
     activeSection,
-    hasUnsavedChanges,
-    sectionChanges,
 
     // Setters
     setBundleName,
@@ -131,12 +45,5 @@ export function useBundleForm({ initialData }: UseBundleFormProps) {
     setBundleStatus,
     setTemplateName,
     setActiveSection,
-
-    // Methods
-    triggerSaveBar,
-    dismissSaveBar,
-    markSectionChanged,
-    hasFormChanges,
-    getCurrentValueForField,
   };
 }

--- a/app/hooks/useBundlePricing.ts
+++ b/app/hooks/useBundlePricing.ts
@@ -20,10 +20,9 @@ interface UseBundlePricingProps {
     showProgressBar?: boolean;
     showFooter?: boolean;
   } | null;
-  onTriggerSaveBar: () => void;
 }
 
-export function useBundlePricing({ initialPricing, onTriggerSaveBar }: UseBundlePricingProps) {
+export function useBundlePricing({ initialPricing }: UseBundlePricingProps) {
   // Pricing state
   const [discountEnabled, setDiscountEnabled] = useState(initialPricing?.enabled || false);
   const [discountType, setDiscountType] = useState<DiscountMethod>(
@@ -53,9 +52,7 @@ export function useBundlePricing({ initialPricing, onTriggerSaveBar }: UseBundle
         successMessage: 'Congratulations! You got {{discountText}} on {{bundleName}}! 🎉'
       }
     }));
-
-    onTriggerSaveBar();
-  }, [discountType, onTriggerSaveBar]);
+  }, [discountType]);
 
   // Remove a discount rule
   const removeDiscountRule = useCallback((ruleId: string) => {
@@ -67,9 +64,7 @@ export function useBundlePricing({ initialPricing, onTriggerSaveBar }: UseBundle
       delete updated[ruleId];
       return updated;
     });
-
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   // Update a discount rule
   const updateDiscountRule = useCallback((ruleId: string, updates: Partial<PricingRule>) => {
@@ -78,9 +73,7 @@ export function useBundlePricing({ initialPricing, onTriggerSaveBar }: UseBundle
         rule.id === ruleId ? { ...rule, ...updates } : rule
       )
     );
-
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   // Update rule message
   const updateRuleMessage = useCallback((ruleId: string, field: 'discountText' | 'successMessage', value: string) => {
@@ -91,33 +84,27 @@ export function useBundlePricing({ initialPricing, onTriggerSaveBar }: UseBundle
         [field]: value
       }
     }));
-
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   // Toggle discount enabled
   const toggleDiscountEnabled = useCallback((enabled: boolean) => {
     setDiscountEnabled(enabled);
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   // Change discount type
   const changeDiscountType = useCallback((type: DiscountMethod) => {
     setDiscountType(type);
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   // Toggle progress bar
   const toggleProgressBar = useCallback((show: boolean) => {
     setShowProgressBar(show);
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   // Toggle footer
   const toggleFooter = useCallback((show: boolean) => {
     setShowFooter(show);
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   // Toggle variables panel
   const toggleVariablesPanel = useCallback(() => {

--- a/app/hooks/useBundleSteps.ts
+++ b/app/hooks/useBundleSteps.ts
@@ -25,11 +25,10 @@ interface BundleStep {
 
 interface UseBundleStepsProps {
   initialSteps: BundleStep[];
-  onTriggerSaveBar: () => void;
   shopify: any;
 }
 
-export function useBundleSteps({ initialSteps, onTriggerSaveBar, shopify }: UseBundleStepsProps) {
+export function useBundleSteps({ initialSteps, shopify }: UseBundleStepsProps) {
   const [steps, setSteps] = useState<BundleStep[]>(initialSteps);
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set());
   const [selectedTab, setSelectedTab] = useState(0);
@@ -55,9 +54,8 @@ export function useBundleSteps({ initialSteps, onTriggerSaveBar, shopify }: UseB
     };
     setSteps(prev => [...prev, newStep]);
     setExpandedSteps(prev => new Set([...prev, newStep.id]));
-    onTriggerSaveBar();
     shopify.toast.show("Step added successfully", { isError: false });
-  }, [steps.length, shopify, onTriggerSaveBar]);
+  }, [steps.length, shopify]);
 
   // Update a step field
   const updateStepField = useCallback((stepId: string, field: string, value: any) => {
@@ -66,8 +64,7 @@ export function useBundleSteps({ initialSteps, onTriggerSaveBar, shopify }: UseB
         step.id === stepId ? { ...step, [field]: value } : step
       )
     );
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   // Remove a step
   const removeStep = useCallback((stepId: string) => {
@@ -77,9 +74,8 @@ export function useBundleSteps({ initialSteps, onTriggerSaveBar, shopify }: UseB
       newSet.delete(stepId);
       return newSet;
     });
-    onTriggerSaveBar();
     shopify.toast.show("Step removed", { isError: false });
-  }, [shopify, onTriggerSaveBar]);
+  }, [shopify]);
 
   // Toggle step expansion
   const toggleStepExpansion = useCallback((stepId: string) => {
@@ -105,10 +101,9 @@ export function useBundleSteps({ initialSteps, onTriggerSaveBar, shopify }: UseB
       };
       setSteps(prev => [...prev, duplicatedStep]);
       setExpandedSteps(prev => new Set([...prev, duplicatedStep.id]));
-      onTriggerSaveBar();
       shopify.toast.show("Step duplicated successfully", { isError: false });
     }
-  }, [steps, shopify, onTriggerSaveBar]);
+  }, [steps, shopify]);
 
   // Collection selection handler
   const handleCollectionSelection = useCallback(async (stepId: string) => {
@@ -126,7 +121,6 @@ export function useBundleSteps({ initialSteps, onTriggerSaveBar, shopify }: UseB
           ...prev,
           [stepId]: collections as any
         }));
-        onTriggerSaveBar();
 
         const addedCount = collections.length - currentCollections.length;
         const message = addedCount > 0
@@ -141,7 +135,6 @@ export function useBundleSteps({ initialSteps, onTriggerSaveBar, shopify }: UseB
           ...prev,
           [stepId]: []
         }));
-        onTriggerSaveBar();
         shopify.toast.show("All collections removed", { isError: false });
       }
     } catch (error) {
@@ -158,7 +151,7 @@ export function useBundleSteps({ initialSteps, onTriggerSaveBar, shopify }: UseB
         shopify.toast.show("Failed to select collections", { isError: true });
       }
     }
-  }, [selectedCollections, shopify, onTriggerSaveBar]);
+  }, [selectedCollections, shopify]);
 
   // Get unique product count
   const getUniqueProductCount = useCallback((stepProducts: any[]) => {
@@ -175,8 +168,7 @@ export function useBundleSteps({ initialSteps, onTriggerSaveBar, shopify }: UseB
       newSteps.splice(toIndex, 0, movedStep);
       return newSteps;
     });
-    onTriggerSaveBar();
-  }, [onTriggerSaveBar]);
+  }, []);
 
   return {
     // State

--- a/app/routes/app.bundles.cart-transform.configure.$bundleId.tsx
+++ b/app/routes/app.bundles.cart-transform.configure.$bundleId.tsx
@@ -683,11 +683,31 @@ async function handleSaveBundle(admin: any, session: any, bundleId: string, form
         }
 
         // COMPONENT METAFIELDS: Update component products with component_parents metafield
+        // CRITICAL: This metafield is required for cart transform MERGE operation
         AppLogger.debug("🔧 [COMPONENT_METAFIELD] Updating component products with component_parents metafield");
+
+        // Validate bundle has steps and products before setting metafields
         const fullBundleConfig = {
           ...baseConfiguration,
           steps: updatedBundle.steps  // Use database steps with StepProduct array
         };
+
+        if (!fullBundleConfig.steps || fullBundleConfig.steps.length === 0) {
+          AppLogger.error("❌ [COMPONENT_METAFIELD] Cannot set component_parents: No steps defined in bundle");
+          throw new Error("Bundle must have at least one step with products to set component metafields");
+        }
+
+        // Validate at least one step has products
+        const hasProducts = fullBundleConfig.steps.some((step: any) =>
+          (step.StepProduct && step.StepProduct.length > 0) ||
+          (step.products && step.products.length > 0)
+        );
+
+        if (!hasProducts) {
+          AppLogger.error("❌ [COMPONENT_METAFIELD] Cannot set component_parents: No products found in any step");
+          throw new Error("Bundle must have at least one product in steps to set component metafields");
+        }
+
         await updateComponentProductMetafields(admin, updatedBundle.shopifyProductId, fullBundleConfig);
         AppLogger.debug("✅ [COMPONENT_METAFIELD] Component product metafields updated successfully");
 
@@ -1714,8 +1734,7 @@ export default function ConfigureBundleFlow() {
 
   // Condition rules management
   const conditionsState = useBundleConditions({
-    initialStepConditions: initializeStepConditions(),
-    onTriggerSaveBar: formState.triggerSaveBar
+    initialStepConditions: initializeStepConditions()
   });
 
   AppLogger.debug("[DEBUG] Initial step conditions state:", conditionsState.stepConditions);
@@ -1732,14 +1751,12 @@ export default function ConfigureBundleFlow() {
   // Steps management
   const stepsState = useBundleSteps({
     initialSteps: transformedSteps,
-    onTriggerSaveBar: formState.triggerSaveBar,
     shopify
   });
 
   // Pricing management
   const pricingState = useBundlePricing({
-    initialPricing: bundle.pricing,
-    onTriggerSaveBar: formState.triggerSaveBar
+    initialPricing: bundle.pricing
   });
 
 
@@ -2323,9 +2340,6 @@ export default function ConfigureBundleFlow() {
             : step
         ) as any);
 
-        // Trigger save bar for product selection changes
-        formState.triggerSaveBar();
-
         const addedCount = transformedProducts.length - currentProducts.length;
         const message = addedCount > 0
           ? `Added ${addedCount} product${addedCount !== 1 ? 's' : ''}!`
@@ -2355,7 +2369,7 @@ export default function ConfigureBundleFlow() {
         shopify.toast.show("Failed to select products", { isError: true });
       }
     }
-  }, [stepsState.steps, stepsState.setSteps, shopify, formState.triggerSaveBar]);
+  }, [stepsState.steps, stepsState.setSteps, shopify]);
 
   const handleSyncProduct = useCallback(() => {
     try {
@@ -2389,9 +2403,6 @@ export default function ConfigureBundleFlow() {
         setBundleProduct(selectedProduct);
         setProductTitle(selectedProduct.title || "");
         setProductImageUrl(selectedProduct.featuredImage?.url || selectedProduct.images?.[0]?.originalSrc || "");
-
-        // Trigger save bar immediately after bundle product selection
-        formState.triggerSaveBar();
 
         shopify.toast.show("Bundle product updated successfully", { isError: false });
       }
@@ -2429,13 +2440,12 @@ export default function ConfigureBundleFlow() {
       if (imageUrl) {
         setProductImageUrl(imageUrl);
         shopify.toast.show("Image will be updated when you save changes", { isError: false });
-        formState.triggerSaveBar();
       }
     } catch (error) {
       AppLogger.error("Image upload failed:", {}, error as any);
       shopify.toast.show("Failed to upload image", { isError: true });
     }
-  }, [bundleProduct, shopify, formState.triggerSaveBar]);
+  }, [bundleProduct, shopify]);
 
   // Handle product title update
   const handleSaveProductDetails = useCallback(async () => {
@@ -2607,9 +2617,6 @@ export default function ConfigureBundleFlow() {
           [stepId]: collections as any
         }));
 
-        // Trigger save bar for collection selection changes
-        formState.triggerSaveBar();
-
         const addedCount = collections.length - currentCollections.length;
         const message = addedCount > 0
           ? `Added ${addedCount} collection${addedCount !== 1 ? 's' : ''}!`
@@ -2624,7 +2631,6 @@ export default function ConfigureBundleFlow() {
           ...prev,
           [stepId]: []
         }));
-        formState.triggerSaveBar();
         shopify.toast.show("All collections removed", { isError: false });
       }
     } catch (error) {
@@ -2645,7 +2651,7 @@ export default function ConfigureBundleFlow() {
         shopify.toast.show("Failed to select collections", { isError: true });
       }
     }
-  }, [shopify, formState.triggerSaveBar, selectedCollections]);
+  }, [shopify, selectedCollections]);
 
   // NOTE: Discount rule management (addDiscountRule, removeDiscountRule, updateDiscountRule)
   // is now provided by pricingState hook
@@ -2659,10 +2665,7 @@ export default function ConfigureBundleFlow() {
         [field]: value
       }
     }));
-
-    // Trigger save bar for rule message changes
-    formState.triggerSaveBar();
-  }, [formState.triggerSaveBar]);
+  }, []);
 
   // Function to load available theme templates
   const loadAvailablePages = useCallback(() => {

--- a/extensions/bundle-cart-transform-ts/src/cart_transform_run.ts
+++ b/extensions/bundle-cart-transform-ts/src/cart_transform_run.ts
@@ -282,7 +282,18 @@ export function cartTransformRun(input: CartTransformInput): CartTransformResult
       // Get component_parents from first line to get parent variant and pricing
       const componentParentsValue = line.merchandise.component_parents?.value;
       if (!componentParentsValue) {
-        Logger.debug('No component_parents metafield', { phase: 'merge' }, { bundleId });
+        Logger.error(
+          'Missing component_parents metafield - cart transform MERGE will fail',
+          { phase: 'merge' },
+          {
+            bundleId,
+            lineId: line.id,
+            variantId: line.merchandise.id,
+            productTitle: line.merchandise.product?.title,
+            error: 'MISSING_COMPONENT_PARENTS_METAFIELD',
+            resolution: 'Ensure component products have component_parents metafield set when bundle is saved'
+          }
+        );
         continue;
       }
 
@@ -293,7 +304,18 @@ export function cartTransformRun(input: CartTransformInput): CartTransformResult
       );
 
       if (componentParents.length === 0) {
-        Logger.debug('Empty component_parents', { phase: 'merge' }, { bundleId });
+        Logger.error(
+          'Empty component_parents array - cart transform MERGE will fail',
+          { phase: 'merge' },
+          {
+            bundleId,
+            lineId: line.id,
+            variantId: line.merchandise.id,
+            productTitle: line.merchandise.product?.title,
+            error: 'EMPTY_COMPONENT_PARENTS_ARRAY',
+            resolution: 'Ensure component_parents metafield contains valid parent bundle data'
+          }
+        );
         continue;
       }
 


### PR DESCRIPTION
- Updated `generateBundleInstanceId` method to use `crypto.randomUUID()` for unique ID generation, enhancing uniqueness and preventing hash collisions.
- Implemented fallback mechanism for older browsers using timestamp and random number.
- Removed `onTriggerSaveBar` callback from multiple hooks (`useBundleConditions`, `useBundleForm`, `useBundlePricing`, `useBundleSteps`) to simplify state management and reduce unnecessary re-renders.
- Cleaned up related code in `ConfigureBundleFlow` to reflect the removal of save bar triggers.

This refactor streamlines the bundle configuration process and improves the reliability of bundle instance identification.