### PR TITLE
fix: Remove forced estree-util-value-to-estree@3.5.0 override that broke Remix build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10557,18 +10557,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/estree-util-value-to-estree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.5.0.tgz",
-      "integrity": "sha512-aMV56R27Gv3QmfmF1MY12GWkGzzeAezAX+UplqHVASfjc9wNzI/X6hC0S9oxq61WT4aQesLGslWP9tKk6ghRZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/remcohaszing"
-      }
-    },
     "node_modules/estree-util-visit": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-1.2.1.tgz",
@@ -12541,6 +12529,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-reference": {
@@ -18101,6 +18101,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-mdx-frontmatter/node_modules/estree-util-value-to-estree": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-1.3.0.tgz",
+      "integrity": "sha512-Y+ughcF9jSUJvncXwqRageavjrNPAI+1M/L3BI3PyLp1nmgYTGUXU6t5z1Y7OWuThoDdhPME07bQU+d5LxdJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/remark-parse": {

--- a/package.json
+++ b/package.json
@@ -109,8 +109,7 @@
     "undici": "6.23.0",
     "valibot": "1.2.0",
     "rollup": "4.59.0",
-    "esbuild": "0.25.0",
-    "estree-util-value-to-estree": "3.5.0"
+    "esbuild": "0.25.0"
   },
   "overrides": {
     "@graphql-tools/url-loader": "8.0.16",
@@ -121,8 +120,7 @@
     "undici": "6.23.0",
     "valibot": "1.2.0",
     "rollup": "4.59.0",
-    "esbuild": "0.25.0",
-    "estree-util-value-to-estree": "3.5.0"
+    "esbuild": "0.25.0"
   },
   "author": "Anurag"
 }


### PR DESCRIPTION


v3.x is ESM-only. remark-mdx-frontmatter (used by @remix-run/dev) requires() it via CommonJS, causing ERR_REQUIRE_ESM at build time. Removing the override lets npm install the compatible v1.x in remark-mdx-frontmatter's own node_modules instead of hoisting the incompatible v3.5.0 globally.