### PR TITLE
[unlisted-bundle-widget-fix-1] fix: Remove remaining templateResult r…

### DIFF
--- a/app/services/widget-installation/widget-full-page-bundle.server.ts
+++ b/app/services/widget-installation/widget-full-page-bundle.server.ts
@@ -261,31 +261,7 @@ export async function createFullPageBundle(
       pageId: createdPage.id,
       pageHandle: createdPage.handle,
       pageUrl,
-      templateApplied: templateResult.success
     });
-
-    // If template file write failed (e.g. theme API error), surface a deep link
-    // so the merchant can manually add the block via Theme Editor as a fallback.
-    if (!templateResult.success) {
-      const deepLink = generateThemeEditorDeepLink(
-        shop,
-        apiKey,
-        'bundle-full-page',
-        bundleId,
-        'page',
-        'newAppsSection'
-      );
-
-      return {
-        success: true,
-        pageId: createdPage.id,
-        pageHandle: createdPage.handle,
-        pageUrl,
-        slugAdjusted,
-        widgetInstallationRequired: true,
-        widgetInstallationLink: deepLink.url
-      };
-    }
 
     return {
       success: true,


### PR DESCRIPTION
…eferences after cleanup

Two references to templateResult (log field + success check) were left behind when ensureBundlePageTemplate was removed, causing ReferenceError on Sync Bundle.