### PR TITLE
[full-page-bundle-placeholder-fix-1] fix: Set templateSuffix on bundle pages, use shared full-page-bundle template

### DIFF
--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/route.tsx
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/route.tsx
@@ -1227,11 +1227,13 @@ export default function ConfigureBundleFlow() {
       // Adding bundleId parameter allows the widget's Liquid code to auto-detect and populate
       // the bundle_id setting in the theme editor, making setup seamless for merchants
       //
-      // For Shopify pages, template format is: page.{handle}
+      // For full-page bundles: always use the shared 'page.full-page-bundle' template.
+      // All bundle pages are assigned this templateSuffix so the block only needs to be
+      // installed once. page.handle in Liquid identifies which bundle to render.
       // For product templates, template format is just: {handle}
-      const templateParam = template.isPage ? `page.${template.handle}` : template.handle;
+      const templateParam = template.isPage ? 'page.full-page-bundle' : template.handle;
 
-      const themeEditorUrl = `https://${shopDomain}.myshopify.com/admin/themes/current/editor?template=${templateParam}&addAppBlockId=${appBlockId}&target=newAppsSection&bundleId=${bundle.id}`;
+      const themeEditorUrl = `https://${shopDomain}.myshopify.com/admin/themes/current/editor?template=${templateParam}&addAppBlockId=${appBlockId}&target=newAppsSection`;
 
       AppLogger.debug(`🔗 [THEME_EDITOR] Generated deep link with bundleId:`, {
         templateParam,

--- a/app/services/widget-installation/widget-full-page-bundle.server.ts
+++ b/app/services/widget-installation/widget-full-page-bundle.server.ts
@@ -58,6 +58,7 @@ export async function createFullPageBundle(
               id
               title
               handle
+              templateSuffix
             }
           }
         }
@@ -86,6 +87,7 @@ export async function createFullPageBundle(
               id
               title
               handle
+              templateSuffix
             }
             userErrors {
               field
@@ -101,7 +103,8 @@ export async function createFullPageBundle(
             title: pageTitle,
             handle: pageHandle,
             body: '',
-            isPublished: true
+            isPublished: true,
+            templateSuffix: 'full-page-bundle'
           }
         }
       });
@@ -141,8 +144,36 @@ export async function createFullPageBundle(
         component: 'WidgetFullPageBundle',
         pageId: createdPage.id,
         pageHandle: createdPage.handle,
+        templateSuffix: createdPage.templateSuffix,
         bundleId
       });
+
+      // Ensure existing page uses the shared full-page-bundle template
+      if (createdPage.templateSuffix !== 'full-page-bundle') {
+        const UPDATE_PAGE_TEMPLATE = `
+          mutation updatePageTemplate($id: ID!, $page: PageUpdateInput!) {
+            pageUpdate(id: $id, page: $page) {
+              page { id templateSuffix }
+              userErrors { field message }
+            }
+          }
+        `;
+        const updateResponse = await admin.graphql(UPDATE_PAGE_TEMPLATE, {
+          variables: { id: createdPage.id, page: { templateSuffix: 'full-page-bundle' } }
+        });
+        const updateData = await updateResponse.json();
+        if (updateData.data?.pageUpdate?.userErrors?.length > 0) {
+          AppLogger.warn('Could not update templateSuffix on existing page (non-critical)', {
+            component: 'WidgetFullPageBundle',
+            errors: updateData.data.pageUpdate.userErrors
+          });
+        } else {
+          AppLogger.info('Updated existing page templateSuffix to full-page-bundle', {
+            component: 'WidgetFullPageBundle',
+            pageId: createdPage.id
+          });
+        }
+      }
     }
 
     // Step 2a: Ensure PAGE metafield definition exists with PUBLIC_READ storefront access

--- a/docs/issues-prod/full-page-bundle-placeholder-fix-1.md
+++ b/docs/issues-prod/full-page-bundle-placeholder-fix-1.md
@@ -1,10 +1,10 @@
 # Issue: Full-Page Bundle Shows "Please configure a Bundle ID" Placeholder
 
 **Issue ID:** full-page-bundle-placeholder-fix-1
-**Status:** Completed
+**Status:** In Progress
 **Priority:** 🔴 High
 **Created:** 2026-03-12
-**Last Updated:** 2026-03-13
+**Last Updated:** 2026-03-16
 
 ## Overview
 
@@ -49,7 +49,34 @@ The app created `$app:bundle_id` metafields on pages via `metafieldsSet`, but ne
 - [x] Phase 4: Fix TAKEN silent skip — update storefront access on existing definition
 - [x] Phase 5: Fix root causes — malformed extension UID + wrong settings variable in Liquid
 - [x] Phase 6: Fix definitive root cause — extract bundle ID from page.handle
+- [x] Phase 8: Fix page templateSuffix — all bundle pages use shared 'full-page-bundle' template
 - [ ] Phase 7: shopify app deploy + verify on storefront
+
+### 2026-03-16 - Phase 8: Fix page templateSuffix — all bundle pages use shared template
+
+**Root Cause Found (Final):** Two compounding issues caused the persistent placeholder:
+
+1. **`shopify app deploy` was never run after Phase 6** — The `page.handle` Liquid fix exists in
+   the committed code but was never deployed to Shopify's CDN. The live storefront was still
+   running the old Liquid that only read from `page.metafields['$app'].bundle_id` (nil) and
+   `block.settings.bundle_id` (empty) → always showed placeholder.
+
+2. **Pages created without `templateSuffix`** — Bundle pages were created with no template
+   assignment so they use Shopify's default `templates/page.json`. The theme editor deep link
+   was opening a per-bundle custom template (`page.bundle-{bundleId}`). Even if the merchant
+   added the block to that custom template, the page still renders with `templates/page.json`
+   (which may not have the block). The block and the page were never connected.
+
+**Fix:**
+- `widget-full-page-bundle.server.ts`: New pages created with `templateSuffix: 'full-page-bundle'`.
+  Existing pages (when `createFullPageBundle` is called again) have their `templateSuffix` updated
+  via `pageUpdate` mutation.
+- `route.tsx`: Theme editor URL now always uses `template=page.full-page-bundle` for full-page
+  bundles instead of per-bundle `page.bundle-{bundleId}`. Merchant installs the block ONCE on
+  the shared `full-page-bundle` template; all bundle pages show their respective bundle via
+  `page.handle | remove_first: 'bundle-'` extraction already in the Liquid.
+
+**Next:** Run `shopify app deploy` to push Liquid changes to CDN.
 
 ### 2026-03-13 - Phase 6: Definitive fix — page.handle extraction
 


### PR DESCRIPTION
- pageCreate now sets templateSuffix: 'full-page-bundle' so all bundle pages use a single shared template instead of per-bundle custom templates
- pageUpdate migrates existing pages to full-page-bundle templateSuffix
- Theme editor deep link uses template=page.full-page-bundle (not per-bundle page.bundle-{id}), so merchants install the block once for all bundles
- Removed bundleId from theme editor URL (not needed — page.handle extraction in Liquid already handles which bundle to render)

Root causes resolved:
1. Pages were created without templateSuffix → used default page.json template which may not have the bundle block installed
2. Theme editor opened per-bundle custom template that was never assigned to the page — block existed in template file but page never rendered it