### PR TITLE
chore: switch database provider from SQLite to PostgreSQL

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,9 +10,9 @@ generator client {
 // See https://www.prisma.io/docs/orm/reference/prisma-schema-reference#string for more information
 datasource db {
   // Comment out for development environment
-  provider = "sqlite"
+  provider = "postgresql"
   // Comment out for production environment
-  url      = "file:./dev.db"
+  url      = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
 


### PR DESCRIPTION
Updated database configuration for staging/production deployment:
- Changed provider from sqlite to postgresql
- Updated connection URL to use DATABASE_URL environment variable
- Maintains DIRECT_URL for migrations and connection pooling

This enables testing on staging branch with PostgreSQL database.