### PR TITLE
[embed-block-architecture-1] fix: Remove duplicate apiKey declaration…

### DIFF
--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/handlers.server.ts
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/handlers.server.ts
@@ -1150,7 +1150,6 @@ export async function handleSyncBundle(admin: ShopifyAdmin, session: Session, bu
 
     // Return embed activation link — merchant needs to activate the bundle-full-page-embed
     // embed block once in Theme Settings > App Embeds. After that all bundle pages work.
-    const apiKey = process.env.SHOPIFY_API_KEY || '';
     const shopDomain = session.shop.replace('.myshopify.com', '');
     const widgetInstallationLink = apiKey
       ? `https://${shopDomain}.myshopify.com/admin/themes/current/editor?context=apps&activateAppId=${apiKey}/bundle-full-page-embed`


### PR DESCRIPTION
… in handleSyncBundle

apiKey was already declared at line 1042 (used for createFullPageBundle); the second declaration at line 1153 caused an esbuild duplicate-symbol error.