### PR TITLE
[pricing-calculation-bugs-fix-1] fix: Full-page widget now sets unique _bundle_id and _bundle_name

### DIFF
--- a/app/assets/bundle-widget-full-page.js
+++ b/app/assets/bundle-widget-full-page.js
@@ -2035,6 +2035,14 @@ class BundleWidgetFullPage {
       // Build cart items from selected products
       const items = [];
 
+      // Generate unique bundle instance ID for this add-to-cart action
+      // This allows cart transform to group components and prevents Shopify from
+      // consolidating separate bundle instances added at different times
+      const bundleInstanceId = crypto.randomUUID();
+      const bundleName = this.selectedBundle.name || 'Bundle';
+
+      console.log('[CART] Creating bundle instance:', { bundleInstanceId, bundleName });
+
       this.selectedBundle.steps.forEach((step, stepIndex) => {
         const stepSelections = this.selectedProducts[stepIndex] || {};
 
@@ -2055,8 +2063,9 @@ class BundleWidgetFullPage {
               id: numericVariantId,
               quantity: quantity,
               properties: {
-                '_bundle_id': this.selectedBundle.id,
-                '_step_index': stepIndex,
+                '_bundle_id': bundleInstanceId,
+                '_bundle_name': bundleName,
+                '_step_index': String(stepIndex),
                 '_step_name': step.name
               }
             });

--- a/docs/issues-prod/pricing-calculation-bugs-fix-1.md
+++ b/docs/issues-prod/pricing-calculation-bugs-fix-1.md
@@ -1,10 +1,10 @@
 # Issue: Pricing Calculation Bugs Fix
 
 **Issue ID:** pricing-calculation-bugs-fix-1
-**Status:** Completed
+**Status:** In Progress
 **Priority:** High
 **Created:** 2026-02-05
-**Last Updated:** 2026-02-05
+**Last Updated:** 2026-02-06
 
 ---
 
@@ -133,3 +133,27 @@ The cart-line-item targets are static and render automatically — they don't ap
 
 - [x] Phase 9: Add block targets for checkout editor placement
 - [x] Phase 10: Remove block targets (static cart-line targets auto-render, no editor needed)
+
+### 2026-02-06 - Fix Full-Page Bundle MERGE Not Working
+
+**Problem 9: Full-page bundle MERGE not triggering - cart transform only doing EXPAND**
+The full-page widget's `addBundleToCart()` method had two critical issues:
+1. Used static `this.selectedBundle.id` (database ID) as `_bundle_id` instead of unique instance ID
+2. Missing `_bundle_name` attribute entirely
+
+The cart transform requires both `_bundle_id` (unique per add-to-cart) and `_bundle_name` (for display) to trigger MERGE operation.
+
+**Root Cause:**
+- Line 2058: `'_bundle_id': this.selectedBundle.id` - same ID for every add-to-cart
+- Missing `_bundle_name` property in cart line properties
+
+**Files Modified:**
+
+12. `app/assets/bundle-widget-full-page.js`
+    - Generate unique `_bundle_id` using `crypto.randomUUID()` for each add-to-cart
+    - Add `_bundle_name` attribute with `this.selectedBundle.name`
+
+13. `extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js`
+    - Rebuilt widget bundle
+
+- [x] Phase 11: Fix full-page widget to set unique `_bundle_id` and `_bundle_name` attributes

--- a/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
@@ -4121,6 +4121,14 @@ class BundleWidgetFullPage {
       // Build cart items from selected products
       const items = [];
 
+      // Generate unique bundle instance ID for this add-to-cart action
+      // This allows cart transform to group components and prevents Shopify from
+      // consolidating separate bundle instances added at different times
+      const bundleInstanceId = crypto.randomUUID();
+      const bundleName = this.selectedBundle.name || 'Bundle';
+
+      console.log('[CART] Creating bundle instance:', { bundleInstanceId, bundleName });
+
       this.selectedBundle.steps.forEach((step, stepIndex) => {
         const stepSelections = this.selectedProducts[stepIndex] || {};
 
@@ -4141,8 +4149,9 @@ class BundleWidgetFullPage {
               id: numericVariantId,
               quantity: quantity,
               properties: {
-                '_bundle_id': this.selectedBundle.id,
-                '_step_index': stepIndex,
+                '_bundle_id': bundleInstanceId,
+                '_bundle_name': bundleName,
+                '_step_index': String(stepIndex),
                 '_step_name': step.name
               }
             });


### PR DESCRIPTION


- Generate unique bundle instance ID using crypto.randomUUID() for each add-to-cart
- Add _bundle_name attribute with bundle name for cart transform MERGE
- Fixes MERGE not triggering because _bundle_id was static and _bundle_name was missing
- Rebuilt widget bundle