### PR TITLE
[preview-url-stale-memory-fix-1] fix: Store product handle in DB to e…

### DIFF
--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/route.tsx
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/route.tsx
@@ -680,57 +680,50 @@ export default function ConfigureBundleFlow() {
     }
 
     // FOR PRODUCT-PAGE BUNDLES: Use product URL
-    if (!bundleProduct) {
-      shopify.toast.show("Bundle product not found. Please select a bundle product first.", {
-        isError: true,
-        duration: 4000
-      });
-      return;
-    }
-
-    // Try different URL construction methods
     let productUrl = null;
+    const productHandle = bundleProduct?.handle || bundle.shopifyProductHandle;
 
-    AppLogger.debug('Bundle product data for preview:', {
-      id: bundleProduct.id,
-      handle: bundleProduct.handle,
-      status: bundleProduct.status,
-      publishedOnCurrentPublication: bundleProduct.status === 'ACTIVE',
-      onlineStoreUrl: bundleProduct.onlineStoreUrl,
-      onlineStorePreviewUrl: bundleProduct.onlineStorePreviewUrl,
-      shop: shop
-    });
+    if (bundleProduct) {
+      AppLogger.debug('Bundle product data for preview:', {
+        id: bundleProduct.id,
+        handle: bundleProduct.handle,
+        status: bundleProduct.status,
+        publishedOnCurrentPublication: bundleProduct.status === 'ACTIVE',
+        onlineStoreUrl: bundleProduct.onlineStoreUrl,
+        onlineStorePreviewUrl: bundleProduct.onlineStorePreviewUrl,
+        shop: shop
+      });
 
-    // Method 1: Use onlineStorePreviewUrl first (works for both published and draft products)
-    if (bundleProduct.onlineStorePreviewUrl) {
-      productUrl = bundleProduct.onlineStorePreviewUrl;
+      // Method 1: Use onlineStorePreviewUrl first (works for both published and draft products)
+      if (bundleProduct.onlineStorePreviewUrl) {
+        productUrl = bundleProduct.onlineStorePreviewUrl;
+      }
+      // Method 2: Fallback to onlineStoreUrl if preview URL not available
+      else if (bundleProduct.onlineStoreUrl) {
+        productUrl = bundleProduct.onlineStoreUrl;
+      }
     }
-    // Method 2: Fallback to onlineStoreUrl if preview URL not available
-    else if (bundleProduct.onlineStoreUrl) {
-      productUrl = bundleProduct.onlineStoreUrl;
-    }
-    // Method 3: Construct URL based on shop type (development vs live store)
-    else if (bundleProduct.handle) {
+
+    // Method 3: Construct URL from handle (GraphQL product handle or DB-stored handle)
+    if (!productUrl && productHandle) {
       if (shop.includes('shopifypreview.com')) {
-        // For development stores with shopifypreview.com domain
-        productUrl = `https://${shop}/products/${bundleProduct.handle}`;
+        productUrl = `https://${shop}/products/${productHandle}`;
       } else {
-        // For live stores or development stores with myshopify.com
         const shopDomain = shop.includes('.myshopify.com')
           ? shop.replace('.myshopify.com', '')
           : shop;
-        productUrl = `https://${shopDomain}.myshopify.com/products/${bundleProduct.handle}`;
+        productUrl = `https://${shopDomain}.myshopify.com/products/${productHandle}`;
       }
     }
     // Method 4: Fallback - Extract ID and use admin URL
-    else if (bundleProduct.id) {
+    else if (!productUrl && bundleProduct?.id) {
       const productId = bundleProduct.id.includes('gid://shopify/Product/')
         ? bundleProduct.id.split('/').pop()
         : bundleProduct.id;
 
       const shopDomain = shop.includes('.myshopify.com')
         ? shop.replace('.myshopify.com', '')
-        : shop.split('.')[0]; // Extract first part of domain
+        : shop.split('.')[0];
 
       productUrl = `https://admin.shopify.com/store/${shopDomain}/products/${productId}`;
     }
@@ -738,8 +731,7 @@ export default function ConfigureBundleFlow() {
     if (productUrl) {
       open(productUrl, '_blank');
 
-      // Show appropriate success message based on the URL type used
-      const isPreviewUrl = productUrl === bundleProduct.onlineStorePreviewUrl;
+      const isPreviewUrl = bundleProduct && productUrl === bundleProduct.onlineStorePreviewUrl;
       const message = isPreviewUrl
         ? "Bundle product preview opened in new tab"
         : "Bundle product opened in new tab";

--- a/app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/route.tsx
+++ b/app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/route.tsx
@@ -658,58 +658,51 @@ export default function ConfigureBundleFlow() {
       return;
     }
 
-    // Check if bundle product exists
-    if (!bundleProduct) {
-      shopify.toast.show("Bundle product not found. Please select a bundle product first.", {
-        isError: true,
-        duration: 4000
-      });
-      return;
-    }
-
     // Try different URL construction methods
     let productUrl = null;
+    const productHandle = bundleProduct?.handle || bundle.shopifyProductHandle;
 
-    AppLogger.debug('Bundle product data for preview:', {
-      id: bundleProduct.id,
-      handle: bundleProduct.handle,
-      status: bundleProduct.status,
-      publishedOnCurrentPublication: bundleProduct.status === 'ACTIVE',
-      onlineStoreUrl: bundleProduct.onlineStoreUrl,
-      onlineStorePreviewUrl: bundleProduct.onlineStorePreviewUrl,
-      shop: shop
-    });
+    if (bundleProduct) {
+      AppLogger.debug('Bundle product data for preview:', {
+        id: bundleProduct.id,
+        handle: bundleProduct.handle,
+        status: bundleProduct.status,
+        publishedOnCurrentPublication: bundleProduct.status === 'ACTIVE',
+        onlineStoreUrl: bundleProduct.onlineStoreUrl,
+        onlineStorePreviewUrl: bundleProduct.onlineStorePreviewUrl,
+        shop: shop
+      });
 
-    // Method 1: Use onlineStorePreviewUrl first (works for both published and draft products)
-    if (bundleProduct.onlineStorePreviewUrl) {
-      productUrl = bundleProduct.onlineStorePreviewUrl;
+      // Method 1: Use onlineStorePreviewUrl first (works for both published and draft products)
+      if (bundleProduct.onlineStorePreviewUrl) {
+        productUrl = bundleProduct.onlineStorePreviewUrl;
+      }
+      // Method 2: Fallback to onlineStoreUrl if preview URL not available
+      else if (bundleProduct.onlineStoreUrl) {
+        productUrl = bundleProduct.onlineStoreUrl;
+      }
     }
-    // Method 2: Fallback to onlineStoreUrl if preview URL not available
-    else if (bundleProduct.onlineStoreUrl) {
-      productUrl = bundleProduct.onlineStoreUrl;
-    }
-    // Method 3: Construct URL based on shop type (development vs live store)
-    else if (bundleProduct.handle) {
+
+    // Method 3: Construct URL from handle (GraphQL product handle or DB-stored handle)
+    if (!productUrl && productHandle) {
       if (shop.includes('shopifypreview.com')) {
-        // For development stores with shopifypreview.com domain
-        productUrl = `https://${shop}/products/${bundleProduct.handle}`;
+        productUrl = `https://${shop}/products/${productHandle}`;
       } else {
-        // For live stores or development stores with myshopify.com
         const shopDomain = shop.includes('.myshopify.com')
           ? shop.replace('.myshopify.com', '')
           : shop;
-        productUrl = `https://${shopDomain}.myshopify.com/products/${bundleProduct.handle}`;
+        productUrl = `https://${shopDomain}.myshopify.com/products/${productHandle}`;
       }
     }
     // Method 4: Fallback - Extract ID and use admin URL
-    else if (bundleProduct.id) {
+    else if (!productUrl && bundleProduct?.id) {
       const productId = bundleProduct.id.includes('gid://shopify/Product/')
         ? bundleProduct.id.split('/').pop()
         : bundleProduct.id;
 
       const shopDomain = shop.includes('.myshopify.com')
         ? shop.replace('.myshopify.com', '')
-        : shop.split('.')[0]; // Extract first part of domain
+        : shop.split('.')[0];
 
       productUrl = `https://admin.shopify.com/store/${shopDomain}/products/${productId}`;
     }
@@ -723,8 +716,7 @@ export default function ConfigureBundleFlow() {
 
       open(productUrl, '_blank');
 
-      // Show appropriate success message based on the URL type used
-      const isPreviewUrl = productUrl === bundleProduct.onlineStorePreviewUrl;
+      const isPreviewUrl = bundleProduct && productUrl === bundleProduct.onlineStorePreviewUrl;
       const message = isPreviewUrl
         ? "Bundle product preview opened in new tab"
         : "Bundle product opened in new tab";
@@ -737,7 +729,7 @@ export default function ConfigureBundleFlow() {
         duration: 5000
       });
     }
-  }, [isDirty, bundleProduct, shop, shopify]);
+  }, [isDirty, bundle, bundleProduct, shop, shopify]);
 
   const handleSectionChange = useCallback((section: string) => {
     if (isDirty) {

--- a/app/routes/app/app.dashboard/handlers/handlers.server.ts
+++ b/app/routes/app/app.dashboard/handlers/handlers.server.ts
@@ -415,6 +415,7 @@ export async function handleCreateBundle(
     }
 
     const shopifyProductId = productData.data?.productCreate?.product?.id;
+    const shopifyProductHandle = productData.data?.productCreate?.product?.handle;
 
     if (!shopifyProductId) {
       AppLogger.error("No product ID returned from Shopify", { component: "app.dashboard", operation: "create-bundle" });
@@ -445,6 +446,7 @@ export async function handleCreateBundle(
         fullPageLayout: bundleType === BundleType.FULL_PAGE ? (fullPageLayout as any || FullPageLayout.FOOTER_BOTTOM) : null,
         status: BundleStatus.DRAFT,
         shopifyProductId: shopifyProductId,
+        shopifyProductHandle: shopifyProductHandle || null,
       },
     });
 

--- a/app/routes/app/app.dashboard/route.tsx
+++ b/app/routes/app/app.dashboard/route.tsx
@@ -60,6 +60,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       bundleType: true,
       createdAt: true,
       shopifyProductId: true, // For product page preview URL
+      shopifyProductHandle: true, // For product page preview URL (stored in DB)
       shopifyPageHandle: true, // For full page preview URL
       pricing: {
         select: {
@@ -75,14 +76,14 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     orderBy: { createdAt: "desc" },
   });
 
-  // Fetch product handles for product_page bundles that have shopifyProductId
-  const productPageBundles = bundles.filter(b => b.bundleType === BundleType.PRODUCT_PAGE && b.shopifyProductId);
-  const productHandles: Record<string, string> = {};
+  // Backfill: fetch + persist product handles for legacy bundles missing shopifyProductHandle
+  const bundlesNeedingBackfill = bundles.filter(
+    b => b.bundleType === BundleType.PRODUCT_PAGE && b.shopifyProductId && !b.shopifyProductHandle
+  );
 
-  if (productPageBundles.length > 0) {
+  if (bundlesNeedingBackfill.length > 0) {
     try {
-      // Batch fetch product handles using GraphQL
-      const productIds = productPageBundles.map(b => b.shopifyProductId).filter(Boolean);
+      const productIds = bundlesNeedingBackfill.map(b => b.shopifyProductId).filter(Boolean);
       const GET_PRODUCTS = `
         query GetProductHandles($ids: [ID!]!) {
           nodes(ids: $ids) {
@@ -102,24 +103,31 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       if (data.data?.nodes) {
         for (const node of data.data.nodes) {
           if (node?.id && node?.handle) {
-            productHandles[node.id] = node.handle;
+            // Persist handle to DB so future loads skip GraphQL
+            const bundleToUpdate = bundlesNeedingBackfill.find(b => b.shopifyProductId === node.id);
+            if (bundleToUpdate) {
+              bundleToUpdate.shopifyProductHandle = node.handle;
+              await db.bundle.update({
+                where: { id: bundleToUpdate.id },
+                data: { shopifyProductHandle: node.handle }
+              });
+            }
           }
         }
       }
     } catch (error) {
-      // Log error but continue - preview will just not work for these bundles
-      AppLogger.error("Failed to fetch product handles", {
+      AppLogger.error("Failed to backfill product handles", {
         component: "app.dashboard",
-        operation: "fetch-product-handles"
+        operation: "backfill-product-handles"
       }, error);
     }
   }
 
-  // Enhance bundles with preview URLs
+  // Enhance bundles with preview URLs — now purely from DB fields
   const bundlesWithPreview = bundles.map(bundle => ({
     ...bundle,
     previewHandle: bundle.bundleType === BundleType.PRODUCT_PAGE
-      ? (bundle.shopifyProductId ? productHandles[bundle.shopifyProductId] : null)
+      ? bundle.shopifyProductHandle
       : bundle.shopifyPageHandle
   }));
 

--- a/docs/issues-prod/preview-url-stale-memory-fix-1.md
+++ b/docs/issues-prod/preview-url-stale-memory-fix-1.md
@@ -1,0 +1,50 @@
+# Issue: Store product handle in DB to fix stale preview URLs
+
+**Issue ID:** preview-url-stale-memory-fix-1
+**Status:** Completed
+**Priority:** 🔴 High
+**Created:** 2026-03-07
+**Last Updated:** 2026-03-07 12:30
+
+## Overview
+
+When a user creates a full-page bundle then a product-page bundle, the "Preview Bundle" / "Add to Storefront" link can point to the wrong (stale) URL. Product-page bundle preview handles are fetched at runtime from Shopify GraphQL (not stored in DB), while full-page handles ARE stored in DB (`shopifyPageHandle`). Fix: store `shopifyProductHandle` in the DB at bundle creation time.
+
+## Progress Log
+
+### 2026-03-07 12:00 - Planning Complete
+- ✅ Analyzed codebase: dashboard loader, configure routes, creation handler
+- ✅ Identified root cause: product handles fetched at runtime via GraphQL, not persisted
+- ✅ Confirmed `CREATE_BUNDLE_PRODUCT_WITH_MEDIA` mutation already returns `handle`
+- ✅ Created implementation plan
+- Next: Begin Phase 1 — Schema migration
+
+### 2026-03-07 12:30 - All Phases Completed
+- ✅ Phase 1: Added `shopifyProductHandle String?` to Bundle model in `prisma/schema.prisma`
+  - Created migration `20260307120000_add_shopify_product_handle`
+- ✅ Phase 2: Extract + save handle from `productCreate` mutation response
+  - Modified `app/routes/app/app.dashboard/handlers/handlers.server.ts` (lines 418, 449)
+- ✅ Phase 3: Dashboard loader now uses `bundle.shopifyProductHandle` from DB
+  - Removed runtime GraphQL `GetProductHandles` query
+  - Added backfill for legacy bundles: fetches handle from GraphQL and persists to DB on first load
+  - Modified `app/routes/app/app.dashboard/route.tsx` (lines 63, 78-130)
+- ✅ Phase 4: Both configure routes use `bundle.shopifyProductHandle` as fallback
+  - Modified `app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/route.tsx`
+  - Modified `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/route.tsx`
+- ✅ Phase 5: Backfill integrated into dashboard loader (Phase 3)
+
+## Phases Checklist
+
+- [x] Phase 1: Add `shopifyProductHandle` to Prisma schema + migration
+- [x] Phase 2: Save handle at bundle creation time
+- [x] Phase 3: Simplify dashboard loader to use DB handle
+- [x] Phase 4: Add fallback in configure route preview handlers
+- [x] Phase 5: Backfill existing bundles
+
+## Related Files
+
+- `prisma/schema.prisma` — Bundle model
+- `app/routes/app/app.dashboard/handlers/handlers.server.ts` — Bundle creation
+- `app/routes/app/app.dashboard/route.tsx` — Dashboard loader + preview
+- `app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/route.tsx` — Preview handler
+- `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/route.tsx` — Preview handler

--- a/prisma/migrations/20260307120000_add_shopify_product_handle/migration.sql
+++ b/prisma/migrations/20260307120000_add_shopify_product_handle/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Bundle" ADD COLUMN "shopifyProductHandle" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,7 +86,8 @@ model Bundle {
   name             String
   description      String?
   shopId           String
-  shopifyProductId String? // Shopify Product ID (GID) for product-page bundles
+  shopifyProductId     String? // Shopify Product ID (GID) for product-page bundles
+  shopifyProductHandle String? // Shopify Product handle for preview URLs (e.g., "summer-bundle")
   shopifyPageHandle String? // Shopify Page handle for full-page bundles (e.g., "build-your-bundle")
   shopifyPageId    String? // Shopify Page ID (GID) for full-page bundles
   templateName     String? // Template name for bundle container (e.g., "cart-transform", "product")


### PR DESCRIPTION
…liminate stale preview URLs

Product-page bundle preview handles were fetched at runtime from Shopify GraphQL, causing stale/wrong URLs when switching between bundle types. Now shopifyProductHandle is persisted in the Bundle table at creation time, matching how full-page bundles already store shopifyPageHandle. Includes a one-time backfill for existing bundles.