### PR TITLE
[full-page-bundle-placeholder-fix-1] fix: Revert section.settings to …

### DIFF
--- a/extensions/bundle-builder/blocks/bundle-full-page.liquid
+++ b/extensions/bundle-builder/blocks/bundle-full-page.liquid
@@ -142,36 +142,39 @@
 {% comment %}
   Resolve bundle ID from three sources in priority order:
 
-  1. page.handle  — MOST RELIABLE. App creates pages with handle "bundle-{bundleId}".
-                    Bundle IDs are CUIDs (lowercase alphanumeric, no special chars),
-                    so the handle is always "bundle-" + bundleId with no transformation.
-                    Stripping the prefix gives back the exact bundleId. Works on every
-                    app-created bundle page with zero metafield or deploy dependency.
+  1. page.handle  — MOST RELIABLE (primary source).
+                    App creates bundle pages with handle "bundle-{bundleId}".
+                    Bundle IDs are Prisma CUIDs (lowercase alphanumeric, no special
+                    chars), so `remove_first: 'bundle-'` gives back the exact bundleId.
+                    Zero dependency on metafields, definitions, or deploy state.
 
-  2. page.metafields['$app'].bundle_id  — Set by metafieldsSet on page creation.
-                    Requires MetafieldDefinition with storefront: PUBLIC_READ. Used as
-                    primary automated path if handle extraction ever doesn't apply.
+  2. page.metafields['$app'].bundle_id  — NOTE: '$app' in the Admin API expands to
+                    'app--{app_id}' internally. The correct Liquid accessor would be
+                    page.metafields['app--{app_id}']['bundle_id'] but the app_id is not
+                    easily available at Liquid render time. This path is kept as a
+                    secondary fallback but may always return nil. Source 1 supersedes it.
 
-  3. section.settings.bundle_id  — Manual fallback. Merchant enters bundle ID in the
-                    Shopify theme editor. NOTE: target="section" in TOML means settings
-                    are accessed via section.settings (NOT block.settings).
+  3. block.settings.bundle_id  — Manual fallback. Merchant enters bundle ID in the
+                    Shopify theme editor. Per Shopify docs, ALL theme app extension
+                    blocks (including target="section") access settings via block.settings,
+                    not section.settings.
 {% endcomment %}
 
-{% comment %} Source 1: Extract bundle ID from the page handle {% endcomment %}
+{% comment %} Source 1: Extract bundle ID from page handle (primary — always works) {% endcomment %}
 {% if page.handle contains 'bundle-' %}
   {% assign bundle_id_from_handle = page.handle | remove_first: 'bundle-' %}
 {% else %}
   {% assign bundle_id_from_handle = nil %}
 {% endif %}
 
-{% comment %} Source 2: Page metafield (requires PUBLIC_READ definition) {% endcomment %}
+{% comment %} Source 2: Page metafield (may not resolve due to $app namespace expansion) {% endcomment %}
 {% assign app_namespace = '$app' %}
 {% assign bundle_id_from_metafield = page.metafields[app_namespace].bundle_id %}
 
-{% comment %} Source 3: Section setting (manual theme editor input) {% endcomment %}
-{% assign bundle_id_from_setting = section.settings.bundle_id %}
+{% comment %} Source 3: Block setting (manual theme editor input) {% endcomment %}
+{% assign bundle_id_from_setting = block.settings.bundle_id %}
 
-{% comment %} Priority: handle > metafield > section setting {% endcomment %}
+{% comment %} Priority: handle > metafield > block setting {% endcomment %}
 {% if bundle_id_from_handle and bundle_id_from_handle != blank %}
   {% assign bundle_id = bundle_id_from_handle %}
   {% assign bundle_id_source = "page_handle" %}
@@ -180,7 +183,7 @@
   {% assign bundle_id_source = "page_metafield_automated" %}
 {% elsif bundle_id_from_setting and bundle_id_from_setting != blank %}
   {% assign bundle_id = bundle_id_from_setting %}
-  {% assign bundle_id_source = "section_setting_manual" %}
+  {% assign bundle_id_source = "block_setting_manual" %}
 {% else %}
   {% assign bundle_id = nil %}
   {% assign bundle_id_source = "none" %}


### PR DESCRIPTION
…block.settings (Shopify docs confirm block.settings is correct for all targets)

Shopify docs explicitly show block.settings used with target="section" schema. All theme app extension blocks use block.settings regardless of target value. The section.settings change was incorrect — reverted.

Also annotated the $app metafield path: Shopify expands $app to app--{app_id} internally, so page.metafields['$app'].bundle_id has likely never resolved. The page.handle approach (already committed) is the correct primary source.