### PR TITLE
fix: use correct modal size and increase height for better workspace

### DIFF
--- a/app/routes/app.design-control-panel.tsx
+++ b/app/routes/app.design-control-panel.tsx
@@ -911,7 +911,7 @@ export default function DesignControlPanel() {
         open={modalActive}
         onClose={handleCloseModal}
         title="Customisations"
-        size="fullScreen"
+        size="large"
         primaryAction={{
           content: "Save",
           onAction: handleSaveSettings,
@@ -924,7 +924,7 @@ export default function DesignControlPanel() {
         ]}
       >
         <Modal.Section flush>
-          <div style={{ display: "flex", height: "calc(100vh - 120px)", minHeight: "600px" }}>
+          <div style={{ display: "flex", height: "80vh", minHeight: "700px" }}>
             {/* Left Sidebar - Navigation */}
             <div
               style={{


### PR DESCRIPTION
- Change modal size from fullScreen to large (maximum available in Polaris)
- Increase modal height to 80vh for more workspace
- Set minimum height to 700px for consistent experience