### PR TITLE
Improve bundle widget UI consistency and fix z-index issues

### DIFF
--- a/app/assets/bundle-widget-full.js
+++ b/app/assets/bundle-widget-full.js
@@ -1287,14 +1287,10 @@ class BundleWidget {
       stepBox.appendChild(plusIcon);
     }
 
-    // Add step name
+    // Add step name (without step number)
     const stepName = document.createElement('p');
     stepName.className = 'step-name';
-    if (this.config.showStepNumbers) {
-      stepName.textContent = `${index + 1}. ${step.name || `Step ${index + 1}`}`;
-    } else {
-      stepName.textContent = step.name || `Step ${index + 1}`;
-    }
+    stepName.textContent = step.name || `Step ${index + 1}`;
     stepBox.appendChild(stepName);
 
     // Add selection count

--- a/extensions/bundle-builder/assets/bundle-widget.css
+++ b/extensions/bundle-builder/assets/bundle-widget.css
@@ -85,7 +85,7 @@
 
 .step-box {
   border: 2px solid #e5e7eb;
-  border-radius: 16px;
+  border-radius: 12px;
   width: 100%;
   max-width: var(--step-box-size, 150px);
   height: auto;
@@ -97,69 +97,25 @@
   align-items: center;
   text-align: center;
   cursor: pointer;
-  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
-  background: linear-gradient(135deg, #ffffff 0%, #f9fafb 100%);
+  background: #ffffff;
   box-sizing: border-box;
   padding: 16px;
   margin: 0;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05), 0 1px 2px rgba(0, 0, 0, 0.05);
   overflow: hidden;
-}
-
-.step-box::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 4px;
-  background: linear-gradient(90deg, #7132FF 0%, #9b6bff 100%);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.step-box:hover {
-  border-color: #7132FF;
-  background: linear-gradient(135deg, #faf8ff 0%, #f5f3ff 100%);
-  transform: translateY(-4px);
-  box-shadow: 0 12px 24px rgba(113, 50, 255, 0.12), 0 6px 12px rgba(113, 50, 255, 0.08);
-}
-
-.step-box:hover::before {
-  opacity: 1;
 }
 
 .step-box.step-completed {
   border-color: #10b981;
   background: linear-gradient(135deg, #f0fdf4 0%, #ecfdf5 100%);
-  box-shadow: 0 1px 3px rgba(16, 185, 129, 0.1), 0 1px 2px rgba(16, 185, 129, 0.06);
-}
-
-.step-box.step-completed::before {
-  background: linear-gradient(90deg, #10b981 0%, #34d399 100%);
-  opacity: 1;
-}
-
-.step-box.step-completed:hover {
-  border-color: #059669;
-  background: linear-gradient(135deg, #ecfdf5 0%, #d1fae5 100%);
-  transform: translateY(-4px);
-  box-shadow: 0 12px 24px rgba(16, 185, 129, 0.15), 0 6px 12px rgba(16, 185, 129, 0.1);
 }
 
 .plus-icon {
   font-size: 3.5em;
   font-weight: 300;
-  color: #d1d5db;
+  color: var(--bundle-empty-state-text, #d1d5db);
   margin-bottom: 12px;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   line-height: 1;
-}
-
-.step-box:hover .plus-icon {
-  color: #7132FF;
-  transform: rotate(90deg) scale(1.1);
 }
 
 .step-box.step-completed .plus-icon {
@@ -180,12 +136,12 @@
 }
 
 .step-name {
-  font-size: 0.875em;
-  color: #374151;
+  font-size: 14px;
+  color: var(--bundle-empty-state-text, #374151);
   font-weight: 600;
   margin: 0;
   padding: 0 8px;
-  letter-spacing: -0.01em;
+  text-align: center;
   line-height: 1.3;
 }
 
@@ -203,8 +159,7 @@
 }
 
 .step-box.step-completed .step-selection-count {
-  color: #10b981;
-  font-weight: 600;
+  display: none;
 }
 
 /* Step images container */
@@ -256,20 +211,20 @@
 /* Clear badge - top right cross button */
 .step-clear-badge {
   position: absolute;
-  top: 8px;
-  right: 8px;
-  width: 24px;
-  height: 24px;
+  top: 6px;
+  right: 6px;
+  width: 26px;
+  height: 26px;
   background: #EF4444;
   color: white;
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 700;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  z-index: 3;
+  z-index: 100;
   transition: all 0.2s ease;
   box-shadow: 0 2px 6px rgba(239, 68, 68, 0.3);
   line-height: 1;
@@ -893,9 +848,12 @@
   padding: 10px 12px;
   border-radius: 10px;
   border: 1px solid rgba(0, 0, 0, 0.06);
+  display: block;
+  white-space: nowrap;
 }
 
 .modal-body .product-card .product-price-strike {
+  display: inline;
   color: var(--bundle-product-strike-price-color, #9CA3AF);
   font-size: var(--bundle-product-strike-price-font-size, 16px);
   font-weight: var(--bundle-product-strike-price-font-weight, 500);
@@ -904,6 +862,7 @@
 }
 
 .modal-body .product-card .product-price {
+  display: inline;
   color: var(--bundle-product-final-price-color, #000000);
   font-size: var(--bundle-product-final-price-font-size, 20px);
   font-weight: var(--bundle-product-final-price-font-weight, 700);
@@ -1496,7 +1455,7 @@
   padding: 20px 40px;
   border-radius: 11px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
-  z-index: 10000;
+  z-index: 1000001;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
- Fix toast notifications z-index (10000 → 1000001) to display above modal
- Simplify step cards: remove step numbers, hide selection count when products selected
- Reposition clear badge to top-right corner with higher z-index (100)
- Remove all animations from empty state cards to match DCP preview exactly
- Fix product card pricing layout: display prices horizontally instead of vertically
- Ensure all UI elements match DCP modal preview for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)