### PR TITLE
[ppb-variant-state-card-bug-1] fix: State cards now render correctly for non-default variant selections

### DIFF
--- a/app/assets/bundle-widget-product-page.js
+++ b/app/assets/bundle-widget-product-page.js
@@ -728,7 +728,7 @@ class BundleWidgetProductPage {
         const selectedEntries = Object.entries(stepSelections).filter(([, qty]) => qty > 0);
 
         if (selectedEntries.length > 0) {
-          const products = this.stepProductData[stepIndex] || [];
+          const products = this.expandProductsByVariant(this.stepProductData[stepIndex] || []);
           selectedEntries.forEach(([variantId, qty]) => {
             const product = products.find(p => (p.variantId || p.id) === variantId);
             if (product) {
@@ -2355,7 +2355,7 @@ class BundleWidgetProductPage {
     const unavailableProducts = []; // Track unavailable products
 
     this.selectedProducts.forEach((stepSelections, stepIndex) => {
-      const productsInStep = this.stepProductData[stepIndex];
+      const productsInStep = this.expandProductsByVariant(this.stepProductData[stepIndex] || []);
 
       Object.entries(stepSelections).forEach(([variantId, quantity]) => {
         if (quantity > 0) {
@@ -2367,9 +2367,8 @@ class BundleWidgetProductPage {
               return; // Skip this product
             }
 
-
-            // Use selected variant ID; fall back to first variant for single-variant products.
-            const actualVariantId = product.variantId ?? product.variants?.[0]?.id;
+            // variantId is already the user-selected variant ID from selectedProducts
+            const actualVariantId = variantId;
 
             const step = this.selectedBundle.steps[stepIndex];
             const properties = {

--- a/docs/issues-prod/ppb-variant-state-card-bug-1.md
+++ b/docs/issues-prod/ppb-variant-state-card-bug-1.md
@@ -1,0 +1,62 @@
+# Issue: PDP Widget — State Cards Missing for Non-Default Variant Selections
+
+**Issue ID:** ppb-variant-state-card-bug-1
+**Status:** Completed
+**Priority:** 🔴 High
+**Created:** 2026-03-21
+**Last Updated:** 2026-03-21 18:30
+
+## Overview
+
+After selecting products in the bottom-sheet modal for a multi-step bundle, only 1 of 3 state
+cards renders on the product page. The other 2 steps become invisible (no filled card, no empty
+card), even though pricing ($15) and the Add to Cart button correctly reflect all 3 selections.
+
+## Root Cause
+
+`renderProductPageLayout` and `buildCartItems` look up selected products using:
+```js
+products.find(p => (p.variantId || p.id) === variantId)
+```
+where `products = this.stepProductData[stepIndex]` — the RAW (un-expanded) product list.
+
+`stepProductData` stores one entry per product with `variantId = defaultVariant.id` (first variant).
+
+The modal uses `expandProductsByVariant(rawProducts)` which creates one card per variant.
+When a user selects a non-default variant, `selectedProducts[i][nonDefaultVariantId] = 1`.
+The raw-list `find` doesn't match that variantId → no state card rendered, product skipped in cart.
+
+`PricingCalculator.calculateBundleTotal` already has a nested-variants fallback (that's why $15
+shows correctly), but `renderProductPageLayout` and `buildCartItems` are missing it.
+
+This also causes the stale-state bug: steps 1 & 2 have no state cards (no × button),
+so those selections can't be cleared, and re-opening the modal shows them as pre-selected.
+
+## Fix
+
+Use `expandProductsByVariant` before the find in both places, matching how the modal renders:
+- `renderProductPageLayout` line ~731
+- `buildCartItems` line ~2362 (also use `variantId` directly as `actualVariantId`)
+
+## Progress Log
+
+### 2026-03-21 18:00 - Implementing fix
+
+- `renderProductPageLayout` (line 731): changed `this.stepProductData[stepIndex] || []` to
+  `this.expandProductsByVariant(this.stepProductData[stepIndex] || [])` — now matches modal expansion
+- `buildCartItems` (line 2358): same expansion applied; also replaced
+  `product.variantId ?? product.variants?.[0]?.id` with `variantId` (the key from selectedProducts)
+  so the exact user-selected variant is always added to cart, never the default
+- Built widget bundle: 150.7 KB
+
+### 2026-03-21 18:30 - Committed
+
+Files changed:
+- `app/assets/bundle-widget-product-page.js`
+- `extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js`
+
+## Phases Checklist
+- [x] Fix renderProductPageLayout
+- [x] Fix buildCartItems
+- [x] Build widget bundle
+- [ ] Deploy + verify on storefront (manual step)

--- a/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
@@ -2220,7 +2220,7 @@ class BundleWidgetProductPage {
         const selectedEntries = Object.entries(stepSelections).filter(([, qty]) => qty > 0);
 
         if (selectedEntries.length > 0) {
-          const products = this.stepProductData[stepIndex] || [];
+          const products = this.expandProductsByVariant(this.stepProductData[stepIndex] || []);
           selectedEntries.forEach(([variantId, qty]) => {
             const product = products.find(p => (p.variantId || p.id) === variantId);
             if (product) {
@@ -3847,7 +3847,7 @@ class BundleWidgetProductPage {
     const unavailableProducts = []; // Track unavailable products
 
     this.selectedProducts.forEach((stepSelections, stepIndex) => {
-      const productsInStep = this.stepProductData[stepIndex];
+      const productsInStep = this.expandProductsByVariant(this.stepProductData[stepIndex] || []);
 
       Object.entries(stepSelections).forEach(([variantId, quantity]) => {
         if (quantity > 0) {
@@ -3859,9 +3859,8 @@ class BundleWidgetProductPage {
               return; // Skip this product
             }
 
-
-            // Use selected variant ID; fall back to first variant for single-variant products.
-            const actualVariantId = product.variantId ?? product.variants?.[0]?.id;
+            // variantId is already the user-selected variant ID from selectedProducts
+            const actualVariantId = variantId;
 
             const step = this.selectedBundle.steps[stepIndex];
             const properties = {


### PR DESCRIPTION
renderProductPageLayout and buildCartItems both used raw stepProductData (default variant only) to look up selected products. When a non-default variant was chosen via the modal, the find failed silently — state cards didn't render and the variant wasn't added to cart.

Fix: expand products via expandProductsByVariant() before the find in both places, matching the same expansion the modal already uses. Also use `variantId` (the key from selectedProducts) directly as actualVariantId in buildCartItems so the correct variant is always sent to Shopify /cart/add.js regardless of which variant was selected.

This resolves both symptoms:
- Only 1 state card shown instead of 3 after completing all steps
- Pre-selected products appearing in modal after clearing state cards (stale state)