### PR TITLE
Remove bottom border from bundle widget header

### DIFF
--- a/extensions/bundle-builder/assets/bundle-widget.css
+++ b/extensions/bundle-builder/assets/bundle-widget.css
@@ -2063,7 +2063,6 @@
   padding: 20px 16px;
   text-align: center;
   background: var(--bundle-background-color, #ffffff);
-  border-bottom: 1px solid var(--bundle-border-color, #e5e7eb);
 }
 
 .bundle-title {


### PR DESCRIPTION
## Summary
Removed the bottom border styling from the bundle widget header element to simplify the visual design.

## Changes
- Removed `border-bottom: 1px solid var(--bundle-border-color, #e5e7eb);` from the `.bundle-widget-header` CSS rule

## Details
This change removes the visual separator line that was previously displayed at the bottom of the bundle widget header. The header will now have a cleaner appearance without the border, relying on spacing and other visual elements for separation from the content below.