### PR TITLE
Merge feature/dcp-staging into STAGING

### DIFF
--- a/app/assets/bundle-widget-full.js
+++ b/app/assets/bundle-widget-full.js
@@ -834,52 +834,13 @@ class BundleWidget {
       showTitle: dataset.showTitle !== 'false',
       showStepNumbers: dataset.showStepNumbers !== 'false',
       showFooterMessaging: dataset.showFooterMessaging !== 'false',
-      discountTextTemplate: this.normalizeDiscountTemplate(dataset.discountTextTemplate),
-      successMessageTemplate: this.normalizeSuccessTemplate(dataset.successMessageTemplate),
-      progressTextTemplate: dataset.progressTextTemplate || '{currentQuantity} / {targetQuantity} items',
+      // Messages will be set from bundle.pricing.messages after bundle loads
+      discountTextTemplate: 'Add {conditionText} to get {discountText}',
+      successMessageTemplate: 'Congratulations! You got {discountText}!',
       currentProductId: window.currentProductId,
       currentProductHandle: window.currentProductHandle,
       currentProductCollections: window.currentProductCollections
     };
-  }
-
-  normalizeDiscountTemplate(template) {
-    // Professional template normalization with comprehensive old variable detection
-    const modernTemplate = 'Add {conditionText} to get {discountText}';
-
-    // If no template provided, use modern default
-    if (!template) {
-      return modernTemplate;
-    }
-
-    // Detect old variable patterns and normalize to modern format
-    const oldVariablePatterns = [
-      'discountConditionDiff',
-      'discountUnit',
-      'discountValue',
-      'discountValueUnit'
-    ];
-
-    const hasOldVariables = oldVariablePatterns.some(pattern => template.includes(pattern));
-
-    if (hasOldVariables) {
-      return modernTemplate;
-    }
-
-    // Template is already modern, return as-is
-    return template;
-  }
-
-  normalizeSuccessTemplate(template) {
-    // Use template as-is, or fall back to modern default
-    const modernTemplate = 'Congratulations! You got {discountText}!';
-
-    if (!template || template.trim() === '') {
-      return modernTemplate;
-    }
-
-    // Return the template without modification - let merchants control the message
-    return template;
   }
 
   async loadBundleData() {
@@ -939,6 +900,31 @@ class BundleWidget {
 
   selectBundle() {
     this.selectedBundle = BundleDataManager.selectBundle(this.bundleData, this.config);
+
+    // Update message templates from bundle pricing messages
+    this.updateMessagesFromBundle();
+  }
+
+  updateMessagesFromBundle() {
+    // Use bundle pricing messages if available, otherwise keep defaults
+    if (this.selectedBundle?.pricing?.messages) {
+      const messages = this.selectedBundle.pricing.messages;
+
+      if (messages.progress) {
+        this.config.discountTextTemplate = messages.progress;
+      }
+
+      if (messages.qualified) {
+        this.config.successMessageTemplate = messages.qualified;
+      }
+
+      console.log('[BUNDLE_MESSAGES] Using bundle pricing messages:', {
+        progress: this.config.discountTextTemplate,
+        qualified: this.config.successMessageTemplate
+      });
+    } else {
+      console.log('[BUNDLE_MESSAGES] No pricing messages in bundle, using defaults');
+    }
   }
 
   initializeDataStructures() {
@@ -1237,10 +1223,15 @@ class BundleWidget {
     if (hasSelections) {
       stepBox.classList.add('step-completed');
 
-      // Add cross badge at top right to clear all selections
+      // Add close icon badge at top right to clear all selections
       const clearBadge = document.createElement('div');
       clearBadge.className = 'step-clear-badge';
-      clearBadge.innerHTML = '&times;';
+      clearBadge.innerHTML = `
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <circle cx="12" cy="12" r="12" fill="#f3f4f6"/>
+          <path d="M8 8L16 16M16 8L8 16" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      `;
       clearBadge.title = 'Remove all products from this step';
       clearBadge.addEventListener('click', (e) => {
         e.stopPropagation(); // Prevent opening modal
@@ -1287,17 +1278,20 @@ class BundleWidget {
       stepBox.appendChild(plusIcon);
     }
 
-    // Add step name (without step number)
-    const stepName = document.createElement('p');
-    stepName.className = 'step-name';
-    stepName.textContent = step.name || `Step ${index + 1}`;
-    stepBox.appendChild(stepName);
+    // Only show step name and selection count if no selections made
+    if (!hasSelections) {
+      // Add step name (without step number)
+      const stepName = document.createElement('p');
+      stepName.className = 'step-name';
+      stepName.textContent = step.name || `Step ${index + 1}`;
+      stepBox.appendChild(stepName);
 
-    // Add selection count
-    const selectionCount = document.createElement('div');
-    selectionCount.className = 'step-selection-count';
-    selectionCount.textContent = this.getStepSelectionText(selectedProducts);
-    stepBox.appendChild(selectionCount);
+      // Add selection count
+      const selectionCount = document.createElement('div');
+      selectionCount.className = 'step-selection-count';
+      selectionCount.textContent = this.getStepSelectionText(selectedProducts);
+      stepBox.appendChild(selectionCount);
+    }
 
     // Add click handler
     stepBox.addEventListener('click', () => this.openModal(index));
@@ -1504,6 +1498,12 @@ class BundleWidget {
 
   // Helper method to get formatted header text
   getFormattedHeaderText() {
+    // If discount is not enabled, show step name
+    if (!this.selectedBundle?.pricing?.enabled) {
+      const currentStep = this.selectedBundle?.steps?.[this.currentStepIndex];
+      return currentStep?.name || `Step ${this.currentStepIndex + 1}`;
+    }
+
     const { totalQuantity, totalPrice } = PricingCalculator.calculateBundleTotal(
       this.selectedProducts,
       this.stepProductData
@@ -2146,6 +2146,9 @@ class BundleWidget {
 
     const currencyInfo = CurrencyManager.getCurrencyInfo();
 
+    // Update modal header text dynamically
+    this.updateModalHeaderText(totalPrice, totalQuantity, discountInfo, currencyInfo);
+
     // Update cart badge with total item count
     const cartBadge = this.elements.modal.querySelector('.cart-badge-count');
     if (cartBadge) {
@@ -2157,6 +2160,33 @@ class BundleWidget {
 
     // Update discount messaging and progress bar
     this.updateModalDiscountMessaging(totalPrice, totalQuantity, discountInfo, currencyInfo);
+  }
+
+  updateModalHeaderText(totalPrice, totalQuantity, discountInfo, currencyInfo) {
+    const modalStepTitle = this.elements.modal.querySelector('.modal-step-title');
+    if (!modalStepTitle) return;
+
+    // If discount is not enabled, show step name
+    if (!this.selectedBundle?.pricing?.enabled) {
+      const currentStep = this.selectedBundle?.steps?.[this.currentStepIndex];
+      modalStepTitle.innerHTML = currentStep?.name || `Step ${this.currentStepIndex + 1}`;
+      return;
+    }
+
+    const variables = TemplateManager.createDiscountVariables(
+      this.selectedBundle,
+      totalPrice,
+      totalQuantity,
+      discountInfo,
+      currencyInfo
+    );
+
+    const headerText = TemplateManager.replaceVariables(
+      this.config.discountTextTemplate,
+      variables
+    );
+
+    modalStepTitle.innerHTML = headerText;
   }
 
   updateModalDiscountMessaging(totalPrice, totalQuantity, discountInfo, currencyInfo) {

--- a/app/components/design-control-panel/icons/index.tsx
+++ b/app/components/design-control-panel/icons/index.tsx
@@ -116,3 +116,34 @@ export function PlusIcon({
     </svg>
   );
 }
+
+/**
+ * Close Icon with circular background
+ * Used in: Clear badge on step cards
+ */
+export function CloseIcon({
+  width = 24,
+  height = 24,
+  color = "#000",
+  bgColor = "#f3f4f6",
+  className
+}: IconProps & { bgColor?: string }) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+    >
+      <circle cx="12" cy="12" r="12" fill={bgColor}/>
+      <path
+        d="M8 8L16 16M16 8L8 16"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/app/components/design-control-panel/preview/BundleFooterPreview.tsx
+++ b/app/components/design-control-panel/preview/BundleFooterPreview.tsx
@@ -25,6 +25,10 @@ interface BundleFooterPreviewProps {
   footerDiscountTextVisibility: boolean;
   footerProgressBarFilledColor: string;
   footerProgressBarEmptyColor: string;
+  successMessageFontSize: number;
+  successMessageFontWeight: number;
+  successMessageTextColor: string;
+  successMessageBgColor: string;
 }
 
 export function BundleFooterPreview(props: BundleFooterPreviewProps) {
@@ -52,6 +56,10 @@ export function BundleFooterPreview(props: BundleFooterPreviewProps) {
     footerDiscountTextVisibility,
     footerProgressBarFilledColor,
     footerProgressBarEmptyColor,
+    successMessageFontSize,
+    successMessageFontWeight,
+    successMessageTextColor,
+    successMessageBgColor,
   } = props;
 
   // Bundle Footer - Main footer subsection
@@ -480,6 +488,28 @@ export function BundleFooterPreview(props: BundleFooterPreviewProps) {
                 }}
               >
                 <span style={{ color: "#374151", fontWeight: 600 }}>2</span> / <span style={{ color: "#374151", fontWeight: 600 }}>4</span> items
+              </div>
+            </div>
+
+            {/* Success Message Preview */}
+            <div
+              style={{
+                marginTop: "16px",
+                padding: "12px 16px",
+                backgroundColor: successMessageBgColor,
+                borderRadius: "8px",
+                textAlign: "center",
+                position: "relative",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: `${successMessageFontSize}px`,
+                  fontWeight: successMessageFontWeight,
+                  color: successMessageTextColor,
+                }}
+              >
+                Congratulations! You got 10% off!
               </div>
             </div>
           </div>

--- a/app/routes/api.design-settings.$shopDomain.tsx
+++ b/app/routes/api.design-settings.$shopDomain.tsx
@@ -224,6 +224,10 @@ function generateCSSFromSettings(s: any, bundleType: string): string {
   --bundle-footer-discount-display: ${s.footerDiscountTextVisibility !== false ? 'block' : 'none'};
   --bundle-footer-progress-filled: ${s.footerProgressBarFilledColor || globalPrimaryButton};
   --bundle-footer-progress-empty: ${s.footerProgressBarEmptyColor || '#E3E3E3'};
+  --bundle-success-message-font-size: ${s.successMessageFontSize || 16}px;
+  --bundle-success-message-font-weight: ${s.successMessageFontWeight || 600};
+  --bundle-success-message-text-color: ${s.successMessageTextColor || '#065F46'};
+  --bundle-success-message-bg-color: ${s.successMessageBgColor || '#D1FAE5'};
 
   /* BUNDLE HEADER */
   --bundle-header-tab-active-bg: ${s.headerTabActiveBgColor || globalPrimaryButton};

--- a/app/routes/app.design-control-panel.tsx
+++ b/app/routes/app.design-control-panel.tsx
@@ -129,6 +129,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
       footerDiscountTextVisibility: true,
       footerProgressBarFilledColor: "#000000",
       footerProgressBarEmptyColor: "#E3E3E3",
+      // Success Message Styling
+      successMessageFontSize: 16,
+      successMessageFontWeight: 600,
+      successMessageTextColor: "#065F46",
+      successMessageBgColor: "#D1FAE5",
       // Bundle Step Bar - Step Name
       stepNameFontColor: "#000000",
       stepNameFontSize: 16,
@@ -256,6 +261,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
       footerDiscountTextVisibility: true,
       footerProgressBarFilledColor: "#7132FF",
       footerProgressBarEmptyColor: "#E5E7EB",
+      // Success Message Styling
+      successMessageFontSize: 16,
+      successMessageFontWeight: 600,
+      successMessageTextColor: "#065F46",
+      successMessageBgColor: "#D1FAE5",
       // Bundle Step Bar - Step Name
       stepNameFontColor: "#111827",
       stepNameFontSize: 18,
@@ -629,6 +639,12 @@ export default function DesignControlPanel() {
   const [footerProgressBarFilledColor, setFooterProgressBarFilledColor] = useState(currentSettings.footerProgressBarFilledColor);
   const [footerProgressBarEmptyColor, setFooterProgressBarEmptyColor] = useState(currentSettings.footerProgressBarEmptyColor);
 
+  // Success Message Styling
+  const [successMessageFontSize, setSuccessMessageFontSize] = useState(currentSettings.successMessageFontSize || 16);
+  const [successMessageFontWeight, setSuccessMessageFontWeight] = useState(currentSettings.successMessageFontWeight || 600);
+  const [successMessageTextColor, setSuccessMessageTextColor] = useState(currentSettings.successMessageTextColor || "#065F46");
+  const [successMessageBgColor, setSuccessMessageBgColor] = useState(currentSettings.successMessageBgColor || "#D1FAE5");
+
   // Bundle Header Section
   // Tabs
   const [headerTabActiveBgColor, setHeaderTabActiveBgColor] = useState(currentSettings.headerTabActiveBgColor || "#000000");
@@ -739,6 +755,10 @@ export default function DesignControlPanel() {
     setFooterDiscountTextVisibility(newSettings.footerDiscountTextVisibility);
     setFooterProgressBarFilledColor(newSettings.footerProgressBarFilledColor);
     setFooterProgressBarEmptyColor(newSettings.footerProgressBarEmptyColor);
+    setSuccessMessageFontSize(newSettings.successMessageFontSize);
+    setSuccessMessageFontWeight(newSettings.successMessageFontWeight);
+    setSuccessMessageTextColor(newSettings.successMessageTextColor);
+    setSuccessMessageBgColor(newSettings.successMessageBgColor);
     // Bundle Step Bar
     setStepNameFontColor(newSettings.stepNameFontColor);
     setStepNameFontSize(newSettings.stepNameFontSize);
@@ -825,6 +845,10 @@ export default function DesignControlPanel() {
       footerDiscountTextVisibility !== current.footerDiscountTextVisibility ||
       footerProgressBarFilledColor !== current.footerProgressBarFilledColor ||
       footerProgressBarEmptyColor !== current.footerProgressBarEmptyColor ||
+      successMessageFontSize !== current.successMessageFontSize ||
+      successMessageFontWeight !== current.successMessageFontWeight ||
+      successMessageTextColor !== current.successMessageTextColor ||
+      successMessageBgColor !== current.successMessageBgColor ||
       stepNameFontColor !== current.stepNameFontColor ||
       stepNameFontSize !== current.stepNameFontSize ||
       completedStepCheckMarkColor !== current.completedStepCheckMarkColor ||
@@ -922,6 +946,10 @@ export default function DesignControlPanel() {
     footerDiscountTextVisibility,
     footerProgressBarFilledColor,
     footerProgressBarEmptyColor,
+    successMessageFontSize,
+    successMessageFontWeight,
+    successMessageTextColor,
+    successMessageBgColor,
     headerTabActiveBgColor,
     headerTabActiveTextColor,
     headerTabInactiveBgColor,
@@ -1003,6 +1031,10 @@ export default function DesignControlPanel() {
     setFooterDiscountTextVisibility(savedSettings.footerDiscountTextVisibility);
     setFooterProgressBarFilledColor(savedSettings.footerProgressBarFilledColor);
     setFooterProgressBarEmptyColor(savedSettings.footerProgressBarEmptyColor);
+    setSuccessMessageFontSize(savedSettings.successMessageFontSize || 16);
+    setSuccessMessageFontWeight(savedSettings.successMessageFontWeight || 600);
+    setSuccessMessageTextColor(savedSettings.successMessageTextColor || "#065F46");
+    setSuccessMessageBgColor(savedSettings.successMessageBgColor || "#D1FAE5");
     setStepNameFontColor(savedSettings.stepNameFontColor);
     setStepNameFontSize(savedSettings.stepNameFontSize);
     setCompletedStepCheckMarkColor(savedSettings.completedStepCheckMarkColor);
@@ -1152,6 +1184,10 @@ export default function DesignControlPanel() {
       footerDiscountTextVisibility,
       footerProgressBarFilledColor,
       footerProgressBarEmptyColor,
+      successMessageFontSize,
+      successMessageFontWeight,
+      successMessageTextColor,
+      successMessageBgColor,
       stepNameFontColor,
       stepNameFontSize,
       completedStepCheckMarkColor,
@@ -1249,6 +1285,10 @@ export default function DesignControlPanel() {
     footerDiscountTextVisibility,
     footerProgressBarFilledColor,
     footerProgressBarEmptyColor,
+    successMessageFontSize,
+    successMessageFontWeight,
+    successMessageTextColor,
+    successMessageBgColor,
     headerTabActiveBgColor,
     headerTabActiveTextColor,
     headerTabInactiveBgColor,
@@ -1304,6 +1344,10 @@ export default function DesignControlPanel() {
           footerDiscountTextVisibility={footerDiscountTextVisibility}
           footerProgressBarFilledColor={footerProgressBarFilledColor}
           footerProgressBarEmptyColor={footerProgressBarEmptyColor}
+          successMessageFontSize={successMessageFontSize}
+          successMessageFontWeight={successMessageFontWeight}
+          successMessageTextColor={successMessageTextColor}
+          successMessageBgColor={successMessageBgColor}
         />
       );
     }
@@ -2635,6 +2679,60 @@ export default function DesignControlPanel() {
               label="Progress Bar Empty Color"
               value={footerProgressBarEmptyColor}
               onChange={setFooterProgressBarEmptyColor}
+            />
+
+            <Divider />
+
+            <Text as="p" variant="headingSm" fontWeight="semibold">
+              Success Message Styling
+            </Text>
+
+            <RangeSlider
+              label="Font Size"
+              value={successMessageFontSize}
+              onChange={setSuccessMessageFontSize}
+              min={10}
+              max={24}
+              output
+              suffix={successMessageFontSize ? `${successMessageFontSize}px` : ""}
+            />
+
+            <BlockStack gap="200">
+              <Text as="p" variant="bodySm">
+                Font Weight
+              </Text>
+              <ButtonGroup variant="segmented">
+                <Button
+                  pressed={successMessageFontWeight === 400}
+                  onClick={() => setSuccessMessageFontWeight(400)}
+                >
+                  Normal
+                </Button>
+                <Button
+                  pressed={successMessageFontWeight === 600}
+                  onClick={() => setSuccessMessageFontWeight(600)}
+                >
+                  Semi-Bold
+                </Button>
+                <Button
+                  pressed={successMessageFontWeight === 700}
+                  onClick={() => setSuccessMessageFontWeight(700)}
+                >
+                  Bold
+                </Button>
+              </ButtonGroup>
+            </BlockStack>
+
+            <ColorPicker
+              label="Text Color"
+              value={successMessageTextColor}
+              onChange={setSuccessMessageTextColor}
+            />
+
+            <ColorPicker
+              label="Background Color"
+              value={successMessageBgColor}
+              onChange={setSuccessMessageBgColor}
             />
           </BlockStack>
         );

--- a/extensions/bundle-builder/assets/bundle-widget.css
+++ b/extensions/bundle-builder/assets/bundle-widget.css
@@ -84,7 +84,7 @@
 
 
 .step-box {
-  border: 2px solid #e5e7eb;
+  border: 2.6px var(--bundle-empty-state-border-style, solid) var(--bundle-empty-state-card-border, #e5e7eb);
   border-radius: 12px;
   width: 100%;
   max-width: var(--step-box-size, 150px);
@@ -98,11 +98,22 @@
   text-align: center;
   cursor: pointer;
   position: relative;
-  background: #ffffff;
+  background: var(--bundle-empty-state-card-bg, #ffffff);
   box-sizing: border-box;
   padding: 16px;
   margin: 0;
   overflow: hidden;
+  outline: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.step-box:focus {
+  outline: none;
+}
+
+.step-box:focus-visible {
+  outline: 2px solid var(--bundle-empty-state-card-border, #e5e7eb);
+  outline-offset: 2px;
 }
 
 .step-box.step-completed {
@@ -116,6 +127,9 @@
   color: var(--bundle-empty-state-text, #d1d5db);
   margin-bottom: 12px;
   line-height: 1;
+  transition: none;
+  animation: none;
+  transform: none;
 }
 
 .step-box.step-completed .plus-icon {
@@ -145,10 +159,6 @@
   line-height: 1.3;
 }
 
-.step-box.step-completed .step-name {
-  color: #059669;
-}
-
 .step-selection-count {
   font-size: 0.75em;
   color: #9ca3af;
@@ -156,10 +166,6 @@
   margin-top: 4px;
   letter-spacing: 0.02em;
   text-transform: uppercase;
-}
-
-.step-box.step-completed .step-selection-count {
-  display: none;
 }
 
 /* Step images container */
@@ -171,8 +177,17 @@
   gap: 6px;
   max-width: 100px;
   max-height: 70px;
-  margin-bottom: 12px;
+  margin-bottom: 0;
   overflow: hidden;
+}
+
+/* Center images when they are the only content */
+.step-box.step-completed .step-images {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
 }
 
 .step-image {
@@ -208,32 +223,34 @@
   height: 26px;
 }
 
-/* Clear badge - top right cross button */
+/* Clear badge - top right close icon button */
 .step-clear-badge {
   position: absolute;
   top: 6px;
   right: 6px;
-  width: 26px;
-  height: 26px;
-  background: #EF4444;
-  color: white;
-  font-size: 20px;
-  font-weight: 700;
-  border-radius: 50%;
+  width: 24px;
+  height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   z-index: 100;
   transition: all 0.2s ease;
-  box-shadow: 0 2px 6px rgba(239, 68, 68, 0.3);
   line-height: 1;
 }
 
+.step-clear-badge svg {
+  width: 100%;
+  height: 100%;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
+}
+
 .step-clear-badge:hover {
-  background: #DC2626;
   transform: scale(1.1);
-  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.4);
+}
+
+.step-clear-badge:hover svg circle {
+  fill: #e5e7eb;
 }
 
 .step-clear-badge:active {
@@ -429,7 +446,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 20px 40px 20px;
+  padding: calc(var(--modal-header-padding, 40px) * 0.5) var(--modal-header-padding, 40px) calc(var(--modal-header-padding, 40px) * 0.5);
   border-bottom: 1px solid #E5E7EB;
   margin-bottom: 0;
   position: relative;
@@ -694,7 +711,7 @@
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 32px 40px 32px;
+  padding: calc(var(--modal-body-padding, 40px) * 0.8) var(--modal-body-padding, 40px) calc(var(--modal-body-padding, 40px) * 0.8);
   box-sizing: border-box;
   background-color: #F3F4F6;
   /* Ensure proper scrolling within the modal content */
@@ -761,7 +778,7 @@
   border-radius: 16px;
   padding: 20px;
   width: 100%;
-  min-height: 420px;
+  min-height: var(--modal-product-card-height, 420px);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.03);
   position: relative;
   display: flex;
@@ -798,7 +815,7 @@
 
 .modal-body .product-card .product-image {
   width: 100%;
-  height: 200px;
+  height: var(--modal-product-image-height, 200px);
   background-color: #F8F8F8;
   border-radius: 12px;
   margin-bottom: 16px;
@@ -826,7 +843,7 @@
 
 .modal-body .product-card .product-title {
   color: var(--bundle-product-card-font-color, #111827);
-  font-size: var(--bundle-product-card-font-size, 16px);
+  font-size: calc(var(--bundle-product-card-font-size, 16px) * var(--modal-product-title-size, 100%) / 100);
   font-weight: var(--bundle-product-card-font-weight, 700);
   text-align: center;
   margin-bottom: 10px;
@@ -844,7 +861,7 @@
   text-align: center;
   flex-shrink: 0;
   position: relative;
-  background: linear-gradient(135deg, #F9FAFB 0%, #F3F4F6 100%);
+  background: var(--modal-product-price-bg, linear-gradient(135deg, #F9FAFB 0%, #F3F4F6 100%));
   padding: 10px 12px;
   border-radius: 10px;
   border: 1px solid rgba(0, 0, 0, 0.06);
@@ -855,7 +872,7 @@
 .modal-body .product-card .product-price-strike {
   display: inline;
   color: var(--bundle-product-strike-price-color, #9CA3AF);
-  font-size: var(--bundle-product-strike-price-font-size, 16px);
+  font-size: calc(var(--bundle-product-strike-price-font-size, 16px) * var(--modal-product-price-size, 100%) / 100);
   font-weight: var(--bundle-product-strike-price-font-weight, 500);
   text-decoration: line-through;
   margin-right: 8px;
@@ -863,8 +880,8 @@
 
 .modal-body .product-card .product-price {
   display: inline;
-  color: var(--bundle-product-final-price-color, #000000);
-  font-size: var(--bundle-product-final-price-font-size, 20px);
+  color: var(--modal-product-price-color, var(--bundle-product-final-price-color, #000000));
+  font-size: calc(var(--bundle-product-final-price-font-size, 20px) * var(--modal-product-price-size, 100%) / 100);
   font-weight: var(--bundle-product-final-price-font-weight, 700);
   letter-spacing: 0.3px;
 }
@@ -1255,8 +1272,9 @@
 }
 
 .modal-footer-discount-messaging.qualified .footer-discount-text {
-  color: #059669;
-  font-weight: 600;
+  color: var(--bundle-success-message-text-color, #059669);
+  font-weight: var(--bundle-success-message-font-weight, 600);
+  font-size: var(--bundle-success-message-font-size, 16px);
 }
 
 /* Modal Footer Progress Bar */
@@ -1377,19 +1395,7 @@
   overflow: hidden;
 }
 
-/* Added product price - Uses DCP variables */
-.product-price {
-  font-size: var(--bundle-product-final-price-font-size, 0.85em);
-  font-weight: var(--bundle-product-final-price-font-weight, 700);
-  margin-bottom: 8px;
-  color: var(--bundle-product-final-price-color, #2c5530);
-  text-align: center;
-  background: var(--modal-product-price-bg, #f0f8f0);
-  padding: 4px 8px;
-  border-radius: 4px;
-  border: 1px solid #e0f0e0;
-  display: var(--bundle-product-price-display, block);
-}
+/* Removed conflicting .product-price - proper styling is in .modal-body .product-card .product-price */
 
 /* ===== GENERAL SECTION STYLES ===== */
 
@@ -1632,14 +1638,15 @@
 }
 
 .bundle-footer-messaging.qualified {
-  background: linear-gradient(135deg, #ecfdf5 0%, #d1fae5 100%);
+  background: var(--bundle-success-message-bg-color, linear-gradient(135deg, #ecfdf5 0%, #d1fae5 100%));
   border-color: #10b981;
   box-shadow: 0 4px 12px rgba(16, 185, 129, 0.15);
 }
 
 .bundle-footer-messaging.qualified .footer-discount-text {
-  color: #065f46;
-  font-size: 16px;
+  color: var(--bundle-success-message-text-color, #065f46);
+  font-size: var(--bundle-success-message-font-size, 16px);
+  font-weight: var(--bundle-success-message-font-weight, 600);
 }
 
 .footer-progress-container {
@@ -1735,7 +1742,7 @@
 
 /* Progress bar completion effects */
 .progress-fill.completed {
-  background: linear-gradient(90deg, var(--progress-bar-color, #28a745) 0%, #20c997 100%);
+  background: linear-gradient(90deg, var(--bundle-footer-progress-filled, #000000) 0%, var(--bundle-footer-progress-filled, #000000) 100%);
   animation: progressComplete 0.6s ease-out;
 }
 
@@ -1803,11 +1810,11 @@
 /* Mobile-specific optimizations */
 @media (max-width: 480px) {
   .modal-body {
-    padding: 0 15px 15px;
+    padding: 0 calc(var(--modal-body-padding, 40px) * 0.375) calc(var(--modal-body-padding, 40px) * 0.375);
   }
-  
+
   .modal-header {
-    padding: 15px 20px 5px;
+    padding: calc(var(--modal-header-padding, 40px) * 0.375) calc(var(--modal-header-padding, 40px) * 0.5) calc(var(--modal-header-padding, 40px) * 0.125);
   }
   
   .modal-footer {
@@ -1845,12 +1852,14 @@
 }
 
 .bundle-footer-messaging.qualified {
-  border-color: var(--progress-bar-color, #28a745);
-  background: linear-gradient(135deg, #d4edda 0%, #e8f5e8 100%);
+  border-color: var(--savings-badge-color, #28a745);
+  background: var(--bundle-success-message-bg-color, linear-gradient(135deg, #d4edda 0%, #e8f5e8 100%));
 }
 
 .bundle-footer-messaging.qualified .footer-discount-text {
-  color: #155724;
+  color: var(--bundle-success-message-text-color, #155724);
+  font-size: var(--bundle-success-message-font-size, 16px);
+  font-weight: var(--bundle-success-message-font-weight, 600);
 }
 
 /* Animated encouragement messages */

--- a/extensions/bundle-builder/blocks/bundle.liquid
+++ b/extensions/bundle-builder/blocks/bundle.liquid
@@ -102,39 +102,7 @@
     },
     {
       "type": "header",
-      "content": "Discount messaging"
-    },
-    {
-      "type": "textarea",
-      "id": "discount_text_template",
-      "label": "Progress encouragement message",
-      "default": "Add {conditionText} to get {discountText}",
-      "info": "Text shown to encourage customers to complete their bundle. Available variables: {conditionText}, {discountText}, {amountNeeded}, {itemsNeeded}, {progressPercentage}, {bundleName}"
-    },
-    {
-      "type": "textarea",
-      "id": "success_message_template",
-      "label": "Bundle completion message",
-      "default": "Congratulations! You got {discountText}!",
-      "info": "Celebratory message displayed when the customer has qualified for the bundle discount. Available variables: {discountText}, {bundleName}, {amountSaved}, {progressPercentage}"
-    },
-    {
-      "type": "text",
-      "id": "progress_text_template",
-      "label": "Progress counter format",
-      "default": "{selectedQuantity} / {targetQuantity} items",
-      "info": "Format for the progress counter display. Available variables: {selectedQuantity}, {targetQuantity}"
-    },
-    {
-      "type": "header",
       "content": "Progress bar styling"
-    },
-    {
-      "type": "color",
-      "id": "progress_bar_color",
-      "label": "Progress bar fill color",
-      "info": "Primary color for the progress bar fill gradient",
-      "default": "#7132FF"
     },
     {
       "type": "color",
@@ -167,6 +135,65 @@
     },
     {
       "type": "header",
+      "content": "Spacing & layout"
+    },
+    {
+      "type": "range",
+      "id": "container_spacing",
+      "min": 0,
+      "max": 50,
+      "step": 5,
+      "unit": "px",
+      "label": "Container spacing",
+      "default": 20,
+      "info": "Margin and padding around the entire widget container"
+    },
+    {
+      "type": "range",
+      "id": "element_spacing",
+      "min": 0,
+      "max": 30,
+      "step": 5,
+      "unit": "px",
+      "label": "Element spacing",
+      "default": 15,
+      "info": "Space between major sections (header, steps, footer)"
+    },
+    {
+      "type": "range",
+      "id": "step_card_gap",
+      "min": 0,
+      "max": 30,
+      "step": 5,
+      "unit": "px",
+      "label": "Step card gap",
+      "default": 15,
+      "info": "Gap between product step cards in the grid"
+    },
+    {
+      "type": "range",
+      "id": "modal_header_padding",
+      "min": 10,
+      "max": 60,
+      "step": 5,
+      "unit": "px",
+      "label": "Modal header padding",
+      "default": 40,
+      "info": "Internal padding for modal header section"
+    },
+    {
+      "type": "range",
+      "id": "modal_body_padding",
+      "min": 10,
+      "max": 60,
+      "step": 5,
+      "unit": "px",
+      "label": "Modal body padding",
+      "default": 40,
+      "info": "Internal padding for modal content area"
+    },
+    {
+      "type": "header",
       "content": "Step navigation styling"
     },
     {
@@ -179,20 +206,6 @@
       "label": "Step tab border radius",
       "default": 10,
       "info": "Rounded corners for step navigation tabs"
-    },
-    {
-      "type": "color",
-      "id": "step_tab_active_color",
-      "label": "Active step background",
-      "info": "Background color for the currently active step",
-      "default": "#111827"
-    },
-    {
-      "type": "color",
-      "id": "step_tab_completed_color",
-      "label": "Completed step color",
-      "info": "Color for completed step indicators",
-      "default": "#10b981"
     },
     {
       "type": "header",
@@ -219,13 +232,6 @@
       "label": "Modal product image height",
       "default": 70,
       "info": "Height of product images in the modal"
-    },
-    {
-      "type": "color",
-      "id": "modal_step_title_color",
-      "label": "Modal step title color",
-      "info": "Color for step titles in the modal",
-      "default": "#2c5530"
     },
     {
       "type": "color",
@@ -335,41 +341,28 @@
       data-show-title="{{ block.settings.show_bundle_title }}"
       data-show-step-numbers="{{ block.settings.show_step_numbers }}"
       data-show-footer-messaging="{{ block.settings.show_footer_messaging }}"
-      data-discount-text-template="{{ block.settings.discount_text_template | escape }}"
-      data-success-message-template="{{ block.settings.success_message_template | escape }}"
-      data-progress-text-template="{{ block.settings.progress_text_template | escape }}"
       style="
         --step-box-size: {{ block.settings.step_box_size }}px;
         --button-height: {{ block.settings.button_height }}px;
         --widget-max-width: {{ block.settings.widget_max_width }}px;
         --step-cards-per-row: {{ block.settings.step_cards_per_row }};
-        --container-spacing: 20px;
-        --element-spacing: 15px;
-        --step-card-spacing: 15px;
+        --container-spacing: {{ block.settings.container_spacing | default: 20 }}px;
+        --element-spacing: {{ block.settings.element_spacing | default: 15 }}px;
+        --step-card-spacing: {{ block.settings.step_card_gap | default: 15 }}px;
+        --modal-header-padding: {{ block.settings.modal_header_padding | default: 40 }}px;
+        --modal-body-padding: {{ block.settings.modal_body_padding | default: 40 }}px;
         --button-spacing: 25px;
         --modal-footer-bg-color: #ffffff;
         --modal-footer-text-color: #2d3748;
-        --modal-footer-accent-color: {{ block.settings.progress_bar_color }};
         --modal-footer-success-color: {{ block.settings.success_color }};
         --footer-bg-color: #f8f9fa;
         --footer-text-color: {{ block.settings.success_color }};
-        --progress-bar-color: {{ block.settings.progress_bar_color }};
         --progress-bar-height: {{ block.settings.progress_bar_height | default: 12 }}px;
         --progress-bar-border-radius: {{ block.settings.progress_bar_border_radius | default: 999 }}px;
         --savings-badge-color: {{ block.settings.success_color }};
         --modal-tab-border-radius: {{ block.settings.step_tab_border_radius }}px;
-        --modal-tab-active-bg-start: {{ block.settings.step_tab_active_color }};
-        --modal-tab-active-bg-end: {{ block.settings.step_tab_active_color }};
-        --modal-tab-active-border-color: {{ block.settings.step_tab_active_color }};
-        --modal-tab-completed-border-color: {{ block.settings.step_tab_completed_color }};
-        --modal-tab-completed-number-bg: {{ block.settings.step_tab_completed_color }};
-        --modal-tab-checkmark-bg: {{ block.settings.step_tab_completed_color }};
-        --modal-tab-completed-progress-fill-start: {{ block.settings.step_tab_completed_color }};
-        --modal-tab-progress-fill-start: {{ block.settings.progress_bar_color }};
-        --modal-tab-progress-fill-end: {{ block.settings.progress_bar_color }};
         --modal-product-card-height: {{ block.settings.modal_product_card_height }}px;
         --modal-product-image-height: {{ block.settings.modal_product_image_height }}px;
-        --modal-step-title-color: {{ block.settings.modal_step_title_color }};
         --modal-product-price-color: {{ block.settings.modal_product_price_color }};
         --modal-product-price-bg: {{ block.settings.modal_product_price_bg }};
         --modal-product-title-size: {{ block.settings.modal_product_title_size }}%;


### PR DESCRIPTION
Theme Editor Changes:
- Remove duplicate color settings already controlled by DCP (progress bar, step tabs, modal title colors)
- Add spacing/padding controls: container spacing, element spacing, step card gap, modal header/body padding
- Migrate discount message templates from theme editor to admin bundle configuration for centralized control

DCP Enhancements:
- Add success message styling options (font size, weight, color, background)
- Add success message preview in DCP modal
- Generate CSS variables for success message customization

Widget Updates:
- Use bundle.pricing.messages from admin instead of theme editor templates
- Update modal header text dynamically as products are added
- Apply spacing variables with responsive mobile adjustments
- Connect theme editor settings to CSS variables for modal product cards

Settings now within Shopify limits (23/25 interactive, 6/6 headers)