### PR TITLE
[fpb-widget-free-gift-footer-bugs-1] fix: Show total product count in…

### DIFF
--- a/app/assets/bundle-widget-full-page.js
+++ b/app/assets/bundle-widget-full-page.js
@@ -2232,9 +2232,13 @@ class BundleWidgetFullPage {
     const toggleBtn = document.createElement('button');
     toggleBtn.className = 'footer-toggle';
     toggleBtn.setAttribute('type', 'button');
-    const showStepsCounter = !this.bundleHasNoConditions();
+    const hasConditions = !this.bundleHasNoConditions();
+    const totalSelected = allSelectedProducts.filter(p => !p.isDefault).length;
+    const toggleText = hasConditions
+      ? `${totalQuantity}/${totalRequired} Steps`
+      : `${totalSelected} Product${totalSelected !== 1 ? 's' : ''}`;
     toggleBtn.innerHTML = `
-      ${showStepsCounter ? `<span class="footer-toggle-text">${totalQuantity}/${totalRequired} Steps</span>` : ''}
+      <span class="footer-toggle-text">${toggleText}</span>
       <svg class="footer-chevron" viewBox="0 0 20 20" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5">
         <path d="M5 8l5 5 5-5"/>
       </svg>

--- a/docs/issues-prod/fpb-widget-free-gift-footer-bugs-1.md
+++ b/docs/issues-prod/fpb-widget-free-gift-footer-bugs-1.md
@@ -4,7 +4,7 @@
 **Status:** Completed
 **Priority:** 🟡 Medium
 **Created:** 2026-04-02
-**Last Updated:** 2026-04-02 14:30
+**Last Updated:** 2026-04-02 14:45
 
 ## Overview
 SIT QA session on `test-bundle-store123.myshopify.com/pages/preview-564` surfaced four bugs
@@ -44,7 +44,7 @@ Two locations hardcode the dollar sign instead of using `CurrencyManager.convert
 ## Progress Log
 
 ### 2026-04-02 14:30 - Completed all four fixes
-- ✅ Bug 1 + 2: `_createFooterBar()` — counter hidden when `bundleHasNoConditions()` is true; label renamed "Products" → "Steps"
+- ✅ Bug 1 + 2: `_createFooterBar()` — conditionless bundles show `N Products` (total count, no denominator); bundles with conditions show `N/M Steps`
 - ✅ Bug 3: `renderFullPageFooter()` — `totalRequired` now skips `isFreeGift` and `isDefault` steps
 - ✅ Bug 4: Product card (line ~1964) — replaced hardcoded `$0.00` with `CurrencyManager.convertAndFormat(0, _ci)`
 - ✅ Bug 4: Side panel row (line ~1119) — replaced hardcoded `$0.00` with `CurrencyManager.convertAndFormat(0, currencyInfo)`

--- a/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
@@ -4675,9 +4675,13 @@ class BundleWidgetFullPage {
     const toggleBtn = document.createElement('button');
     toggleBtn.className = 'footer-toggle';
     toggleBtn.setAttribute('type', 'button');
-    const showStepsCounter = !this.bundleHasNoConditions();
+    const hasConditions = !this.bundleHasNoConditions();
+    const totalSelected = allSelectedProducts.filter(p => !p.isDefault).length;
+    const toggleText = hasConditions
+      ? `${totalQuantity}/${totalRequired} Steps`
+      : `${totalSelected} Product${totalSelected !== 1 ? 's' : ''}`;
     toggleBtn.innerHTML = `
-      ${showStepsCounter ? `<span class="footer-toggle-text">${totalQuantity}/${totalRequired} Steps</span>` : ''}
+      <span class="footer-toggle-text">${toggleText}</span>
       <svg class="footer-chevron" viewBox="0 0 20 20" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5">
         <path d="M5 8l5 5 5-5"/>
       </svg>


### PR DESCRIPTION
… footer for conditionless bundles

Conditionless bundles now show "N Products" (just the count) in the footer toggle. Bundles with step conditions continue to show "N/M Steps".