### PR TITLE
[embed-block-architecture-1] fix: Shopify extension validation errors…

### DIFF
--- a/extensions/bundle-builder/blocks/bundle-full-page-embed.liquid
+++ b/extensions/bundle-builder/blocks/bundle-full-page-embed.liquid
@@ -105,7 +105,7 @@
 
 {% schema %}
 {
-  "name": "Wolfpack Bundle (Full Page)",
+  "name": "Wolfpack Bundle Full Page",
   "target": "body",
   "enabled_on": {
     "templates": ["page"]

--- a/extensions/bundle-builder/blocks/bundle-product-page-embed.liquid
+++ b/extensions/bundle-builder/blocks/bundle-product-page-embed.liquid
@@ -129,6 +129,7 @@
   .product-add-to-cart:not(.bundle-add-to-cart) {
     display: none !important;
   }
+</style>
 {% endif %}
 
 <script>
@@ -248,7 +249,7 @@
 
 {% schema %}
 {
-  "name": "Wolfpack Bundle (Product Page)",
+  "name": "Wolfpack Bundle (Product)",
   "target": "body",
   "enabled_on": {
     "templates": ["product"]


### PR DESCRIPTION
… in embed blocks

- Add missing </style> closing tag in bundle-product-page-embed.liquid
- Shorten schema names to ≤25 chars (Shopify limit): "Wolfpack Bundle Full Page" and "Wolfpack Bundle (Product)"