### PR TITLE
[login-screen-fix-2] fix: Use client-side redirect to prevent token exchange short-circuit

### DIFF
--- a/app/routes/app/app._index.tsx
+++ b/app/routes/app/app._index.tsx
@@ -1,17 +1,32 @@
-import { redirect, type LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useEffect } from "react";
+import { useNavigate } from "@remix-run/react";
 
-// This route exists solely to redirect /app → /app/dashboard.
-// Authentication is already handled by the parent layout route (app.tsx),
-// which calls authenticate.admin(request). Calling it here a second time
-// in parallel triggers a token-exchange race condition with unstable_newEmbeddedAuthStrategy
-// (both loaders fire simultaneously and both try to exchange the same id_token).
-// The $app:serverUrl metafield sync has been moved to the afterAuth hook in shopify.server.ts.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function loader({ request }: LoaderFunctionArgs) {
-  throw redirect("/app/dashboard");
+// This route redirects /app → /app/dashboard using CLIENT-SIDE navigation.
+//
+// Why not a server-side redirect (throw redirect)?
+// With unstable_newEmbeddedAuthStrategy, the parent layout (app.tsx) exchanges
+// the one-shot id_token for an access token via authenticate.admin(). Remix runs
+// layout and child loaders in parallel. A synchronous `throw redirect()` here
+// short-circuits Promise.all before the parent's token exchange completes, so no
+// session is stored. The subsequent request to /app/dashboard has no id_token,
+// no Authorization header, and no session — causing a redirect to /auth/login.
+//
+// By returning from the loader and redirecting on the client, we ensure:
+// 1. Parent's authenticate.admin() completes the token exchange
+// 2. React renders → App Bridge initializes
+// 3. Client-side navigation adds the Authorization header via App Bridge
+// 4. Dashboard loader's authenticate.admin() finds the stored session
+export function loader() {
+  return json(null);
 }
 
-// This component never renders — the loader always redirects.
 export default function AppIndex() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate("/app/dashboard", { replace: true });
+  }, [navigate]);
+
   return null;
 }

--- a/docs/issues-prod/login-screen-fix-2.md
+++ b/docs/issues-prod/login-screen-fix-2.md
@@ -1,0 +1,70 @@
+# Issue: Fix Login Screen — Server-Side Redirect Breaks Token Exchange
+
+**Issue ID:** login-screen-fix-2
+**Status:** Completed
+**Priority:** 🔴 High
+**Created:** 2026-03-01
+**Last Updated:** 2026-03-01 14:00
+
+## Overview
+
+Despite the fixes in `login-screen-fix-1`, the login screen still appears inside the
+embedded Shopify Admin iframe after reinstalling the app. The previous fix removed
+`authenticate.admin()` from `app._index.tsx` to prevent a parallel token-exchange race
+condition, but replaced it with `throw redirect("/app/dashboard")` — a server-side redirect
+that short-circuits the parent layout's token exchange.
+
+## Root Cause
+
+With `unstable_newEmbeddedAuthStrategy`, Remix runs the layout (`app.tsx`) and child
+(`app._index.tsx`) loaders **in parallel** via `Promise.all`. The flow was:
+
+1. Shopify iframe opens `/?id_token=...&shop=...`
+2. Root `_index` redirects to `/app?id_token=...&shop=...`
+3. Remix fires both loaders in parallel:
+   - `app.tsx` → `await authenticate.admin(request)` (takes ~200ms for token exchange)
+   - `app._index.tsx` → `throw redirect("/app/dashboard")` (resolves **immediately**)
+4. `throw redirect()` rejects the promise instantly → `Promise.all` short-circuits
+5. Remix sends the 302 before the parent's token exchange completes
+6. Browser navigates to `/app/dashboard` — no `id_token`, no `Authorization` header,
+   no stored session
+7. `authenticate.admin()` fails → redirects to `/auth/login`
+
+With the new embedded auth strategy, there are **no cookie-based sessions** — only
+token-based auth via `id_token` (initial) and `Authorization` headers (subsequent requests
+via App Bridge). A server-side redirect breaks both mechanisms.
+
+## Fix
+
+Changed `app._index.tsx` from a server-side `throw redirect("/app/dashboard")` to a
+**client-side redirect** using `useNavigate` + `useEffect`:
+
+1. Loader returns `json(null)` — does NOT redirect or call `authenticate.admin()`
+2. Parent layout's `authenticate.admin()` completes the token exchange and stores session
+3. React renders → App Bridge initializes
+4. `useEffect` fires `navigate("/app/dashboard", { replace: true })`
+5. Client-side navigation uses App Bridge's fetch interceptor (adds `Authorization` header)
+6. Dashboard loader's `authenticate.admin()` validates JWT → finds stored session → success
+
+## Files Modified
+
+- `app/routes/app/app._index.tsx` — Replaced `throw redirect()` with client-side navigate
+
+## Progress Log
+
+### 2026-03-01 14:00 - Completed Fix
+
+- ✅ Analyzed Render logs: confirmed 302 redirect chain showing 3.9ms auth failure
+- ✅ Identified `throw redirect()` as the cause of Promise.all short-circuit
+- ✅ Changed to client-side redirect with `useNavigate` + `useEffect`
+- ✅ ESLint: 0 errors
+- ✅ TypeScript: no new errors
+- Next: Deploy to SIT and verify
+
+## Phases Checklist
+
+- [x] Diagnose root cause from Render logs
+- [x] Implement client-side redirect fix
+- [x] Lint and type-check
+- [x] Commit
+- [ ] Deploy to SIT and verify


### PR DESCRIPTION
The server-side `throw redirect("/app/dashboard")` in app._index.tsx was short-circuiting Promise.all before the parent layout's authenticate.admin() could complete the token exchange. With unstable_newEmbeddedAuthStrategy, this left no stored session for the subsequent /app/dashboard request, causing a redirect loop to /auth/login.

Changed to a client-side redirect via useNavigate + useEffect so the parent's token exchange completes, App Bridge initializes, and subsequent navigation includes the Authorization header.