### PR TITLE
[sync-bundle-no-page-1] fix: Allow Sync Bundle when shopifyPageId is …

### DIFF
--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/handlers.server.ts
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/handlers.server.ts
@@ -1005,40 +1005,38 @@ export async function handleSyncBundle(admin: ShopifyAdmin, session: Session, bu
       return json({ success: false, error: 'Bundle not found' }, { status: 404 });
     }
 
-    if (!bundle.shopifyPageId) {
-      return json({
-        success: false,
-        error: 'Bundle has no Shopify page — save the bundle first to create a page',
-      }, { status: 400 });
-    }
-
-    // 2. Delete Shopify page
-    const DELETE_PAGE = `
-      mutation DeletePage($id: ID!) {
-        pageDelete(id: $id) {
-          deletedPageId
-          userErrors { field message }
+    // 2. Delete existing Shopify page (only if one exists — bundles without a page skip
+    //    straight to creation, which fixes broken/migrated records in a single sync).
+    if (bundle.shopifyPageId) {
+      const DELETE_PAGE = `
+        mutation DeletePage($id: ID!) {
+          pageDelete(id: $id) {
+            deletedPageId
+            userErrors { field message }
+          }
         }
+      `;
+
+      const deleteResponse = await admin.graphql(DELETE_PAGE, {
+        variables: { id: bundle.shopifyPageId },
+      });
+      const deleteData = await deleteResponse.json();
+
+      if (deleteData.data?.pageDelete?.userErrors?.length > 0) {
+        const err = deleteData.data.pageDelete.userErrors[0];
+        return json({ success: false, error: `Failed to delete Shopify page: ${err.message}` }, { status: 400 });
       }
-    `;
 
-    const deleteResponse = await admin.graphql(DELETE_PAGE, {
-      variables: { id: bundle.shopifyPageId },
-    });
-    const deleteData = await deleteResponse.json();
+      AppLogger.info('[SYNC_BUNDLE] Shopify page deleted', { bundleId, pageId: bundle.shopifyPageId });
 
-    if (deleteData.data?.pageDelete?.userErrors?.length > 0) {
-      const err = deleteData.data.pageDelete.userErrors[0];
-      return json({ success: false, error: `Failed to delete Shopify page: ${err.message}` }, { status: 400 });
+      // 3. Clear page reference from DB so createFullPageBundle will create a fresh page
+      await db.bundle.update({
+        where: { id: bundleId },
+        data: { shopifyPageId: null, shopifyPageHandle: null },
+      });
+    } else {
+      AppLogger.info('[SYNC_BUNDLE] No existing Shopify page — proceeding to create one', { bundleId });
     }
-
-    AppLogger.info('[SYNC_BUNDLE] Shopify page deleted', { bundleId, pageId: bundle.shopifyPageId });
-
-    // 3. Clear page reference from DB so createFullPageBundle will create a fresh page
-    await db.bundle.update({
-      where: { id: bundleId },
-      data: { shopifyPageId: null, shopifyPageHandle: null },
-    });
 
     // 4. Re-create the Shopify page via WidgetInstallationService
     const apiKey = process.env.SHOPIFY_API_KEY || '';

--- a/docs/issues-prod/sync-bundle-no-page-1.md
+++ b/docs/issues-prod/sync-bundle-no-page-1.md
@@ -1,0 +1,42 @@
+# Issue: Sync Bundle Fails When shopifyPageId Is Null
+
+**Issue ID:** sync-bundle-no-page-1
+**Status:** Completed
+**Priority:** 🔴 High
+**Created:** 2026-04-02
+**Last Updated:** 2026-04-02 14:05
+
+## Overview
+"Sync Bundle" returns a 400 toast error — "Bundle has no Shopify page — save the bundle
+first to create a page" — for any bundle whose `shopifyPageId` is null in the database.
+
+This affects:
+- Bundles created in SIT/PROD that never had a page (e.g. migrated records)
+- Any bundle where `shopifyPageId` was cleared without a corresponding page being created
+
+## Root Cause
+`handleSyncBundle` hard-guards at line 1008 with `if (!bundle.shopifyPageId) return 400`.
+The intent was to prevent the delete-then-recreate page flow from running when there's
+nothing to delete. But the guard is too broad: it blocks the entire sync, including the
+page creation step that would fix the missing page.
+
+**Fix:** Make the page deletion conditional (`if (bundle.shopifyPageId)`). When there's
+no page, skip straight to the page-creation step (step 4). The rest of the sync
+(metafields, product creation) is unchanged.
+
+## Progress Log
+
+### 2026-04-02 14:05 - Completed
+- ✅ Removed hard `if (!bundle.shopifyPageId) return 400` guard
+- ✅ Wrapped page delete + DB clear in `if (bundle.shopifyPageId)` block
+- ✅ Added `else` log: "No existing Shopify page — proceeding to create one"
+- ✅ Lint: 0 errors
+- ✅ Committed
+
+## Files to Change
+- `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/handlers.server.ts`
+
+## Phases Checklist
+- [x] Remove hard guard; make page delete conditional
+- [x] Lint
+- [x] Commit


### PR DESCRIPTION
…null

Remove hard guard that returned 400 for bundles with no page. Page delete is now conditional; missing-page bundles skip straight to creation, fixing sync for migrated/broken records in one click.