### PR TITLE
Remove promo banner component from full-page bundle pages

### DIFF
--- a/app/assets/bundle-widget-full-page.js
+++ b/app/assets/bundle-widget-full-page.js
@@ -730,12 +730,6 @@ class BundleWidgetFullPage {
     contentSection.className = 'full-page-content-section';
 
     // OPTIMISTIC RENDERING: Render non-product UI immediately
-    // 0. Render promotional banner if bundle has promotion text
-    const promoBanner = this.createPromoBanner();
-    if (promoBanner) {
-      contentSection.appendChild(promoBanner);
-    }
-
     // 1. Render step timeline at top
     const stepTimeline = this.createStepTimeline();
     contentSection.appendChild(stepTimeline);

--- a/docs/issues-prod/remove-yellow-box-component-1.md
+++ b/docs/issues-prod/remove-yellow-box-component-1.md
@@ -1,0 +1,36 @@
+# Issue: Remove Yellow Box Component (Promo Banner) from Full-Page Bundles
+
+**Issue ID:** remove-yellow-box-component-1
+**Status:** Completed
+**Priority:** 🟡 Medium
+**Created:** 2026-01-25
+**Last Updated:** 2026-01-25 12:05
+
+## Overview
+Remove the promo banner component (showing bundle name like "StrangeObjectsinmirror") that appears at the top of full-page bundle storefront pages. This component displays in a yellow-bordered box and is not needed.
+
+## Progress Log
+
+### 2026-01-25 12:00 - Starting Removal of Promo Banner
+- What I'm about to implement: Remove the createPromoBanner() call from renderFullPageLayout()
+- Files I'll modify:
+  - `app/assets/bundle-widget-full-page.js` (source)
+  - Will rebuild widgets to update bundled file
+- Expected outcome: The yellow box/promo banner will no longer appear on full-page bundle pages
+
+### 2026-01-25 12:05 - Completed Removal of Promo Banner
+- ✅ Removed promo banner rendering code from renderFullPageLayout()
+- ✅ Built widget bundles successfully
+- Files modified:
+  - `app/assets/bundle-widget-full-page.js` (removed lines 733-737)
+  - `extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js` (rebuilt)
+- The promo banner component is no longer rendered on full-page bundle pages
+
+## Related Documentation
+- Source file: `app/assets/bundle-widget-full-page.js` (lines 733-737 removed)
+- Bundled file: `extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js`
+
+## Phases Checklist
+- [x] Phase 1: Remove promo banner rendering code
+- [x] Phase 2: Build widget bundles
+- [x] Phase 3: Test and commit

--- a/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
@@ -2310,12 +2310,6 @@ class BundleWidgetFullPage {
     contentSection.className = 'full-page-content-section';
 
     // OPTIMISTIC RENDERING: Render non-product UI immediately
-    // 0. Render promotional banner if bundle has promotion text
-    const promoBanner = this.createPromoBanner();
-    if (promoBanner) {
-      contentSection.appendChild(promoBanner);
-    }
-
     // 1. Render step timeline at top
     const stepTimeline = this.createStepTimeline();
     contentSection.appendChild(stepTimeline);


### PR DESCRIPTION
## Summary
Removes the promotional banner component (yellow-bordered box displaying bundle name) from the top of full-page bundle storefront pages. This component is no longer needed in the UI.

## Changes Made
- Removed `createPromoBanner()` call and conditional rendering logic from `renderFullPageLayout()` method in `BundleWidgetFullPage` class
- Removed 6 lines of code (lines 733-737) that handled promo banner creation and DOM insertion
- Updated both source and bundled widget files to reflect the removal

## Files Modified
- `app/assets/bundle-widget-full-page.js` - Source file
- `extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js` - Built/bundled version

## Impact
The promo banner will no longer render on full-page bundle pages. The step timeline will now be the first UI element rendered in the content section, immediately following the optimistic rendering phase.