### PR TITLE
Fix checkout extension targeting configuration syntax

### DIFF
--- a/extensions/bundle-checkout-ui/shopify.extension.toml
+++ b/extensions/bundle-checkout-ui/shopify.extension.toml
@@ -14,7 +14,7 @@ uid = "feb2dedd-7b8a-5fa3-1766-e04fa7aebc8abbe9ecbf"
 # and the file that contains your extension’s source code. Learn more:
 # https://shopify.dev/docs/api/checkout-ui-extensions/latest/extension-targets-overview
 
-[targeting]
+[[targeting]]
 module = "./src/Checkout.jsx"
 target = "purchase.checkout.cart-line-item.render-after"
 


### PR DESCRIPTION
## Summary
Updated the checkout extension configuration to use the correct TOML array syntax for the targeting section.

## Changes
- Changed `[targeting]` to `[[targeting]]` in `shopify.extension.toml`
  - This corrects the TOML syntax from a regular table to an array of tables, which is the proper format for defining multiple or extensible targeting configurations in Shopify checkout UI extensions

## Details
The `[[targeting]]` syntax (double brackets) is the correct TOML array-of-tables notation that allows for proper extension configuration. This ensures the extension configuration is parsed correctly by Shopify's build tools and extension framework.

https://claude.ai/code/session_014SnFgrRLmMq9eWD4cmZ9kN