### PR TITLE
Remove progress bar from footer and add padding to product grid

### DIFF
--- a/app/assets/bundle-widget-full-page.js
+++ b/app/assets/bundle-widget-full-page.js
@@ -1364,10 +1364,6 @@ class BundleWidgetFullPage {
 
     progressSection.innerHTML = `
       ${discountMessage ? `<div class="footer-discount-message">${discountMessage}</div>` : ''}
-      <div class="footer-progress-bar-container">
-        <div class="footer-progress-bar-bg"></div>
-        <div class="footer-progress-bar-fill" style="width: ${progressPercent}%"></div>
-      </div>
     `;
 
     // === SECTION 2: Selected Products Strip (below discount message) ===

--- a/docs/issues-prod/update-product-grid-footer-1.md
+++ b/docs/issues-prod/update-product-grid-footer-1.md
@@ -1,0 +1,37 @@
+# Issue: Update Product Grid Footer
+
+**Issue ID:** update-product-grid-footer-1
+**Status:** Completed
+**Priority:** 🟢 Low
+**Created:** 2026-01-25
+**Last Updated:** 2026-01-25 20:30
+
+## Overview
+Add padding-top to the product grid and remove the progress bar container from the footer section in the full-page bundle widget.
+
+## Progress Log
+
+### 2026-01-25 20:30 - Starting Changes
+- Adding `padding-top: 20px` to `.full-page-product-grid` CSS class
+- Removing `.footer-progress-bar-container` div from footer section in JS
+- Files to modify:
+  - `extensions/bundle-builder/assets/bundle-widget-full-page.css`
+  - `app/assets/bundle-widget-full-page.js`
+
+## Related Documentation
+- Full-page bundle widget styles and components
+
+### 2026-01-25 20:32 - Completed Changes
+- Added `padding-top: 20px` to `.full-page-product-grid` in CSS
+- Removed `.footer-progress-bar-container` div from footer in JS
+- Built widget bundles
+- Files modified:
+  - `extensions/bundle-builder/assets/bundle-widget-full-page.css`
+  - `app/assets/bundle-widget-full-page.js`
+  - `extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js`
+
+## Phases Checklist
+- [x] Add padding-top to product grid CSS
+- [x] Remove progress bar container from footer JS
+- [x] Build widget bundles
+- [x] Commit changes

--- a/docs/issues-prod/update-product-grid-footer-1.md
+++ b/docs/issues-prod/update-product-grid-footer-1.md
@@ -4,7 +4,7 @@
 **Status:** Completed
 **Priority:** 🟢 Low
 **Created:** 2026-01-25
-**Last Updated:** 2026-01-25 20:30
+**Last Updated:** 2026-01-25 20:33
 
 ## Overview
 Add padding-top to the product grid and remove the progress bar container from the footer section in the full-page bundle widget.

--- a/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
@@ -3024,10 +3024,6 @@ class BundleWidgetFullPage {
 
     progressSection.innerHTML = `
       ${discountMessage ? `<div class="footer-discount-message">${discountMessage}</div>` : ''}
-      <div class="footer-progress-bar-container">
-        <div class="footer-progress-bar-bg"></div>
-        <div class="footer-progress-bar-fill" style="width: ${progressPercent}%"></div>
-      </div>
     `;
 
     // === SECTION 2: Selected Products Strip (below discount message) ===

--- a/extensions/bundle-builder/assets/bundle-widget-full-page.css
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page.css
@@ -514,6 +514,7 @@
   );
   gap: var(--bundle-product-card-spacing, 20px);
   margin: 20px 0;
+  padding-top: 20px;
   width: 100%;
   justify-content: center; /* Center grid if cards don't fill width */
   overflow-x: auto; /* Allow horizontal scroll if needed */


### PR DESCRIPTION
## Summary
This PR removes the progress bar container from the bundle widget footer and adds top padding to the product grid for improved spacing.

## Changes Made
- **Removed progress bar container** from the footer section in the full-page bundle widget
  - Deleted the `.footer-progress-bar-container` div and its child elements (`footer-progress-bar-bg` and `footer-progress-bar-fill`) from the footer HTML generation
  - Applied to both source and bundled JavaScript files

- **Added padding to product grid** for better visual spacing
  - Added `padding-top: 20px` to the `.full-page-product-grid` CSS class

- **Updated documentation** with a new issue tracking file documenting the changes and completion status

## Files Modified
- `app/assets/bundle-widget-full-page.js`
- `extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js`
- `extensions/bundle-builder/assets/bundle-widget-full-page.css`
- `docs/issues-prod/update-product-grid-footer-1.md` (new)

## Notes
The progress bar removal simplifies the footer layout while the grid padding adjustment improves the visual hierarchy and spacing of the product grid component.