### PR TITLE
chore: Update package dependencies and widget version

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -136,7 +136,9 @@
       "mcp__shopify-dev-mcp__validate_component_codeblocks",
       "Bash(ls:*)",
       "Bash(npm view:*)",
-      "Bash(npm audit:*)"
+      "Bash(npm audit:*)",
+      "mcp__chrome-devtools__evaluate_script",
+      "mcp__chrome-devtools__take_screenshot"
     ],
     "deny": []
   }

--- a/docs/issues-prod/ppb-state-card-cart-bugs-1.md
+++ b/docs/issues-prod/ppb-state-card-cart-bugs-1.md
@@ -1,0 +1,62 @@
+# Issue: PPB State Cards & Cart Bugs
+
+**Issue ID:** ppb-state-card-cart-bugs-1
+**Status:** In Progress
+**Priority:** 🔴 High
+**Created:** 2026-03-23
+**Last Updated:** 2026-03-23 12:00
+
+## Overview
+Three interrelated bugs in the Product Page Bundle (PPB) widget caused by the deployed
+bundled JS file missing `expandProductsByVariant()` calls in `renderProductPageLayout()`
+and `buildCartItems()`.
+
+### Bug 1: Wrong pricing in cart
+Only 1 product gets added to cart instead of all 3 selected bundle products. The
+`buildCartItems()` method looks up variant IDs in raw `stepProductData` (which stores
+products with their default variant ID). When a user selects a non-default variant,
+the lookup fails silently and that product is skipped.
+
+### Bug 2: Only 1 state card shown after completing all steps
+`renderProductPageLayout()` similarly looks up selected variant IDs in raw
+`stepProductData`. Only step 0's default variant matches; steps 1 and 2 fail silently
+with no card appended.
+
+### Bug 3: Stale pricing in modal after removing state card product
+This is a downstream consequence of Bug 2. Since only 1 state card renders, removing
+it clears step 0 but leaves steps 1 and 2 selections intact (invisible). Reopening the
+modal shows the remaining selections in the pricing pill.
+
+## Root Cause
+The **source code** (`app/assets/bundle-widget-product-page.js`) already contains the
+fixes — both `renderProductPageLayout()` and `buildCartItems()` call
+`expandProductsByVariant()`. The **local bundled file** also has these fixes. But the
+**deployed CDN version** (Shopify extension) does NOT — it was never redeployed after
+the fix was applied.
+
+Additionally, the `WIDGET_VERSION` was not bumped when the fix was added, so the CDN
+version and local version both show `2.3.0` despite different code.
+
+## Fix
+1. Bump `WIDGET_VERSION` to `2.3.1` (bug fix)
+2. Rebuild widget bundles
+3. Deploy to Shopify
+
+## Progress Log
+
+### 2026-03-23 12:00 - Investigation Complete
+- Verified all 3 bugs on live store (parth-boss.myshopify.com)
+- Traced root cause to missing `expandProductsByVariant()` calls in deployed bundled JS
+- Confirmed local source and bundled files already have the fix
+- CDN version (v2.3.0) is stale — needs redeploy with version bump
+
+### 2026-03-23 12:00 - Applying Fix
+- Bumping WIDGET_VERSION to 2.3.1
+- Rebuilding widget bundles
+- Files changed: scripts/build-widget-bundles.js, extensions/bundle-builder/assets/
+
+## Phases Checklist
+- [x] Phase 1: Reproduce and verify all 3 bugs
+- [x] Phase 2: Identify root cause
+- [x] Phase 3: Bump version (2.3.0 → 2.3.1), rebuild bundles
+- [ ] Phase 4: Deploy to Shopify (manual — `shopify app deploy`)

--- a/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
@@ -1,13 +1,13 @@
 /*!
  * Wolfpack Bundle Widget — Full Page
- * Version : 2.3.0
- * Built   : 2026-03-20
+ * Version : 2.3.1
+ * Built   : 2026-03-22
  *
  * Cache note: Shopify CDN cache is busted automatically by shopify app deploy.
  * After deploying, allow 2-10 minutes for propagation before testing.
  * Verify live version: console.log(window.__BUNDLE_WIDGET_VERSION__)
  */
-window.__BUNDLE_WIDGET_VERSION__ = '2.3.0';
+window.__BUNDLE_WIDGET_VERSION__ = '2.3.1';
 (function() {
   'use strict';
 

--- a/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
@@ -1,13 +1,13 @@
 /*!
  * Wolfpack Bundle Widget — Product Page
- * Version : 2.3.0
- * Built   : 2026-03-20
+ * Version : 2.3.1
+ * Built   : 2026-03-22
  *
  * Cache note: Shopify CDN cache is busted automatically by shopify app deploy.
  * After deploying, allow 2-10 minutes for propagation before testing.
  * Verify live version: console.log(window.__BUNDLE_WIDGET_VERSION__)
  */
-window.__BUNDLE_WIDGET_VERSION__ = '2.3.0';
+window.__BUNDLE_WIDGET_VERSION__ = '2.3.1';
 (function() {
   'use strict';
 

--- a/extensions/bundle-checkout-ui/shopify.d.ts
+++ b/extensions/bundle-checkout-ui/shopify.d.ts
@@ -1,19 +1,5 @@
 import '@shopify/ui-extensions';
 
-// Shopify UI Extensions custom web components used in Checkout.tsx
-// Declare these custom elements in the global JSX namespace so both the root
-// tsconfig (react-jsx) and the extension tsconfig (preact) accept them.
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      's-stack': { [key: string]: any };
-      's-text': { [key: string]: any };
-      's-divider': { [key: string]: any };
-      's-clickable': { [key: string]: any };
-    }
-  }
-}
-
 //@ts-ignore
 declare module './src/index.tsx' {
   const shopify:

--- a/extensions/wolfpack-utm-pixel/shopify.extension.toml
+++ b/extensions/wolfpack-utm-pixel/shopify.extension.toml
@@ -1,4 +1,5 @@
 name = "wolfpack-utm-pixel"
+uid = "9c39afc7-f730-af5d-e507-823597e5186693eb73cf"
 type = "web_pixel_extension"
 
 runtime_context = "strict"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@shopify/shopify-app-session-storage-prisma": "^6.0.0",
         "@tailwindcss/postcss": "^4.1.12",
         "autoprefixer": "^10.4.21",
+        "chrome-devtools-mcp": "^0.20.3",
         "crisp-sdk-web": "^1.0.25",
         "dotenv": "^17.2.1",
         "graphql-request": "^7.2.0",
@@ -216,7 +217,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3485,7 +3485,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3599,7 +3598,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
       "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -4850,7 +4848,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -4887,7 +4884,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4908,7 +4904,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4929,7 +4924,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4950,7 +4944,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4971,7 +4964,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4992,7 +4984,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5013,7 +5004,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5034,7 +5024,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5055,7 +5044,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5076,7 +5064,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5097,7 +5084,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5118,7 +5104,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5139,7 +5124,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5168,7 +5152,6 @@
       "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.6.1.tgz",
       "integrity": "sha512-Gp3DI1T/0YyirwJnImR8l9xyVJgKiVzJXmEhic1/7SPw3zStrsvuBpwKnD609CzsIdzxprWa6yTNXN+VLLZPGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@preact/signals-core": "^1.12.2"
       },
@@ -5207,7 +5190,6 @@
       "integrity": "sha512-8E/Nk3eL5g7RQIg/LUj1ICyDmhD053STjxrPxUtCRybs2s/2sOEcx9NpITuAOPn07HEpWBfhAVe1T/HYWXUPOw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -5395,7 +5377,6 @@
       "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.17.4.tgz",
       "integrity": "sha512-El7r5W6ErX9KIy27+urbc4SIZnIlVDgTOUqzA7Zbv7caKYrsvgj/Z3i/LPy4VNfv0G1EdawPOrygJgIKT4r2FA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.8",
         "@babel/generator": "^7.21.5",
@@ -5592,7 +5573,6 @@
       "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.4.tgz",
       "integrity": "sha512-9A29JaYiGHDEmaiQuD1IlO/TrQxnnkj98GpytihU+Nz6yTt6RwzzyMMqTAoasRd1dPD4OeSaSqbwkcim/eE76Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/server-runtime": "2.17.4",
         "@remix-run/web-fetch": "^4.4.2",
@@ -5619,7 +5599,6 @@
       "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.17.4.tgz",
       "integrity": "sha512-MeXHacIBoohr9jzec5j/Rmk57xk34korkPDDb0OPHgkdvh20lO5fJoSAcnZfjTIOH+Vsq1ZRQlmvG5PRQ/64Sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.23.2",
         "@remix-run/server-runtime": "2.17.4",
@@ -5646,7 +5625,6 @@
       "resolved": "https://registry.npmjs.org/@remix-run/route-config/-/route-config-2.17.2.tgz",
       "integrity": "sha512-ptHK+6bS/jCV0zygj6Ufn4VRiXIHaG+ex3w+x+v/Uec/xBBChF8rXt0hfcGJ5AoC9v6HJUgbo7+F7Cjs0hONMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -5677,7 +5655,6 @@
       "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.17.4.tgz",
       "integrity": "sha512-c632agTDib70cytmxMVqSbBMlhFKawcg5048yZZK/qeP2AmUweM7OY6Ivgcmv/pgjLXYOu17UBKhtGU8T5y8cQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/express": "2.17.4",
         "@remix-run/node": "2.17.4",
@@ -6205,7 +6182,6 @@
       "resolved": "https://registry.npmjs.org/@shopify/polaris/-/polaris-12.27.0.tgz",
       "integrity": "sha512-Y8yus6iEjcfW2ZtEJtlqxbWeDJqTX3S/MOLH4GWRvU5gFYJQhlaHaETs0+OimbhEpO95mXbY8qB+KnIJaVBHwA==",
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "@shopify/polaris-icons": "^8.11.1",
         "@shopify/polaris-tokens": "^8.10.0",
@@ -6333,7 +6309,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
       "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -6396,7 +6371,6 @@
       "resolved": "https://registry.npmjs.org/@shopify/shopify-api/-/shopify-api-11.14.1.tgz",
       "integrity": "sha512-5VyQZyNhMN2PJLosA6OytYL1ENmdpqslcTcr1jFjGn6sEuxhXtLav+I74ygdL2iTdjEud4aDBZycgDVxPIH+uw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@shopify/admin-api-client": "^1.1.1",
         "@shopify/graphql-client": "^1.4.1",
@@ -6445,7 +6419,6 @@
       "resolved": "https://registry.npmjs.org/@shopify/shopify-app-session-storage/-/shopify-app-session-storage-3.0.20.tgz",
       "integrity": "sha512-qgO3XCi81EkLumXDVS5MgaKeLBsezJVKaS/QHjRQvLI1XsNaFlH+xguZOIFo6cqVjBCKoBplaQAJX3w9LBdc/Q==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@shopify/shopify-api": "^11.0.0"
       }
@@ -7051,8 +7024,7 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
       "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai-subset": {
       "version": "1.3.6",
@@ -7333,7 +7305,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
       "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -7385,7 +7356,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -7476,7 +7446,6 @@
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -7512,7 +7481,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -8388,7 +8356,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9200,7 +9167,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9723,6 +9689,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chrome-devtools-mcp": {
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-0.20.3.tgz",
+      "integrity": "sha512-6MlNKlKa+J1FX9w4SUnFERF4MRGWLlrnZvIJGhhsuuMPM7qUG0F4SwheRyjwl0+tsTemxMCBHiib8mXkg5j6og==",
+      "license": "Apache-2.0",
+      "bin": {
+        "chrome-devtools": "build/src/bin/chrome-devtools.js",
+        "chrome-devtools-mcp": "build/src/bin/chrome-devtools-mcp.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/ci-info": {
@@ -11303,7 +11282,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12370,7 +12348,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -13251,7 +13228,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -14809,7 +14785,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -16034,7 +16009,6 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
       "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -18713,7 +18687,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -18971,7 +18944,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -19169,7 +19141,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
       "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -19250,7 +19221,6 @@
       "integrity": "sha512-QEuCwxu+Uq9BffFw7in8In+WfbSUN0ewnaSUKloLkbJd42w6EyFckux4M0f7VwwHlM3A8ssaz4OyniCXlsn0WA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.14.0",
         "@prisma/engines": "6.14.0"
@@ -19567,7 +19537,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19580,7 +19549,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -19599,15 +19567,13 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -19883,8 +19849,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -21653,7 +21618,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22522,7 +22486,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23121,7 +23084,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -23653,7 +23615,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24534,7 +24495,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@shopify/shopify-app-session-storage-prisma": "^6.0.0",
     "@tailwindcss/postcss": "^4.1.12",
     "autoprefixer": "^10.4.21",
+    "chrome-devtools-mcp": "^0.20.3",
     "crisp-sdk-web": "^1.0.25",
     "dotenv": "^17.2.1",
     "graphql-request": "^7.2.0",

--- a/scripts/build-widget-bundles.js
+++ b/scripts/build-widget-bundles.js
@@ -36,7 +36,7 @@ const ROOT_DIR = join(__dirname, '..');
 // Verify live version in browser DevTools on the storefront:
 //   console.log(window.__BUNDLE_WIDGET_VERSION__)
 // ---------------------------------------------------------------------------
-const WIDGET_VERSION = '2.3.0';
+const WIDGET_VERSION = '2.3.1';
 
 // Shared component modules (in dependency order)
 const SHARED_MODULES = [


### PR DESCRIPTION
- Added "chrome-devtools-mcp" dependency to package.json and package-lock.json.
- Updated widget version to 2.3.1 in bundle-widget-full-page-bundled.js and bundle-widget-product-page-bundled.js.
- Modified settings.local.json to include new Chrome DevTools commands for script evaluation and screenshot capture.
- Updated shopify.extension.toml with a new unique identifier for the wolfpack-utm-pixel extension.
- Removed unused TypeScript declarations in shopify.d.ts.
- Updated build-widget-bundles.js to reflect the new widget version.