### PR TITLE
[unlisted-bundle-widget-fix-1] fix: Render unlisted bundles and stop …

### DIFF
--- a/app/assets/widgets/shared/bundle-data-manager.js
+++ b/app/assets/widgets/shared/bundle-data-manager.js
@@ -123,7 +123,8 @@ export class BundleDataManager {
     }
 
     const bundles = Object.values(bundlesData).filter(bundle =>
-      this.validateSingleBundle(bundle) && bundle.status === 'active'
+      this.validateSingleBundle(bundle) &&
+      (bundle.status === 'active' || bundle.status === 'unlisted')
     );
 
     if (bundles.length === 0) {

--- a/app/services/widget-installation/widget-full-page-bundle.server.ts
+++ b/app/services/widget-installation/widget-full-page-bundle.server.ts
@@ -8,7 +8,6 @@
 import { AppLogger } from "../../lib/logger";
 import { ensurePageBundleIdMetafieldDefinition, ensureCustomPageBundleIdDefinition, ensureCustomPageBundleConfigDefinition } from "../bundles/metafield-sync.server";
 import { formatBundleForWidget } from "../../lib/bundle-formatter.server";
-import { ensureBundlePageTemplate } from "./widget-theme-template.server";
 import { generateThemeEditorDeepLink } from "./widget-theme-editor-links.server";
 import { slugify, resolveUniqueHandle } from "../../lib/slug-utils";
 import type { FullPageBundleResult } from "./types";
@@ -52,21 +51,12 @@ export async function createFullPageBundle(
       bundleName
     });
 
-    // Step 0: Ensure the bundle page template exists in the active theme
-    const templateResult = await ensureBundlePageTemplate(admin, session, apiKey);
-
-    if (!templateResult.success) {
-      AppLogger.warn('Could not ensure bundle page template (non-fatal)', {
-        component: 'WidgetFullPageBundle',
-        error: templateResult.error
-      });
-    }
-
-    // Always attach the templateSuffix regardless of whether the template file was
-    // just created or already existed. The suffix tells Shopify to serve this page
-    // using templates/page.full-page-bundle.json. Even if that template write failed
-    // above (unlikely now that UUID comes from EXTENSION_UID), the suffix ensures
-    // the page uses the right template as soon as the file exists in the theme.
+    // FPB pages are served via URL redirect (/products/{handle} → /pages/{handle}).
+    // The redirect fires before Shopify's theme engine renders any template, so
+    // templateSuffix is meaningless for routing. We intentionally do NOT call
+    // ensureBundlePageTemplate / themeFilesUpsert here — that API requires a Shopify
+    // exemption that disqualifies the app from the Built For Shopify badge.
+    // Merchants add the app block to their page template once via the Theme Editor.
     const templateSuffix = 'full-page-bundle';
 
     // Step 1: Resolve page handle — use desiredSlug, fall back to slugified bundle name

--- a/docs/issues-prod/unlisted-bundle-widget-fix-1.md
+++ b/docs/issues-prod/unlisted-bundle-widget-fix-1.md
@@ -1,0 +1,46 @@
+# Issue: Unlisted Bundle Widget & Theme Template API Bugs
+
+**Issue ID:** unlisted-bundle-widget-fix-1
+**Status:** Completed
+**Priority:** 🔴 High
+**Created:** 2026-04-02
+**Last Updated:** 2026-04-02 14:20
+
+## Overview
+Two bugs blocking FPB bundles with Unlisted status from rendering:
+
+### Bug 1: Widget rejects unlisted bundles
+`BundleDataManager.selectBundle` filters by `bundle.status === 'active'` — unlisted bundles
+have `status: 'unlisted'` so they are silently dropped, `selectedBundle` is null, and the
+widget shows "No active bundles found for this product."
+
+### Bug 2: `createFullPageBundle` calls `themeFilesUpsert`
+`createFullPageBundle` still calls `ensureBundlePageTemplate` at Step 0, which writes
+`templates/page.full-page-bundle.json` via `themeFilesUpsert`. This:
+- Fails on SIT with "Access denied for themeFilesUpsert field"
+- Disqualifies the app from the Built For Shopify badge (BFS)
+- Is unnecessary — FPB pages are served via URL redirect, the template never renders
+
+## Fixes
+- **Bug 1**: Accept `'unlisted'` alongside `'active'` in `selectBundle` status filter
+- **Bug 2**: Remove `ensureBundlePageTemplate` call + import from `createFullPageBundle`
+
+## Progress Log
+
+### 2026-04-02 14:20 - Completed
+- ✅ Bug 1: Added `|| bundle.status === 'unlisted'` to `selectBundle` filter in `bundle-data-manager.js`
+- ✅ Bug 2: Removed `ensureBundlePageTemplate` call + import from `createFullPageBundle`; replaced with explanatory comment
+- ✅ Rebuilt widget bundles (`npm run build:widgets`)
+- ✅ Lint: 0 errors
+- ✅ Committed
+
+## Files to Change
+- `app/assets/widgets/shared/bundle-data-manager.js`
+- `app/services/widget-installation/widget-full-page-bundle.server.ts`
+
+## Phases Checklist
+- [x] Fix selectBundle status filter
+- [x] Remove ensureBundlePageTemplate call
+- [x] Rebuild widget bundles
+- [x] Lint
+- [x] Commit

--- a/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
@@ -511,7 +511,8 @@ class BundleDataManager {
     }
 
     const bundles = Object.values(bundlesData).filter(bundle =>
-      this.validateSingleBundle(bundle) && bundle.status === 'active'
+      this.validateSingleBundle(bundle) &&
+      (bundle.status === 'active' || bundle.status === 'unlisted')
     );
 
     if (bundles.length === 0) {

--- a/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
@@ -1,7 +1,7 @@
 /*!
  * Wolfpack Bundle Widget — Product Page
  * Version : 2.4.6
- * Built   : 2026-04-01
+ * Built   : 2026-04-02
  *
  * Cache note: Shopify CDN cache is busted automatically by shopify app deploy.
  * After deploying, allow 2-10 minutes for propagation before testing.
@@ -511,7 +511,8 @@ class BundleDataManager {
     }
 
     const bundles = Object.values(bundlesData).filter(bundle =>
-      this.validateSingleBundle(bundle) && bundle.status === 'active'
+      this.validateSingleBundle(bundle) &&
+      (bundle.status === 'active' || bundle.status === 'unlisted')
     );
 
     if (bundles.length === 0) {


### PR DESCRIPTION
…calling themeFilesUpsert

selectBundle now accepts status 'unlisted' alongside 'active' so Ad Campaign bundles render on the storefront instead of showing the fallback UI.

Removed ensureBundlePageTemplate call from createFullPageBundle — it called themeFilesUpsert which fails on SIT and disqualifies the app from the BFS badge. FPB pages route via URL redirect so the template file is never needed.