### PR TITLE
[default-product-bugs-fix-1] fix: Default product seeding, removal gu…

### DIFF
--- a/app/assets/bundle-widget-product-page.js
+++ b/app/assets/bundle-widget-product-page.js
@@ -351,15 +351,15 @@ class BundleWidgetProductPage {
     this.stepProductData = Array(stepsCount).fill(null).map(() => ([]));
     this._stepFetchFailed = {};
 
-    // Pre-mark default steps as complete using a sentinel variant ID
-    // (default products are always included in the bundle — no user selection required)
-    if (this.widgetStyle === 'bottom-sheet') {
-      this.selectedBundle.steps.forEach((step, i) => {
-        if (step.isDefault && step.defaultVariantId) {
-          this.selectedProducts[i][step.defaultVariantId] = 1;
-        }
-      });
-    }
+    // Seed default steps into selectedProducts regardless of widget style.
+    // Default products are always included in the bundle — no user selection required.
+    // buildCartItems() reads selectedProducts, so without this the default item is
+    // silently excluded from the cart payload on classic modal style bundles.
+    this.selectedBundle.steps.forEach((step, i) => {
+      if (step.isDefault && step.defaultVariantId) {
+        this.selectedProducts[i][step.defaultVariantId] = 1;
+      }
+    });
   }
 
   /**
@@ -1122,6 +1122,10 @@ class BundleWidgetProductPage {
 
   // Remove a specific product from selection (decrease quantity by 1)
   removeProductFromSelection(stepIndex, variantId) {
+    // Guard: default products are compulsory — they must always stay in selectedProducts
+    const step = this.selectedBundle?.steps[stepIndex];
+    if (step?.isDefault && step?.defaultVariantId === variantId) return;
+
     const currentQuantity = this.selectedProducts[stepIndex][variantId] || 0;
 
     if (currentQuantity > 1) {

--- a/docs/issues-prod/default-product-bugs-fix-1.md
+++ b/docs/issues-prod/default-product-bugs-fix-1.md
@@ -1,0 +1,53 @@
+# Issue: Default Product Critical Bug Fixes
+
+**Issue ID:** default-product-bugs-fix-1
+**Status:** Completed
+**Priority:** 🔴 High
+**Created:** 2026-04-01
+**Last Updated:** 2026-04-01 01:30
+
+## Overview
+
+Audit of the default product/default step implementation identified 3 bugs:
+
+- **Bug #1 (CRITICAL)**: PPB `initializeDataStructures()` only seeds default products when
+  `widgetStyle === 'bottom-sheet'`. Classic modal style never populates `selectedProducts`
+  for the default step → default product silently excluded from cart.
+- **Bug #2 (Medium)**: `removeProductFromSelection()` has no guard against removing default
+  products — a future code path or edge case can silently wipe the pre-seeded default from
+  `selectedProducts`.
+- **Bug #3 (Low)**: Cart transform has no `isDefaultLine()` utility function (behavior is
+  correct, code clarity only).
+
+## Phases Checklist
+
+- [x] Phase 1: Fix Bug #1 — remove widgetStyle guard from default product seeding ✅
+- [x] Phase 2: Fix Bug #2 — guard removeProductFromSelection() against default products ✅
+- [x] Phase 3: Fix Bug #3 — add isDefaultLine() to cart transform for code clarity ✅
+- [x] Phase 4: Build + lint + commit ✅
+
+## Progress Log
+
+### 2026-04-01 01:00 - All Phases Completed
+
+**Bug #1 — PPB classic modal: default product excluded from cart**
+- ✅ Removed `if (this.widgetStyle === 'bottom-sheet')` guard from default product seeding
+- Default variant ID now always seeded into `selectedProducts[i]` regardless of widget style
+- File: `app/assets/bundle-widget-product-page.js` (line ~354)
+
+**Bug #2 — removeProductFromSelection() can wipe default products**
+- ✅ Added guard at start of method: returns immediately when `step.isDefault && step.defaultVariantId === variantId`
+- File: `app/assets/bundle-widget-product-page.js` (line ~1124)
+
+**Bug #3 — Cart transform: no isDefaultLine() utility**
+- ✅ Added `isDefaultLine()` function alongside `isFreeGiftLine()` for code clarity
+- Default lines are correctly treated as paid items (behavior unchanged)
+- File: `extensions/bundle-cart-transform-ts/src/cart_transform_run.ts`
+
+- ✅ ESLint: 0 errors
+- ✅ Widget version bumped: 2.4.5 → 2.4.6
+- ✅ `npm run build:widgets` — full-page 253.8 KB, product-page 153.7 KB
+- ✅ CSS sizes: 96,061 B (under 100,000 B limit)
+- ✅ Cart transform WASM: Function built successfully
+
+**Status:** Completed. Deploy + Sync Bundle on affected bundles.

--- a/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
@@ -1,13 +1,13 @@
 /*!
  * Wolfpack Bundle Widget — Full Page
- * Version : 2.4.5
+ * Version : 2.4.6
  * Built   : 2026-03-31
  *
  * Cache note: Shopify CDN cache is busted automatically by shopify app deploy.
  * After deploying, allow 2-10 minutes for propagation before testing.
  * Verify live version: console.log(window.__BUNDLE_WIDGET_VERSION__)
  */
-window.__BUNDLE_WIDGET_VERSION__ = '2.4.5';
+window.__BUNDLE_WIDGET_VERSION__ = '2.4.6';
 (function() {
   'use strict';
 

--- a/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
@@ -1,13 +1,13 @@
 /*!
  * Wolfpack Bundle Widget — Product Page
- * Version : 2.4.5
+ * Version : 2.4.6
  * Built   : 2026-03-31
  *
  * Cache note: Shopify CDN cache is busted automatically by shopify app deploy.
  * After deploying, allow 2-10 minutes for propagation before testing.
  * Verify live version: console.log(window.__BUNDLE_WIDGET_VERSION__)
  */
-window.__BUNDLE_WIDGET_VERSION__ = '2.4.5';
+window.__BUNDLE_WIDGET_VERSION__ = '2.4.6';
 (function() {
   'use strict';
 
@@ -1859,15 +1859,15 @@ class BundleWidgetProductPage {
     this.stepProductData = Array(stepsCount).fill(null).map(() => ([]));
     this._stepFetchFailed = {};
 
-    // Pre-mark default steps as complete using a sentinel variant ID
-    // (default products are always included in the bundle — no user selection required)
-    if (this.widgetStyle === 'bottom-sheet') {
-      this.selectedBundle.steps.forEach((step, i) => {
-        if (step.isDefault && step.defaultVariantId) {
-          this.selectedProducts[i][step.defaultVariantId] = 1;
-        }
-      });
-    }
+    // Seed default steps into selectedProducts regardless of widget style.
+    // Default products are always included in the bundle — no user selection required.
+    // buildCartItems() reads selectedProducts, so without this the default item is
+    // silently excluded from the cart payload on classic modal style bundles.
+    this.selectedBundle.steps.forEach((step, i) => {
+      if (step.isDefault && step.defaultVariantId) {
+        this.selectedProducts[i][step.defaultVariantId] = 1;
+      }
+    });
   }
 
   /**
@@ -2630,6 +2630,10 @@ class BundleWidgetProductPage {
 
   // Remove a specific product from selection (decrease quantity by 1)
   removeProductFromSelection(stepIndex, variantId) {
+    // Guard: default products are compulsory — they must always stay in selectedProducts
+    const step = this.selectedBundle?.steps[stepIndex];
+    if (step?.isDefault && step?.defaultVariantId === variantId) return;
+
     const currentQuantity = this.selectedProducts[stepIndex][variantId] || 0;
 
     if (currentQuantity > 1) {

--- a/extensions/bundle-cart-transform-ts/src/cart_transform_run.ts
+++ b/extensions/bundle-cart-transform-ts/src/cart_transform_run.ts
@@ -180,6 +180,16 @@ function isFreeGiftLine(line: CartTransformInput['cart']['lines'][number]): bool
 }
 
 /**
+ * Returns true when the cart line is a default (compulsory) component.
+ * The widget sets `_bundle_step_type: default` on the line properties for default steps.
+ * Default lines are treated as paid items (they contribute to paidTotal and discount
+ * thresholds) — this function exists for logging clarity and future conditional logic.
+ */
+function isDefaultLine(line: CartTransformInput['cart']['lines'][number]): boolean {
+  return line.stepType?.value === 'default';
+}
+
+/**
  * Calculate discount percentage from price adjustment config.
  *
  * paidTotal:     sum of component line costs that are NOT free-gift lines (presentment currency)

--- a/scripts/build-widget-bundles.js
+++ b/scripts/build-widget-bundles.js
@@ -36,7 +36,7 @@ const ROOT_DIR = join(__dirname, '..');
 // Verify live version in browser DevTools on the storefront:
 //   console.log(window.__BUNDLE_WIDGET_VERSION__)
 // ---------------------------------------------------------------------------
-const WIDGET_VERSION = '2.4.5';
+const WIDGET_VERSION = '2.4.6';
 
 // Shared component modules (in dependency order)
 const SHARED_MODULES = [


### PR DESCRIPTION
…ard, and cart transform clarity

Bug #1: initializeDataStructures() now seeds default products into selectedProducts for ALL widget styles, not only bottom-sheet. Classic modal PPBs with a default step were silently excluding the compulsory product from the cart payload.

Bug #2: removeProductFromSelection() returns early when the target variantId belongs to a default step, preventing accidental removal of compulsory items.

Bug #3: Added isDefaultLine() to cart_transform_run.ts alongside isFreeGiftLine() for code symmetry. Default lines remain in paidTotal (correct behavior — they are mandatory paid items).

Widget 2.4.5 → 2.4.6. Cart transform and both widget bundles rebuilt.