### PR TITLE
[pricing-calculation-bugs-fix-1] fix: Remove unsupported TOML sections blocking checkout UI build

### DIFF
--- a/docs/issues-prod/pricing-calculation-bugs-fix-1.md
+++ b/docs/issues-prod/pricing-calculation-bugs-fix-1.md
@@ -157,3 +157,26 @@ The cart transform requires both `_bundle_id` (unique per add-to-cart) and `_bun
     - Rebuilt widget bundle
 
 - [x] Phase 11: Fix full-page widget to set unique `_bundle_id` and `_bundle_name` attributes
+
+### 2026-02-06 - Fix Checkout UI Extension Not Loading
+
+**Problem 10: Checkout UI extension not loading at all**
+The extension wasn't executing - no console logs appeared. Root cause: `shopify app build` was failing due to unsupported `[metafields]` and `[shop]` sections in app TOML config.
+
+**Problem 11: Multiple targets in one extension caused issues**
+Having two targeting blocks in one extension was problematic. Simplified to single checkout target.
+
+**Files Modified:**
+
+14. `shopify.app.toml` and `shopify.app.wolfpack-product-bundles-sit.toml`
+    - Removed unsupported `[metafields]` and `[shop.metafields.*]` sections
+    - These metafield definitions should be managed via Admin API instead
+
+15. `extensions/bundle-checkout-ui/shopify.extension.toml`
+    - Simplified to single extension with checkout cart-line-item target only
+    - Removed thank-you page target to isolate and fix checkout rendering
+
+16. `extensions/bundle-checkout-ui/shopify.d.ts`
+    - Updated type declarations to match single-target configuration
+
+- [ ] Phase 12: Fix checkout UI extension build and deployment

--- a/extensions/bundle-checkout-ui/shopify.d.ts
+++ b/extensions/bundle-checkout-ui/shopify.d.ts
@@ -2,16 +2,12 @@ import '@shopify/ui-extensions';
 
 //@ts-ignore
 declare module './src/index.tsx' {
-  const shopify:
-    | import('@shopify/ui-extensions/purchase.checkout.cart-line-item.render-after').Api
-    | import('@shopify/ui-extensions/purchase.thank-you.cart-line-item.render-after').Api;
+  const shopify: import('@shopify/ui-extensions/purchase.checkout.cart-line-item.render-after').Api;
   const globalThis: { shopify: typeof shopify };
 }
 
 //@ts-ignore
 declare module './src/Checkout.tsx' {
-  const shopify:
-    | import('@shopify/ui-extensions/purchase.checkout.cart-line-item.render-after').Api
-    | import('@shopify/ui-extensions/purchase.thank-you.cart-line-item.render-after').Api;
+  const shopify: import('@shopify/ui-extensions/purchase.checkout.cart-line-item.render-after').Api;
   const globalThis: { shopify: typeof shopify };
 }

--- a/extensions/bundle-checkout-ui/shopify.extension.toml
+++ b/extensions/bundle-checkout-ui/shopify.extension.toml
@@ -10,6 +10,7 @@ api_version = "2025-10"
 # Static target that auto-renders after each cart line in checkout
 # =============================================================================
 [[extensions]]
+uid = "feb2dedd-7b8a-5fa3-1766-e04fa7aebc8abbe9ecbf"
 type = "ui_extension"
 name = "Bundle Pricing - Checkout"
 handle = "bundle-checkout-ui"

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -32,41 +32,5 @@ prefix = "apps"
 [pos]
 embedded = false
 
-[metafields]
-api_version = "2025-10"
-
-[shop.metafields.app.serverUrl]
-type = "single_line_text_field"
-name = "App Server URL"
-description = "URL of the app server for widget API calls"
-
-  [shop.metafields.app.serverUrl.access]
-  admin = "merchant_read_write"
-  storefront = "public_read"
-
-[shop.metafields.app.lastSync]
-type = "single_line_text_field"
-name = "Last Sync Timestamp"
-description = "ISO timestamp of last successful sync with app server"
-
-  [shop.metafields.app.lastSync.access]
-  admin = "merchant_read"
-  storefront = "none"
-
-[shop.metafields.app.productPageWidgetInstalled]
-type = "boolean"
-name = "Product Page Widget Installed"
-description = "Indicates if the product page bundle widget has been installed in the theme"
-
-  [shop.metafields.app.productPageWidgetInstalled.access]
-  admin = "merchant_read_write"
-  storefront = "none"
-
-[shop.metafields.app.fullPageWidgetInstalled]
-type = "boolean"
-name = "Full Page Widget Installed"
-description = "Indicates if the full-page bundle widget has been installed in the theme"
-
-  [shop.metafields.app.fullPageWidgetInstalled.access]
-  admin = "merchant_read_write"
-  storefront = "none"
+# NOTE: Metafields and shop sections commented out - unsupported in current Shopify CLI
+# These metafields should be defined via the Shopify Admin API instead

--- a/shopify.app.wolfpack-product-bundles-sit.toml
+++ b/shopify.app.wolfpack-product-bundles-sit.toml
@@ -10,10 +10,10 @@ api_version = "2025-10"
 
   [[webhooks.subscriptions]]
   topics = [
-  "app_subscriptions/update",
+  "products/update",
   "products/delete",
-  "app_purchases_one_time/update",
-  "products/update"
+  "app_subscriptions/update",
+  "app_purchases_one_time/update"
 ]
   uri = "pubsub://light-quest-455608-i3:wolfpack-product-bundles-staging"
   compliance_topics = [ "customers/data_request", "customers/redact", "shop/redact" ]
@@ -36,41 +36,13 @@ url = "https://wolfpack-product-bundle-app-sit.onrender.com"
 subpath = "product-bundles"
 prefix = "apps"
 
-[metafields]
-api_version = "2025-10"
-
-[shop.metafields.app.serverUrl]
-type = "single_line_text_field"
-name = "App Server URL"
-description = "URL of the app server for widget API calls"
-
-  [shop.metafields.app.serverUrl.access]
-  admin = "merchant_read_write"
-  storefront = "public_read"
-
-[shop.metafields.app.lastSync]
-type = "single_line_text_field"
-name = "Last Sync Timestamp"
-description = "ISO timestamp of last successful sync with app server"
-
-  [shop.metafields.app.lastSync.access]
-  admin = "merchant_read"
-  storefront = "none"
-
-[shop.metafields.app.productPageWidgetInstalled]
-type = "boolean"
-name = "Product Page Widget Installed"
-description = "Indicates if the product page bundle widget has been installed in the theme"
-
-  [shop.metafields.app.productPageWidgetInstalled.access]
-  admin = "merchant_read_write"
-  storefront = "none"
-
-[shop.metafields.app.fullPageWidgetInstalled]
-type = "boolean"
-name = "Full Page Widget Installed"
-description = "Indicates if the full-page bundle widget has been installed in the theme"
-
-  [shop.metafields.app.fullPageWidgetInstalled.access]
-  admin = "merchant_read_write"
-  storefront = "none"
+# NOTE: Metafields and shop sections commented out - unsupported in current Shopify CLI
+# These metafields should be defined via the Shopify Admin API instead
+#
+# [metafields]
+# api_version = "2025-10"
+#
+# [shop.metafields.app.serverUrl]
+# type = "single_line_text_field"
+# name = "App Server URL"
+# ...etc


### PR DESCRIPTION
- Remove [metafields] and [shop.metafields.*] sections from app TOML configs
- These sections are unsupported in current Shopify CLI and were blocking builds
- Simplify checkout extension to single target (checkout only, no thank-you)
- Update type declarations to match single-target configuration