### PR TITLE
[widget-loading-state-stuck-1] fix: Resolve loading overlay stuck visible after fast init

### DIFF
--- a/app/assets/bundle-widget-product-page.js
+++ b/app/assets/bundle-widget-product-page.js
@@ -1794,7 +1794,14 @@ class BundleWidgetProductPage {
     }
 
     this.container.appendChild(overlay);
-    requestAnimationFrame(() => overlay.classList.add('is-visible'));
+    // Force a synchronous reflow so the browser applies the initial opacity:0
+    // before we add 'is-visible'. Using offsetHeight instead of requestAnimationFrame
+    // avoids a race condition where hideLoadingOverlay() is called before the rAF
+    // fires (which happens when loadBundleData() resolves synchronously from the
+    // dataset attribute — microtasks settle before animation frames).
+    // eslint-disable-next-line no-unused-expressions
+    overlay.offsetHeight;
+    overlay.classList.add('is-visible');
   }
 
   hideLoadingOverlay() {

--- a/docs/issues-prod/widget-loading-state-stuck-1.md
+++ b/docs/issues-prod/widget-loading-state-stuck-1.md
@@ -1,0 +1,43 @@
+# Issue: Product Page Widget Stuck in Loading State
+
+**Issue ID:** widget-loading-state-stuck-1
+**Status:** Completed
+**Priority:** 🔴 High
+**Created:** 2026-03-12
+**Last Updated:** 2026-03-12 20:30
+
+## Overview
+
+Product page widget permanently shows a dark loading overlay after init, even after page reload.
+
+## Root Cause
+
+Race condition between `requestAnimationFrame` in `showLoadingOverlay()` and the microtask-resolved `hideLoadingOverlay()` call during init.
+
+`loadBundleData()` is `async` but does **no actual I/O** — it synchronously JSON-parses `dataset.bundleConfig`. When `await`-ed, it resolves in the microtask queue, which settles **before** the next animation frame.
+
+Timeline:
+1. `showLoadingOverlay()` queues `requestAnimationFrame(() => overlay.classList.add('is-visible'))`
+2. `await loadBundleData()` resolves synchronously (microtask)
+3. `hideLoadingOverlay()` removes `is-visible` — class was never added, `transitionend` never fires, overlay stays in DOM
+4. rAF fires → adds `is-visible` → overlay turns opaque
+5. Widget permanently stuck in loading state
+
+## Fix
+
+Replaced `requestAnimationFrame` with `overlay.offsetHeight` (forced synchronous reflow) in `showLoadingOverlay()`. This ensures the browser applies the initial `opacity: 0` before the class is added, without deferring to the next animation frame.
+
+## Progress Log
+
+### 2026-03-12 20:30 - Fixed
+
+- ✅ `app/assets/bundle-widget-product-page.js` — replaced `requestAnimationFrame` with `offsetHeight` reflow
+- ✅ `scripts/build-widget-bundles.js` — bumped `WIDGET_VERSION` from `1.3.2` → `1.3.3`
+- ✅ Rebuilt: `extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js`
+- Next: `shopify app deploy` to push updated JS to Shopify CDN
+
+## Phases Checklist
+
+- [x] Phase 1: Identify race condition
+- [x] Phase 2: Fix and rebuild widget
+- [ ] Phase 3: Deploy with shopify app deploy

--- a/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
@@ -1,13 +1,13 @@
 /*!
  * Wolfpack Bundle Widget — Product Page
- * Version : 1.3.2
+ * Version : 1.3.3
  * Built   : 2026-03-12
  *
  * Cache note: Shopify CDN cache is busted automatically by shopify app deploy.
  * After deploying, allow 2-10 minutes for propagation before testing.
  * Verify live version: console.log(window.__BUNDLE_WIDGET_VERSION__)
  */
-window.__BUNDLE_WIDGET_VERSION__ = '1.3.2';
+window.__BUNDLE_WIDGET_VERSION__ = '1.3.3';
 (function() {
   'use strict';
 
@@ -3274,7 +3274,14 @@ class BundleWidgetProductPage {
     }
 
     this.container.appendChild(overlay);
-    requestAnimationFrame(() => overlay.classList.add('is-visible'));
+    // Force a synchronous reflow so the browser applies the initial opacity:0
+    // before we add 'is-visible'. Using offsetHeight instead of requestAnimationFrame
+    // avoids a race condition where hideLoadingOverlay() is called before the rAF
+    // fires (which happens when loadBundleData() resolves synchronously from the
+    // dataset attribute — microtasks settle before animation frames).
+    // eslint-disable-next-line no-unused-expressions
+    overlay.offsetHeight;
+    overlay.classList.add('is-visible');
   }
 
   hideLoadingOverlay() {

--- a/scripts/build-widget-bundles.js
+++ b/scripts/build-widget-bundles.js
@@ -36,7 +36,7 @@ const ROOT_DIR = join(__dirname, '..');
 // Verify live version in browser DevTools on the storefront:
 //   console.log(window.__BUNDLE_WIDGET_VERSION__)
 // ---------------------------------------------------------------------------
-const WIDGET_VERSION = '1.3.2';
+const WIDGET_VERSION = '1.3.3';
 
 // Shared component modules (in dependency order)
 const SHARED_MODULES = [


### PR DESCRIPTION


Race condition: showLoadingOverlay() used requestAnimationFrame to add 'is-visible', but hideLoadingOverlay() ran in the microtask queue (before the next frame) when loadBundleData() resolved synchronously from the dataset attribute. The rAF then fired after hide, leaving the overlay permanently opaque.

Fix: replace requestAnimationFrame with offsetHeight forced reflow so is-visible is added synchronously in the same call stack.

Bumps widget version 1.3.2 → 1.3.3.