### PR TITLE
[login-screen-fix-2] fix: Remove auth from layout, use exclusive auth in _index with preserved params

### DIFF
--- a/app/routes/app/app._index.tsx
+++ b/app/routes/app/app._index.tsx
@@ -1,32 +1,33 @@
-import { json } from "@remix-run/node";
-import { useEffect } from "react";
-import { useNavigate } from "@remix-run/react";
+import { redirect, type LoaderFunctionArgs } from "@remix-run/node";
+import { authenticate } from "../../shopify.server";
 
-// This route redirects /app → /app/dashboard using CLIENT-SIDE navigation.
+// This route handles /app → authenticates → redirects to /app/dashboard.
 //
-// Why not a server-side redirect (throw redirect)?
-// With unstable_newEmbeddedAuthStrategy, the parent layout (app.tsx) exchanges
-// the one-shot id_token for an access token via authenticate.admin(). Remix runs
-// layout and child loaders in parallel. A synchronous `throw redirect()` here
-// short-circuits Promise.all before the parent's token exchange completes, so no
-// session is stored. The subsequent request to /app/dashboard has no id_token,
-// no Authorization header, and no session — causing a redirect to /auth/login.
-//
-// By returning from the loader and redirecting on the client, we ensure:
-// 1. Parent's authenticate.admin() completes the token exchange
-// 2. React renders → App Bridge initializes
-// 3. Client-side navigation adds the Authorization header via App Bridge
-// 4. Dashboard loader's authenticate.admin() finds the stored session
-export function loader() {
-  return json(null);
+// Auth strategy:
+// - The layout (app.tsx) does NOT call authenticate.admin() because Remix
+//   runs layout and child loaders in parallel, causing a race for the
+//   one-shot id_token with unstable_newEmbeddedAuthStrategy.
+// - Instead, THIS route is the sole auth entry point for /app.
+// - After token exchange, we redirect to /app/dashboard with `shop` and
+//   `host` params preserved so the dashboard's authenticate.admin() can
+//   identify the shop and perform the exit-iframe bounce if needed.
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { session } = await authenticate.admin(request);
+
+  // Preserve embedded context params for the redirect target.
+  // Without shop/host, authenticate.admin() at /app/dashboard can't identify
+  // the shop and falls back to /auth/login (the {shop: null} problem).
+  const url = new URL(request.url);
+  const host = url.searchParams.get("host") || "";
+
+  const params = new URLSearchParams();
+  params.set("shop", session.shop);
+  if (host) params.set("host", host);
+
+  return redirect(`/app/dashboard?${params.toString()}`);
 }
 
+// This component never renders — the loader always redirects.
 export default function AppIndex() {
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    navigate("/app/dashboard", { replace: true });
-  }, [navigate]);
-
   return null;
 }

--- a/app/routes/app/app.tsx
+++ b/app/routes/app/app.tsx
@@ -1,17 +1,17 @@
-import type { HeadersFunction, LoaderFunctionArgs } from "@remix-run/node";
+import type { HeadersFunction } from "@remix-run/node";
 import { Outlet, useLoaderData, useRouteError } from "@remix-run/react";
 import { boundary } from "@shopify/shopify-app-remix/server";
 import { AppProvider } from "@shopify/shopify-app-remix/react";
 import { NavMenu } from "@shopify/app-bridge-react";
 import polarisStyles from "@shopify/polaris/build/esm/styles.css?url";
 
-import { authenticate } from "../../shopify.server";
-
 export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
-  await authenticate.admin(request);
-
+// Auth is NOT called here. Remix runs layout and child loaders in parallel.
+// With unstable_newEmbeddedAuthStrategy, calling authenticate.admin() here
+// races with the child loader (app._index.tsx) for the same one-shot id_token.
+// Each child route calls authenticate.admin() in its own loader instead.
+export const loader = async () => {
   return { apiKey: process.env.SHOPIFY_API_KEY || "" };
 };
 

--- a/docs/issues-prod/login-screen-fix-2.md
+++ b/docs/issues-prod/login-screen-fix-2.md
@@ -1,7 +1,7 @@
 # Issue: Fix Login Screen — Server-Side Redirect Breaks Token Exchange
 
 **Issue ID:** login-screen-fix-2
-**Status:** Completed
+**Status:** In Progress
 **Priority:** 🔴 High
 **Created:** 2026-03-01
 **Last Updated:** 2026-03-01 14:00
@@ -61,10 +61,32 @@ Changed `app._index.tsx` from a server-side `throw redirect("/app/dashboard")` t
 - ✅ TypeScript: no new errors
 - Next: Deploy to SIT and verify
 
+### 2026-03-01 16:00 - Client-side redirect didn't work, new approach
+
+Render logs showed the smoking gun:
+```
+06:51:20 - Authenticating admin request | {shop: wolfpack-store-test-1.myshopify.com}  ← token exchange ✓
+06:51:21 - Authenticating admin request | {shop: null}  ← client redirect, no auth ✗
+06:51:27+ - Many more {shop: null} failures
+```
+
+Client-side redirect fires before App Bridge initializes the Authorization header.
+
+New approach — eliminate the parallel race entirely:
+- **Remove `authenticate.admin()` from `app.tsx` layout** — layout just returns apiKey
+- **`app._index.tsx`**: call `authenticate.admin()` exclusively (no race), then
+  `return redirect("/app/dashboard?shop=...&host=...")` with embedded params preserved
+- Dashboard's `authenticate.admin()` detects embedded context + has shop param → exit-iframe bounce → App Bridge loads → proper auth
+
+Files modified:
+- `app/routes/app/app.tsx` — Removed authenticate.admin() from layout loader
+- `app/routes/app/app._index.tsx` — authenticate.admin() + redirect with preserved params
+
 ## Phases Checklist
 
 - [x] Diagnose root cause from Render logs
-- [x] Implement client-side redirect fix
+- [x] Attempt 1: client-side redirect (failed — App Bridge not ready)
+- [x] Attempt 2: remove auth from layout + server redirect with preserved params
 - [x] Lint and type-check
 - [x] Commit
 - [ ] Deploy to SIT and verify


### PR DESCRIPTION
Root cause confirmed from Render logs: the client-side redirect (useNavigate) fired before App Bridge initialized the Authorization header, causing every subsequent authenticate.admin() call to see {shop: null} and redirect to login.

New approach eliminates the parallel loader race entirely:
- app.tsx layout: removed authenticate.admin() — just returns apiKey
- app._index.tsx: calls authenticate.admin() exclusively (no race for id_token), then redirects to /app/dashboard?shop=...&host=... with embedded context params preserved so the dashboard's auth can identify the shop and perform the exit-iframe bounce via App Bridge.