### PR TITLE
[full-page-bundle-placeholder-fix-1] fix: Extract bundle ID from page…

### DIFF
--- a/docs/issues-prod/full-page-bundle-placeholder-fix-1.md
+++ b/docs/issues-prod/full-page-bundle-placeholder-fix-1.md
@@ -48,7 +48,23 @@ The app created `$app:bundle_id` metafields on pages via `metafieldsSet`, but ne
 - [x] Phase 3: Also call in full-page bundle configure loader (fixes existing shops without re-auth)
 - [x] Phase 4: Fix TAKEN silent skip — update storefront access on existing definition
 - [x] Phase 5: Fix root causes — malformed extension UID + wrong settings variable in Liquid
-- [ ] Phase 6: shopify app deploy + verify on storefront
+- [x] Phase 6: Fix definitive root cause — extract bundle ID from page.handle
+- [ ] Phase 7: shopify app deploy + verify on storefront
+
+### 2026-03-13 - Phase 6: Definitive fix — page.handle extraction
+
+Previous fixes (MetafieldDefinition PUBLIC_READ, section.settings, extension UID) all still
+depended on Shopify's metafield system working correctly. The real definitive fix:
+
+**Page handles are deterministic**: App creates pages with handle `bundle-{bundleId}`.
+Bundle IDs are Prisma CUIDs (lowercase alphanumeric, no special chars). The
+`replace(/[^a-z0-9]+/g, '-')` transformation is a no-op for CUIDs, so the handle is
+always exactly `bundle-` + bundleId. Stripping the prefix in Liquid gives back the exact
+bundle ID — no metafield, no definition, no PUBLIC_READ access required.
+
+Fix: Added `page.handle | remove_first: 'bundle-'` as the PRIMARY source of bundle_id
+in bundle-full-page.liquid. Metafield and section.settings kept as fallbacks.
+Works immediately on all existing bundle pages without redeploy of server code.
 
 ### 2026-03-13 - Phase 5: Identified and fixed two root causes
 

--- a/extensions/bundle-builder/blocks/bundle-full-page.liquid
+++ b/extensions/bundle-builder/blocks/bundle-full-page.liquid
@@ -140,18 +140,42 @@
 {% endcomment %}
 
 {% comment %}
-  Try to get bundle ID from page metafield (automated) first.
-  Falls back to section.settings.bundle_id (manual theme editor input).
+  Resolve bundle ID from three sources in priority order:
 
-  NOTE: This extension has target="section" in the TOML, so settings
-  are accessed via section.settings (NOT block.settings).
+  1. page.handle  — MOST RELIABLE. App creates pages with handle "bundle-{bundleId}".
+                    Bundle IDs are CUIDs (lowercase alphanumeric, no special chars),
+                    so the handle is always "bundle-" + bundleId with no transformation.
+                    Stripping the prefix gives back the exact bundleId. Works on every
+                    app-created bundle page with zero metafield or deploy dependency.
+
+  2. page.metafields['$app'].bundle_id  — Set by metafieldsSet on page creation.
+                    Requires MetafieldDefinition with storefront: PUBLIC_READ. Used as
+                    primary automated path if handle extraction ever doesn't apply.
+
+  3. section.settings.bundle_id  — Manual fallback. Merchant enters bundle ID in the
+                    Shopify theme editor. NOTE: target="section" in TOML means settings
+                    are accessed via section.settings (NOT block.settings).
 {% endcomment %}
+
+{% comment %} Source 1: Extract bundle ID from the page handle {% endcomment %}
+{% if page.handle contains 'bundle-' %}
+  {% assign bundle_id_from_handle = page.handle | remove_first: 'bundle-' %}
+{% else %}
+  {% assign bundle_id_from_handle = nil %}
+{% endif %}
+
+{% comment %} Source 2: Page metafield (requires PUBLIC_READ definition) {% endcomment %}
 {% assign app_namespace = '$app' %}
 {% assign bundle_id_from_metafield = page.metafields[app_namespace].bundle_id %}
+
+{% comment %} Source 3: Section setting (manual theme editor input) {% endcomment %}
 {% assign bundle_id_from_setting = section.settings.bundle_id %}
 
-{% comment %} Priority: Page metafield (automated) > Section setting (manual) {% endcomment %}
-{% if bundle_id_from_metafield and bundle_id_from_metafield != blank %}
+{% comment %} Priority: handle > metafield > section setting {% endcomment %}
+{% if bundle_id_from_handle and bundle_id_from_handle != blank %}
+  {% assign bundle_id = bundle_id_from_handle %}
+  {% assign bundle_id_source = "page_handle" %}
+{% elsif bundle_id_from_metafield and bundle_id_from_metafield != blank %}
   {% assign bundle_id = bundle_id_from_metafield %}
   {% assign bundle_id_source = "page_metafield_automated" %}
 {% elsif bundle_id_from_setting and bundle_id_from_setting != blank %}


### PR DESCRIPTION
….handle — bypasses metafield entirely

App-created bundle pages always have handle 'bundle-{bundleId}'. Bundle IDs are Prisma CUIDs (lowercase alphanumeric) so the handle transformation is identity — stripping 'bundle-' gives back the exact bundleId with no ambiguity. This works on all existing pages with zero metafield/definition dependency. Previous automated path (page.metafields['$app'].bundle_id) and manual path (section.settings.bundle_id) kept as fallbacks.