### PR TITLE
[sync-bundle-1] fix: Pass full session object to createFullPageBundle in handleSyncBundle

### DIFF
--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/handlers.server.ts
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/handlers.server.ts
@@ -932,7 +932,7 @@ export async function handleSyncBundle(admin: ShopifyAdmin, session: Session, bu
     // 4. Re-create the Shopify page via WidgetInstallationService
     const apiKey = process.env.SHOPIFY_API_KEY || '';
     const result = await WidgetInstallationService.createFullPageBundle(
-      admin, session.shop, apiKey, bundleId, bundle.name,
+      admin, session, apiKey, bundleId, bundle.name,
     );
 
     if (!result.success) {


### PR DESCRIPTION
createFullPageBundle signature was updated to take session (ShopSession) not session.shop (string). Passing session.shop caused session.shop to be undefined inside the service, triggering "Cannot read properties of undefined (reading 'replace')".