### PR TITLE
Fix full-page bundle widget UI issues and redesign promo banner

### DIFF
--- a/app/assets/bundle-widget-full-page.js
+++ b/app/assets/bundle-widget-full-page.js
@@ -674,6 +674,13 @@ class BundleWidgetFullPage {
   }
 
   renderHeader() {
+    // For full-page bundles, always hide the main header (promo banner handles the display)
+    const bundleType = this.selectedBundle?.bundleType || BUNDLE_WIDGET.BUNDLE_TYPES.PRODUCT_PAGE;
+    if (bundleType === BUNDLE_WIDGET.BUNDLE_TYPES.FULL_PAGE) {
+      this.elements.header.style.display = 'none';
+      return;
+    }
+
     if (!this.config.showTitle) {
       this.elements.header.style.display = 'none';
       return;
@@ -894,10 +901,10 @@ class BundleWidgetFullPage {
     return productImages;
   }
 
-  // Create bundle instructions header
+  // Create bundle instructions header (only shows step instruction, not bundle title)
   createBundleInstructions() {
     const header = document.createElement('div');
-    header.className = 'bundle-header';
+    header.className = 'bundle-header bundle-step-instruction';
 
     if (!this.selectedBundle || !this.selectedBundle.steps || !this.selectedBundle.steps[this.currentStepIndex]) {
       console.error('[WIDGET_RENDER] Cannot create instructions: selectedBundle or current step is undefined');
@@ -907,81 +914,74 @@ class BundleWidgetFullPage {
     const currentStep = this.selectedBundle.steps[this.currentStepIndex];
 
     // Use custom instruction if provided, otherwise use step instruction or auto-generated text
-    const defaultInstruction = currentStep.instruction || `Select ${currentStep.minQuantity} or more items from ${currentStep.name}`;
+    const defaultInstruction = currentStep.instruction || `Select ${currentStep.minQuantity || 1} or more items from ${currentStep.name}`;
     const instructionText = this.config.customInstruction || defaultInstruction;
 
-    // Use custom title if provided, otherwise use bundle name
-    const title = this.config.customTitle || this.selectedBundle.name;
-
-    // Only show bundle title if showTitle is enabled
-    const bundleTitleHTML = this.config.showTitle
-      ? `<h3 class="bundle-title">${title}</h3>`
-      : '';
-
+    // Only show instruction text (title is shown in promo banner)
     header.innerHTML = `
-      ${bundleTitleHTML}
       <p class="bundle-instruction">${instructionText}</p>
     `;
 
     return header;
   }
 
-  // Create promotional banner (Competitor-Inspired)
+  // Create promotional banner (Competitor-Inspired with gradient hero style)
   createPromoBanner() {
-    // Check if bundle has promotion/discount configuration
-    if (!this.selectedBundle?.pricing?.enabled) {
-      return null;
-    }
-
-    const pricing = this.selectedBundle.pricing;
-    const rules = pricing.rules || [];
+    const pricing = this.selectedBundle?.pricing;
+    const rules = pricing?.rules || [];
+    const currencyInfo = CurrencyManager.getCurrencyInfo();
 
     // Get the best discount message
     let promoTitle = '';
     let promoSubtitle = 'Build Your Own Bundle';
     let promoNote = '(Mix & Match)';
 
-    if (rules.length > 0) {
-      // Find the best discount to highlight
+    if (pricing?.enabled && rules.length > 0) {
+      // Find the best discount to highlight (use nested structure)
       const bestRule = rules.reduce((best, rule) => {
-        const discountValue = rule.discountType === 'percentage'
-          ? rule.discountValue
-          : (rule.discountValue / 100); // Approximate comparison
-        const bestValue = best.discountType === 'percentage'
-          ? best.discountValue
-          : (best.discountValue / 100);
+        const discountValue = rule.discount?.method === 'percentage'
+          ? rule.discount?.value || 0
+          : ((rule.discount?.value || 0) / 100);
+        const bestValue = best.discount?.method === 'percentage'
+          ? best.discount?.value || 0
+          : ((best.discount?.value || 0) / 100);
         return discountValue > bestValue ? rule : best;
       }, rules[0]);
 
-      // Build promo title based on best rule
-      if (bestRule.discountType === 'percentage') {
-        promoTitle = `Add ${bestRule.minQuantity} products to your basket, get ${bestRule.discountValue}% off!`;
-      } else if (bestRule.discountType === 'fixed_amount') {
-        const currencyInfo = CurrencyManager.getCurrencyInfo();
-        const formattedAmount = CurrencyManager.formatMoney(bestRule.discountValue * 100, currencyInfo.display.format);
-        promoTitle = `Add ${bestRule.minQuantity} products to your basket, save ${formattedAmount}!`;
-      } else if (bestRule.discountType === 'fixed_price') {
-        const currencyInfo = CurrencyManager.getCurrencyInfo();
-        const formattedPrice = CurrencyManager.formatMoney(bestRule.discountValue * 100, currencyInfo.display.format);
-        promoTitle = `Add ${bestRule.minQuantity} products for just ${formattedPrice}!`;
+      // Build promo title based on best rule (using nested structure)
+      const targetQty = bestRule.condition?.value || bestRule.minQuantity || 0;
+      const discountMethod = bestRule.discount?.method || bestRule.discountType;
+      const discountValue = bestRule.discount?.value || bestRule.discountValue || 0;
+
+      if (discountMethod === 'percentage') {
+        promoTitle = `Add any ${targetQty} products to your basket, get ${discountValue}% off!`;
+      } else if (discountMethod === 'fixed_amount') {
+        const formattedAmount = CurrencyManager.formatMoney(discountValue * 100, currencyInfo.display.format);
+        promoTitle = `Add any ${targetQty} products to your basket, save ${formattedAmount}!`;
+      } else if (discountMethod === 'fixed_price') {
+        const formattedPrice = CurrencyManager.formatMoney(discountValue * 100, currencyInfo.display.format);
+        promoTitle = `Add any ${targetQty} products for just ${formattedPrice}!`;
       }
     }
 
     // Use custom messages if configured
-    if (pricing.messages?.banner) {
+    if (pricing?.messages?.banner) {
       promoTitle = pricing.messages.banner;
     }
 
+    // If no discount promo, show bundle name as hero banner
     if (!promoTitle) {
-      return null; // No promo to show
+      promoTitle = this.selectedBundle?.name || 'Build Your Bundle';
+      promoSubtitle = '';
+      promoNote = '';
     }
 
     const banner = document.createElement('div');
     banner.className = 'promo-banner';
     banner.innerHTML = `
-      <div class="promo-banner-subtitle">${promoSubtitle}</div>
+      ${promoSubtitle ? `<div class="promo-banner-subtitle">${promoSubtitle}</div>` : ''}
       <h2 class="promo-banner-title">${promoTitle}</h2>
-      <div class="promo-banner-note">${promoNote}</div>
+      ${promoNote ? `<div class="promo-banner-note">${promoNote}</div>` : ''}
     `;
 
     return banner;
@@ -1345,7 +1345,26 @@ class BundleWidgetFullPage {
           variables
         );
       } else if (nextRule) {
-        discountMessage = `Add ${nextRule.remaining} more product(s) to get ${nextRule.discountText}!`;
+        // Calculate remaining items needed from nested rule structure
+        const targetQuantity = nextRule.condition?.value || 0;
+        const remaining = Math.max(0, targetQuantity - totalQuantity);
+
+        // Build discount text from nested discount structure
+        let discountText = '';
+        const discountMethod = nextRule.discount?.method;
+        const discountValue = nextRule.discount?.value || 0;
+
+        if (discountMethod === 'percentage') {
+          discountText = `${discountValue}% off`;
+        } else if (discountMethod === 'fixed_amount') {
+          discountText = CurrencyManager.formatMoney(discountValue * 100, currencyInfo.display.format) + ' off';
+        } else if (discountMethod === 'fixed_price') {
+          discountText = 'a special price of ' + CurrencyManager.formatMoney(discountValue * 100, currencyInfo.display.format);
+        } else {
+          discountText = 'a discount';
+        }
+
+        discountMessage = `Add ${remaining} more product(s) to get ${discountText}!`;
       }
     }
 

--- a/docs/issues-prod/fix-html-meta-tags-1.md
+++ b/docs/issues-prod/fix-html-meta-tags-1.md
@@ -1,0 +1,55 @@
+# Issue: Fix Full-Page Bundle Widget UI Issues
+
+**Issue ID:** fix-html-meta-tags-1
+**Status:** Completed
+**Priority:** High
+**Created:** 2026-01-23
+**Last Updated:** 2026-01-23 14:30
+
+## Overview
+Multiple UI issues in the full-page bundle widget need to be fixed:
+1. Undefined values showing in discount message ("Add undefined more product(s) to get undefined!")
+2. Duplicate bundle title headers showing in blue boxes
+3. Promo banner needs to match competitor design (gradient image-style)
+4. Footer styling is scattered and unprofessional
+5. Default product card padding should be 0 instead of 12
+
+## Progress Log
+
+### 2026-01-23 - Starting UI Fixes
+- Analyzing codebase to identify issues
+- Files to modify:
+  - `app/assets/bundle-widget-full-page.js` - Fix discount message, remove duplicate headers
+  - `extensions/bundle-builder/assets/bundle-widget-full-page.css` - Fix footer styling, promo banner, card padding
+- Root cause of undefined: `getNextDiscountRule` returns nested structure but code accesses non-existent properties
+
+### 2026-01-23 14:30 - Completed All Fixes
+- Fixed undefined discount message by properly extracting values from nested rule structure
+- Removed duplicate bundle headers for full-page bundles (now only shows promo banner + step instruction)
+- Redesigned promo banner with gradient hero style (blue/teal gradient with pattern overlay)
+- Fixed footer styling to be centered and professional:
+  - Light background (#E8F4F8)
+  - Centered layout with max-width
+  - Rounded pill-style buttons
+  - Compact product thumbnails
+  - Orange accent colors for total price
+- Changed default product card padding to 0 (with CSS variable support)
+- Built widget bundles successfully
+
+Files modified:
+- `app/assets/bundle-widget-full-page.js` (lines 676-692, 898-920, 929-988, 1347-1365)
+- `extensions/bundle-builder/assets/bundle-widget-full-page.css` (promo banner, footer, product card sections)
+- `extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js` (rebuilt)
+
+## Related Documentation
+- Full-page widget CSS: `extensions/bundle-builder/assets/bundle-widget-full-page.css`
+- Full-page widget JS: `app/assets/bundle-widget-full-page.js`
+- Shared components: `app/assets/bundle-widget-components.js`
+
+## Phases Checklist
+- [x] Phase 1: Fix undefined discount message
+- [x] Phase 2: Remove duplicate bundle titles
+- [x] Phase 3: Redesign promo banner
+- [x] Phase 4: Fix footer styling
+- [x] Phase 5: Fix product card padding
+- [x] Phase 6: Build and test

--- a/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
@@ -2254,6 +2254,13 @@ class BundleWidgetFullPage {
   }
 
   renderHeader() {
+    // For full-page bundles, always hide the main header (promo banner handles the display)
+    const bundleType = this.selectedBundle?.bundleType || BUNDLE_WIDGET.BUNDLE_TYPES.PRODUCT_PAGE;
+    if (bundleType === BUNDLE_WIDGET.BUNDLE_TYPES.FULL_PAGE) {
+      this.elements.header.style.display = 'none';
+      return;
+    }
+
     if (!this.config.showTitle) {
       this.elements.header.style.display = 'none';
       return;
@@ -2474,10 +2481,10 @@ class BundleWidgetFullPage {
     return productImages;
   }
 
-  // Create bundle instructions header
+  // Create bundle instructions header (only shows step instruction, not bundle title)
   createBundleInstructions() {
     const header = document.createElement('div');
-    header.className = 'bundle-header';
+    header.className = 'bundle-header bundle-step-instruction';
 
     if (!this.selectedBundle || !this.selectedBundle.steps || !this.selectedBundle.steps[this.currentStepIndex]) {
       console.error('[WIDGET_RENDER] Cannot create instructions: selectedBundle or current step is undefined');
@@ -2487,81 +2494,74 @@ class BundleWidgetFullPage {
     const currentStep = this.selectedBundle.steps[this.currentStepIndex];
 
     // Use custom instruction if provided, otherwise use step instruction or auto-generated text
-    const defaultInstruction = currentStep.instruction || `Select ${currentStep.minQuantity} or more items from ${currentStep.name}`;
+    const defaultInstruction = currentStep.instruction || `Select ${currentStep.minQuantity || 1} or more items from ${currentStep.name}`;
     const instructionText = this.config.customInstruction || defaultInstruction;
 
-    // Use custom title if provided, otherwise use bundle name
-    const title = this.config.customTitle || this.selectedBundle.name;
-
-    // Only show bundle title if showTitle is enabled
-    const bundleTitleHTML = this.config.showTitle
-      ? `<h3 class="bundle-title">${title}</h3>`
-      : '';
-
+    // Only show instruction text (title is shown in promo banner)
     header.innerHTML = `
-      ${bundleTitleHTML}
       <p class="bundle-instruction">${instructionText}</p>
     `;
 
     return header;
   }
 
-  // Create promotional banner (Competitor-Inspired)
+  // Create promotional banner (Competitor-Inspired with gradient hero style)
   createPromoBanner() {
-    // Check if bundle has promotion/discount configuration
-    if (!this.selectedBundle?.pricing?.enabled) {
-      return null;
-    }
-
-    const pricing = this.selectedBundle.pricing;
-    const rules = pricing.rules || [];
+    const pricing = this.selectedBundle?.pricing;
+    const rules = pricing?.rules || [];
+    const currencyInfo = CurrencyManager.getCurrencyInfo();
 
     // Get the best discount message
     let promoTitle = '';
     let promoSubtitle = 'Build Your Own Bundle';
     let promoNote = '(Mix & Match)';
 
-    if (rules.length > 0) {
-      // Find the best discount to highlight
+    if (pricing?.enabled && rules.length > 0) {
+      // Find the best discount to highlight (use nested structure)
       const bestRule = rules.reduce((best, rule) => {
-        const discountValue = rule.discountType === 'percentage'
-          ? rule.discountValue
-          : (rule.discountValue / 100); // Approximate comparison
-        const bestValue = best.discountType === 'percentage'
-          ? best.discountValue
-          : (best.discountValue / 100);
+        const discountValue = rule.discount?.method === 'percentage'
+          ? rule.discount?.value || 0
+          : ((rule.discount?.value || 0) / 100);
+        const bestValue = best.discount?.method === 'percentage'
+          ? best.discount?.value || 0
+          : ((best.discount?.value || 0) / 100);
         return discountValue > bestValue ? rule : best;
       }, rules[0]);
 
-      // Build promo title based on best rule
-      if (bestRule.discountType === 'percentage') {
-        promoTitle = `Add ${bestRule.minQuantity} products to your basket, get ${bestRule.discountValue}% off!`;
-      } else if (bestRule.discountType === 'fixed_amount') {
-        const currencyInfo = CurrencyManager.getCurrencyInfo();
-        const formattedAmount = CurrencyManager.formatMoney(bestRule.discountValue * 100, currencyInfo.display.format);
-        promoTitle = `Add ${bestRule.minQuantity} products to your basket, save ${formattedAmount}!`;
-      } else if (bestRule.discountType === 'fixed_price') {
-        const currencyInfo = CurrencyManager.getCurrencyInfo();
-        const formattedPrice = CurrencyManager.formatMoney(bestRule.discountValue * 100, currencyInfo.display.format);
-        promoTitle = `Add ${bestRule.minQuantity} products for just ${formattedPrice}!`;
+      // Build promo title based on best rule (using nested structure)
+      const targetQty = bestRule.condition?.value || bestRule.minQuantity || 0;
+      const discountMethod = bestRule.discount?.method || bestRule.discountType;
+      const discountValue = bestRule.discount?.value || bestRule.discountValue || 0;
+
+      if (discountMethod === 'percentage') {
+        promoTitle = `Add any ${targetQty} products to your basket, get ${discountValue}% off!`;
+      } else if (discountMethod === 'fixed_amount') {
+        const formattedAmount = CurrencyManager.formatMoney(discountValue * 100, currencyInfo.display.format);
+        promoTitle = `Add any ${targetQty} products to your basket, save ${formattedAmount}!`;
+      } else if (discountMethod === 'fixed_price') {
+        const formattedPrice = CurrencyManager.formatMoney(discountValue * 100, currencyInfo.display.format);
+        promoTitle = `Add any ${targetQty} products for just ${formattedPrice}!`;
       }
     }
 
     // Use custom messages if configured
-    if (pricing.messages?.banner) {
+    if (pricing?.messages?.banner) {
       promoTitle = pricing.messages.banner;
     }
 
+    // If no discount promo, show bundle name as hero banner
     if (!promoTitle) {
-      return null; // No promo to show
+      promoTitle = this.selectedBundle?.name || 'Build Your Bundle';
+      promoSubtitle = '';
+      promoNote = '';
     }
 
     const banner = document.createElement('div');
     banner.className = 'promo-banner';
     banner.innerHTML = `
-      <div class="promo-banner-subtitle">${promoSubtitle}</div>
+      ${promoSubtitle ? `<div class="promo-banner-subtitle">${promoSubtitle}</div>` : ''}
       <h2 class="promo-banner-title">${promoTitle}</h2>
-      <div class="promo-banner-note">${promoNote}</div>
+      ${promoNote ? `<div class="promo-banner-note">${promoNote}</div>` : ''}
     `;
 
     return banner;
@@ -2925,7 +2925,26 @@ class BundleWidgetFullPage {
           variables
         );
       } else if (nextRule) {
-        discountMessage = `Add ${nextRule.remaining} more product(s) to get ${nextRule.discountText}!`;
+        // Calculate remaining items needed from nested rule structure
+        const targetQuantity = nextRule.condition?.value || 0;
+        const remaining = Math.max(0, targetQuantity - totalQuantity);
+
+        // Build discount text from nested discount structure
+        let discountText = '';
+        const discountMethod = nextRule.discount?.method;
+        const discountValue = nextRule.discount?.value || 0;
+
+        if (discountMethod === 'percentage') {
+          discountText = `${discountValue}% off`;
+        } else if (discountMethod === 'fixed_amount') {
+          discountText = CurrencyManager.formatMoney(discountValue * 100, currencyInfo.display.format) + ' off';
+        } else if (discountMethod === 'fixed_price') {
+          discountText = 'a special price of ' + CurrencyManager.formatMoney(discountValue * 100, currencyInfo.display.format);
+        } else {
+          discountText = 'a discount';
+        }
+
+        discountMessage = `Add ${remaining} more product(s) to get ${discountText}!`;
       }
     }
 

--- a/extensions/bundle-builder/assets/bundle-widget-full-page.css
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page.css
@@ -370,43 +370,75 @@
 }
 
 /* ============================================================================
-   PROMOTIONAL BANNER (Competitor-Inspired)
+   PROMOTIONAL BANNER (Competitor-Inspired Hero Style)
    ============================================================================ */
 
 .promo-banner {
   width: 100%;
-  padding: 24px 40px;
-  margin-bottom: 20px;
-  background: var(--bundle-promo-banner-bg, linear-gradient(135deg, #E8D5F2 0%, #C5E8F0 100%));
+  padding: 32px 48px;
+  margin-bottom: 24px;
+  background: var(--bundle-promo-banner-bg, linear-gradient(135deg, #3498db 0%, #2980b9 50%, #1abc9c 100%));
   text-align: center;
-  border-radius: var(--bundle-promo-banner-radius, 12px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  border-radius: var(--bundle-promo-banner-radius, 16px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Subtle pattern overlay for depth */
+.promo-banner::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  pointer-events: none;
 }
 
 .promo-banner-subtitle {
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--bundle-promo-banner-subtitle-color, #666666);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--bundle-promo-banner-subtitle-color, rgba(255, 255, 255, 0.9));
   text-transform: uppercase;
-  letter-spacing: 1px;
-  margin-bottom: 8px;
+  letter-spacing: 2px;
+  margin-bottom: 12px;
   font-family: inherit;
+  position: relative;
+  z-index: 1;
 }
 
 .promo-banner-title {
-  font-size: var(--bundle-promo-banner-title-size, 28px);
+  font-size: var(--bundle-promo-banner-title-size, 32px);
   font-weight: 800;
-  color: var(--bundle-promo-banner-title-color, #1E1E1E);
-  margin: 0 0 8px;
+  color: var(--bundle-promo-banner-title-color, #FFFFFF);
+  margin: 0 0 12px;
   font-family: inherit;
-  line-height: 1.2;
+  line-height: 1.3;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  position: relative;
+  z-index: 1;
 }
 
 .promo-banner-note {
-  font-size: 13px;
-  color: var(--bundle-promo-banner-note-color, #666666);
+  font-size: 14px;
+  color: var(--bundle-promo-banner-note-color, rgba(255, 255, 255, 0.85));
   font-style: italic;
   font-family: inherit;
+  position: relative;
+  z-index: 1;
+}
+
+/* Responsive promo banner */
+@media (max-width: 768px) {
+  .promo-banner {
+    padding: 24px 20px;
+  }
+
+  .promo-banner-title {
+    font-size: 24px;
+  }
 }
 
 /* ============================================================================
@@ -497,19 +529,19 @@
   min-height: var(--bundle-product-card-height, 420px);
   max-height: var(--bundle-product-card-height, 420px);
 
-  background: var(--bundle-product-card-bg, #FFFFFF); /* Changed to white for cleaner look */
-  border-radius: var(--bundle-product-card-border-radius, 8px); /* Added border radius */
-  padding: 12px; /* Increased padding for better spacing */
+  background: var(--bundle-product-card-bg, #FFFFFF);
+  border-radius: var(--bundle-product-card-border-radius, 8px);
+  padding: var(--bundle-product-card-padding, 0); /* Default padding is 0 */
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
   box-sizing: border-box;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  border: 1px solid rgba(0, 0, 0, 0.08); /* Subtle border */
+  border: 1px solid rgba(0, 0, 0, 0.08);
   position: relative;
-  overflow: hidden; /* Prevent content overflow */
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04); /* Subtle base shadow */
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
 }
 
 .product-card:hover {
@@ -570,6 +602,9 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  width: 100%;
+  padding: 8px 12px 12px;
+  box-sizing: border-box;
 }
 
 /* Product Title */
@@ -1117,70 +1152,74 @@
 }
 
 /* ============================================================================
-   REDESIGNED FOOTER (Competitor-Inspired)
+   REDESIGNED FOOTER (Competitor-Inspired - Professional Centered Layout)
    ============================================================================ */
 
 .full-page-footer.redesigned {
   display: block !important;
   padding: 0;
-  background: var(--bundle-full-page-footer-bg-color, #FFFFFF);
-  border-top: 1px solid var(--bundle-full-page-footer-border-color, rgba(0, 0, 0, 0.1));
+  background: var(--bundle-full-page-footer-bg-color, #E8F4F8);
+  border-top: 1px solid var(--bundle-full-page-footer-border-color, rgba(0, 0, 0, 0.08));
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.08);
 }
 
 /* Progress Section at top of footer */
 .full-page-footer.redesigned .footer-progress-section {
-  padding: 12px 40px;
-  border-bottom: 1px solid var(--bundle-full-page-footer-border-color, rgba(0, 0, 0, 0.08));
+  padding: 16px 40px 12px;
+  border-bottom: none;
   border-top: none;
-  background: var(--bundle-full-page-progress-bg, #F8F9FA);
+  background: transparent;
+  text-align: center;
 }
 
 .full-page-footer.redesigned .footer-discount-message {
   text-align: center;
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
-  color: var(--bundle-full-page-discount-text-color, #059669);
-  margin-bottom: 10px;
+  color: var(--bundle-full-page-discount-text-color, #E65100);
+  margin-bottom: 12px;
   font-family: inherit;
 }
 
 .full-page-footer.redesigned .footer-progress-bar-container {
-  max-width: 600px;
+  max-width: 800px;
   margin: 0 auto;
-  height: 8px;
-  border-radius: 4px;
+  height: 6px;
+  border-radius: 3px;
 }
 
 .full-page-footer.redesigned .footer-progress-bar-bg {
-  background: var(--bundle-full-page-progress-track, #E0E0E0);
-  border-radius: 4px;
+  background: var(--bundle-full-page-progress-track, #C8E6C9);
+  border-radius: 3px;
 }
 
 .full-page-footer.redesigned .footer-progress-bar-fill {
-  background: var(--bundle-full-page-progress-fill, #00BCD4);
-  border-radius: 4px;
+  background: var(--bundle-full-page-progress-fill, #4CAF50);
+  border-radius: 3px;
 }
 
-/* Main Footer Content */
+/* Main Footer Content - Centered Layout */
 .footer-main-content {
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 16px 40px;
-  gap: 20px;
+  justify-content: center;
+  padding: 16px 40px 20px;
+  gap: 24px;
+  max-width: 900px;
+  margin: 0 auto;
 }
 
 /* Products Strip - Horizontal scrollable */
 .footer-products-strip {
-  flex: 1;
+  flex: 0 1 auto;
   display: flex;
   flex-direction: row;
-  gap: 12px;
+  gap: 8px;
   overflow-x: auto;
   overflow-y: hidden;
-  padding: 8px 0;
-  min-width: 0;
+  padding: 4px 0;
+  max-width: 350px;
 }
 
 .footer-products-strip::-webkit-scrollbar {
@@ -1196,18 +1235,19 @@
   border-radius: 2px;
 }
 
-/* Individual Product Thumbnail */
+/* Individual Product Thumbnail - Compact */
 .footer-product-thumb {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  background: var(--bundle-full-page-footer-thumb-bg, #F8F9FA);
-  border-radius: 8px;
+  gap: 6px;
+  padding: 4px 8px;
+  background: var(--bundle-full-page-footer-thumb-bg, #FFFFFF);
+  border-radius: 6px;
   min-width: fit-content;
   flex-shrink: 0;
-  border: 1px solid var(--bundle-full-page-footer-thumb-border, rgba(0, 0, 0, 0.06));
+  border: 1px solid var(--bundle-full-page-footer-thumb-border, rgba(0, 0, 0, 0.08));
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
 .thumb-image-wrapper {
@@ -1216,24 +1256,24 @@
 }
 
 .thumb-image {
-  width: 48px;
-  height: 48px;
-  border-radius: 6px;
+  width: 36px;
+  height: 36px;
+  border-radius: 4px;
   object-fit: cover;
   border: 1px solid rgba(0, 0, 0, 0.08);
 }
 
 .thumb-remove {
   position: absolute;
-  top: -6px;
-  right: -6px;
-  width: 18px;
-  height: 18px;
+  top: -4px;
+  right: -4px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
   background: var(--bundle-full-page-footer-remove-bg, #FF5252);
   color: white;
   border: none;
-  font-size: 12px;
+  font-size: 10px;
   font-weight: bold;
   cursor: pointer;
   display: flex;
@@ -1252,74 +1292,76 @@
 .thumb-info {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
 }
 
 .thumb-title {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 500;
   color: var(--bundle-full-page-footer-thumb-title, #333333);
   font-family: inherit;
   white-space: nowrap;
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .thumb-price {
-  font-size: 11px;
+  font-size: 10px;
   color: var(--bundle-full-page-footer-thumb-price, #666666);
   font-family: inherit;
 }
 
-/* Total Section */
+/* Total Section - Centered */
 .footer-total-section {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  padding: 0 24px;
+  gap: 12px;
+  padding: 0 16px;
   flex-shrink: 0;
-  min-width: 120px;
 }
 
 .footer-total-section .total-label {
-  font-size: 12px;
-  color: var(--bundle-full-page-footer-total-label-color, #666666);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--bundle-full-page-footer-total-label-color, #333333);
   font-family: inherit;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
 }
 
 .footer-total-section .total-prices {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 8px;
 }
 
 .footer-total-section .total-original {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--bundle-full-page-footer-total-original, #999999);
   text-decoration: line-through;
   font-family: inherit;
 }
 
 .footer-total-section .total-final {
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 700;
-  color: var(--bundle-full-page-footer-total-final, #00BCD4);
+  color: var(--bundle-full-page-footer-total-final, #E65100);
   font-family: inherit;
 }
 
-/* Navigation Section */
+/* Navigation Section - Centered Buttons */
 .footer-nav-section {
   display: flex;
   flex-direction: row;
-  gap: 12px;
+  gap: 10px;
   flex-shrink: 0;
 }
 
 .footer-btn {
-  padding: 14px 32px;
-  border-radius: 8px;
-  font-size: 14px;
+  padding: 12px 28px;
+  border-radius: 25px;
+  font-size: 13px;
   font-weight: 600;
   font-family: inherit;
   cursor: pointer;
@@ -1327,31 +1369,30 @@
   border: none;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  min-width: 100px;
 }
 
 .footer-btn-back {
-  background: var(--bundle-full-page-footer-back-bg, #E0E0E0);
+  background: var(--bundle-full-page-footer-back-bg, #F5C6A5);
   color: var(--bundle-full-page-footer-back-text, #333333);
 }
 
 .footer-btn-back:hover:not(:disabled) {
-  background: var(--bundle-full-page-footer-back-hover, #D0D0D0);
+  background: var(--bundle-full-page-footer-back-hover, #F0B08A);
 }
 
 .footer-btn-next {
-  background: var(--bundle-full-page-footer-next-bg, #00BCD4);
-  color: var(--bundle-full-page-footer-next-text, #FFFFFF);
-  box-shadow: 0 4px 12px rgba(0, 188, 212, 0.3);
+  background: var(--bundle-full-page-footer-next-bg, #F5C6A5);
+  color: var(--bundle-full-page-footer-next-text, #333333);
 }
 
 .footer-btn-next:hover:not(:disabled) {
-  background: var(--bundle-full-page-footer-next-hover, #00ACC1);
-  transform: translateY(-2px);
-  box-shadow: 0 6px 16px rgba(0, 188, 212, 0.4);
+  background: var(--bundle-full-page-footer-next-hover, #F0B08A);
+  transform: translateY(-1px);
 }
 
 .footer-btn:disabled {
-  opacity: 0.5;
+  opacity: 0.4;
   cursor: not-allowed;
   transform: none !important;
 }
@@ -1360,20 +1401,18 @@
 @media (max-width: 768px) {
   .footer-main-content {
     flex-direction: column;
-    padding: 16px 20px;
-    gap: 16px;
+    padding: 12px 16px 16px;
+    gap: 12px;
   }
 
   .footer-products-strip {
     width: 100%;
     max-width: 100%;
+    justify-content: center;
   }
 
   .footer-total-section {
-    flex-direction: row;
-    gap: 12px;
     padding: 0;
-    width: 100%;
     justify-content: center;
   }
 
@@ -1385,14 +1424,16 @@
 
   .footer-nav-section {
     width: 100%;
+    justify-content: center;
   }
 
   .footer-btn {
-    flex: 1;
+    flex: 0 1 auto;
+    min-width: 120px;
   }
 
   .full-page-footer.redesigned .footer-progress-section {
-    padding: 12px 20px;
+    padding: 12px 16px 8px;
   }
 }
 


### PR DESCRIPTION
## Summary
This PR fixes multiple UI issues in the full-page bundle widget and redesigns the promotional banner to match competitor standards with a modern gradient hero style.

## Key Changes

### Bug Fixes
- **Fixed undefined discount messages**: Properly extract values from nested rule structure (`condition.value`, `discount.method`, `discount.value`) instead of accessing non-existent flat properties
- **Removed duplicate bundle title headers**: Full-page bundles now only display the promo banner and step instruction, eliminating redundant title displays
- **Fixed missing minQuantity fallback**: Added default value of 1 when `minQuantity` is undefined in step instructions

### UI Redesign
- **Promo Banner Redesign**: 
  - Changed from light purple/blue gradient to professional blue-teal gradient (`#3498db → #2980b9 → #1abc9c`)
  - Added subtle SVG pattern overlay for depth
  - Increased padding and shadow for more prominent hero-style appearance
  - Made text white with text-shadow for better contrast
  - Added responsive sizing for mobile devices

- **Footer Styling Improvements**:
  - Changed background to light blue (`#E8F4F8`) for better visual hierarchy
  - Centered layout with max-width constraint for professional appearance
  - Redesigned buttons with pill-style rounded corners (`border-radius: 25px`)
  - Changed accent colors to orange (`#E65100`) for total price and buttons
  - Reduced product thumbnail sizes (36px) and spacing for compact footer
  - Improved typography and spacing throughout

- **Product Card Padding**: Changed default padding from `12px` to `0` with CSS variable support (`--bundle-product-card-padding`)

### Code Quality
- Updated comments to clarify that bundle instructions now only show step text (title moved to promo banner)
- Improved null-safety with optional chaining throughout pricing/discount logic
- Added conditional rendering for empty subtitle/note in promo banner

## Files Modified
- `app/assets/bundle-widget-full-page.js` - Core logic fixes and promo banner redesign
- `extensions/bundle-builder/assets/bundle-widget-full-page.css` - Footer and promo banner styling
- `extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js` - Rebuilt bundle with changes
- `docs/issues-prod/fix-html-meta-tags-1.md` - Issue documentation and progress log

## Testing Notes
- Verify discount messages display correctly with various rule configurations
- Test promo banner appearance on mobile and desktop viewports
- Confirm footer layout remains centered and responsive on all screen sizes
- Validate that full-page bundles no longer show duplicate title headers