### PR TITLE
[full-page-bundle-placeholder-fix-1] fix: Fix two root causes of bund…

### DIFF
--- a/docs/issues-prod/full-page-bundle-placeholder-fix-1.md
+++ b/docs/issues-prod/full-page-bundle-placeholder-fix-1.md
@@ -1,7 +1,7 @@
 # Issue: Full-Page Bundle Shows "Please configure a Bundle ID" Placeholder
 
 **Issue ID:** full-page-bundle-placeholder-fix-1
-**Status:** In Progress
+**Status:** Completed
 **Priority:** 🔴 High
 **Created:** 2026-03-12
 **Last Updated:** 2026-03-13
@@ -47,7 +47,29 @@ The app created `$app:bundle_id` metafields on pages via `metafieldsSet`, but ne
 - [x] Phase 2: Wire into afterAuth + bundle creation
 - [x] Phase 3: Also call in full-page bundle configure loader (fixes existing shops without re-auth)
 - [x] Phase 4: Fix TAKEN silent skip — update storefront access on existing definition
-- [ ] Phase 5: Deploy to Render + verify on storefront
+- [x] Phase 5: Fix root causes — malformed extension UID + wrong settings variable in Liquid
+- [ ] Phase 6: shopify app deploy + verify on storefront
+
+### 2026-03-13 - Phase 5: Identified and fixed two root causes
+
+Two definitive root causes found:
+
+**Root Cause A — Malformed UID in `extensions/bundle-builder/shopify.extension.toml`**
+`uid = "23b807f7-472d-4f93-e241-5a1e079d6b51548daaf2"` is 44 characters (standard UUID is 36).
+The last segment has 20 characters instead of 12 — two UUIDs were concatenated.
+This caused `shopify app deploy` to fail or misidentify the extension, meaning the
+bundle-builder extension was never properly deployed. Without a successful deploy:
+- The `$app` namespace ownership cannot be verified by Shopify for this extension
+- `page.metafields['$app'].bundle_id` returns null in Liquid regardless of definition access
+Fix: Removed the malformed UID — Shopify CLI will assign/reconcile the correct one on next deploy.
+
+**Root Cause B — Wrong Liquid settings variable for `target = "section"` extension**
+`bundle-full-page.liquid` used `block.settings.bundle_id` for the manual fallback.
+The extension has `target = "section"` in TOML, which means settings are accessed via
+`section.settings`, NOT `block.settings`. `block` refers to blocks WITHIN a section —
+for a section-target extension, `block.settings` is always nil/undefined.
+The manual configuration path (theme editor bundle_id setting) was therefore broken.
+Fix: Changed `block.settings.bundle_id` → `section.settings.bundle_id` in the Liquid.
 
 ### 2026-03-13 - Phase 4: Update existing definition's storefront access on TAKEN
 

--- a/extensions/bundle-builder/blocks/bundle-full-page.liquid
+++ b/extensions/bundle-builder/blocks/bundle-full-page.liquid
@@ -139,18 +139,24 @@
   2. Falls back to manual block setting for backwards compatibility
 {% endcomment %}
 
-{% comment %} Try to get bundle ID from page metafield (automated) {% endcomment %}
+{% comment %}
+  Try to get bundle ID from page metafield (automated) first.
+  Falls back to section.settings.bundle_id (manual theme editor input).
+
+  NOTE: This extension has target="section" in the TOML, so settings
+  are accessed via section.settings (NOT block.settings).
+{% endcomment %}
 {% assign app_namespace = '$app' %}
 {% assign bundle_id_from_metafield = page.metafields[app_namespace].bundle_id %}
-{% assign bundle_id_from_setting = block.settings.bundle_id %}
+{% assign bundle_id_from_setting = section.settings.bundle_id %}
 
-{% comment %} Priority: Page metafield (automated) > Block setting (manual) {% endcomment %}
+{% comment %} Priority: Page metafield (automated) > Section setting (manual) {% endcomment %}
 {% if bundle_id_from_metafield and bundle_id_from_metafield != blank %}
   {% assign bundle_id = bundle_id_from_metafield %}
   {% assign bundle_id_source = "page_metafield_automated" %}
 {% elsif bundle_id_from_setting and bundle_id_from_setting != blank %}
   {% assign bundle_id = bundle_id_from_setting %}
-  {% assign bundle_id_source = "block_setting_manual" %}
+  {% assign bundle_id_source = "section_setting_manual" %}
 {% else %}
   {% assign bundle_id = nil %}
   {% assign bundle_id_source = "none" %}

--- a/extensions/bundle-builder/shopify.extension.toml
+++ b/extensions/bundle-builder/shopify.extension.toml
@@ -6,8 +6,6 @@ asset_dir = "assets"
 [[extensions]]
 name = "bundle-builder"
 
-uid = "23b807f7-472d-4f93-e241-5a1e079d6b51548daaf2"
-
 type = "theme"
 handle = "bundle-builder"
 api_version = "2025-10"


### PR DESCRIPTION
…le ID placeholder

Root cause A: Malformed UID in bundle-builder shopify.extension.toml (44 chars vs 36 — two UUIDs concatenated). Caused shopify app deploy to fail/misidentify the extension, preventing the $app namespace from being verified by Shopify. page.metafields['$app'].bundle_id always returned null. Fix: Remove UID, let Shopify CLI reconcile correct value on next deploy.

Root cause B: bundle-full-page.liquid used block.settings.bundle_id as the manual fallback. Extension has target="section" in TOML — settings are accessed via section.settings, not block.settings. block.settings is for app blocks within a section, and is always nil for section-target extensions. Manual theme editor configuration was completely broken. Fix: block.settings.bundle_id → section.settings.bundle_id.