### PR TITLE
[fpb-empty-main-section-fix-1] fix: Restore bundle-full-page section …

### DIFF
--- a/docs/issues-prod/fpb-empty-main-section-fix-1.md
+++ b/docs/issues-prod/fpb-empty-main-section-fix-1.md
@@ -33,6 +33,15 @@ hide the parent `shopify-section` using `.shopify-section:has(.main-page-title)`
 - Verified via Chrome DevTools: section hidden, widget now flush against navbar
 - No widget rebuild needed (Liquid-only change)
 
+### 2026-04-08 10:30 - Root cause: widget rendering below footer
+- Root cause identified: `bundle-full-page.liquid` (target: section) was deleted in
+  the embed architecture migration (commit a67339d). The theme still references this block.
+- Shopify reports: `app block path "shopify://apps/wolfpack-product-bundles-sit/blocks/bundle-full-page/..." does not exist`
+- The body-level embed (`bundle-full-page-embed.liquid`, target: body) renders after the footer
+- Fix: Restored `extensions/bundle-builder/blocks/bundle-full-page.liquid` as a section block
+  that renders inside <main> (before the footer)
+- Added JS in restored block to hide body-embed duplicate when section block is active
+
 ## Related Documentation
 - `extensions/bundle-builder/blocks/bundle-full-page-embed.liquid`
 

--- a/extensions/bundle-builder/blocks/bundle-full-page.liquid
+++ b/extensions/bundle-builder/blocks/bundle-full-page.liquid
@@ -1,0 +1,312 @@
+{% comment %}
+  Wolfpack Full-Page Bundle — Section Block (target: section)
+  ============================================================
+  This block is added directly to the page template in the theme customizer.
+  It renders the bundle widget INSIDE <main> (before the footer), unlike the
+  body-embed variant (bundle-full-page-embed.liquid) which renders after the footer.
+
+  Bundle ID resolution (priority order):
+  1. page.metafields.custom.bundle_id  — set by app when "Place Widget Now" is used
+  2. block.settings.bundle_id          — manual fallback via Theme Editor
+{% endcomment %}
+
+{% assign bundle_id_from_metafield = page.metafields.custom.bundle_id %}
+{% assign bundle_id_from_setting   = block.settings.bundle_id %}
+
+{% if bundle_id_from_metafield != blank %}
+  {% assign bundle_id = bundle_id_from_metafield %}
+{% elsif bundle_id_from_setting != blank %}
+  {% assign bundle_id = bundle_id_from_setting %}
+{% else %}
+  {% assign bundle_id = nil %}
+{% endif %}
+
+{% assign should_show_widget = false %}
+{% if bundle_id != blank %}
+  {% assign should_show_widget = true %}
+{% endif %}
+
+{% if request.design_mode %}
+  {% assign should_show_widget = true %}
+  {% unless bundle_id != blank %}
+    {% assign bundle_id = 'preview' %}
+  {% endunless %}
+{% endif %}
+
+{% if should_show_widget %}
+  {% comment %} Bundle config metafield — zero-proxy first paint {% endcomment %}
+  {% assign bundle_config_metafield = page.metafields.custom.bundle_config %}
+  {% if bundle_config_metafield.value != blank %}
+    {% assign bundle_config_json = bundle_config_metafield.value | json %}
+  {% else %}
+    {% assign bundle_config_json = 'null' %}
+  {% endif %}
+
+  {% comment %} Build tier config JSON {% endcomment %}
+  {% assign tier_config_json = '[' %}
+  {% assign tier_json_first = true %}
+  {% for i in (1..4) %}
+    {% assign t_label_key   = 'tier_' | append: i | append: '_label' %}
+    {% assign t_id_key      = 'tier_' | append: i | append: '_bundle_id' %}
+    {% assign t_label       = block.settings[t_label_key] %}
+    {% assign t_bundle_id   = block.settings[t_id_key] %}
+    {% if i == 1 and t_bundle_id == blank %}
+      {% assign t_bundle_id = bundle_id %}
+    {% endif %}
+    {% if t_label != blank and t_bundle_id != blank %}
+      {% unless tier_json_first %}
+        {% assign tier_config_json = tier_config_json | append: ',' %}
+      {% endunless %}
+      {% assign tier_json_first = false %}
+      {% assign tier_config_json = tier_config_json | append: '{"label":' | append: t_label | json | append: ',"bundleId":' | append: t_bundle_id | json | append: '}' %}
+    {% endif %}
+  {% endfor %}
+  {% assign tier_config_json = tier_config_json | append: ']' %}
+
+  <div
+    {{ block.shopify_attributes }}
+    id="bundle-builder-app"
+    data-bundle-id="{{ bundle_id }}"
+    data-bundle-type="full_page"
+    data-bundle-config="{{ bundle_config_json | escape }}"
+    data-show-title="{{ block.settings.show_bundle_title }}"
+    data-show-description="{{ block.settings.show_bundle_description }}"
+    data-show-category-tabs="{{ block.settings.show_category_tabs }}"
+    data-custom-title="{{ block.settings.custom_title | escape }}"
+    data-custom-description="{{ block.settings.custom_description | escape }}"
+    data-product-card-spacing="{{ block.settings.product_card_spacing }}"
+    data-product-cards-per-row="{{ block.settings.product_cards_per_row }}"
+    data-show-promo-banner="{{ block.settings.show_promo_banner | default: true }}"
+    data-promo-banner-subtitle="{{ block.settings.promo_banner_subtitle | default: 'Mix & Match' | escape }}"
+    data-promo-banner-tagline="{{ block.settings.promo_banner_tagline | default: 'Create Your Perfect Bundle' | escape }}"
+    data-promo-banner-note="{{ block.settings.promo_banner_note | default: 'Mix & Match Your Favorites' | escape }}"
+    data-tier-config="{{ tier_config_json | escape }}"
+    class="bundle-widget-container bundle-widget-full-page"
+  >
+    <div class="bundle-loading">
+      <div class="loading-spinner"></div>
+    </div>
+  </div>
+
+  {% if block.settings.hide_page_title %}
+  <style>
+    /* Hide the theme's page <h1> — the widget renders its own title */
+    .section-content-wrapper h1,
+    .page__heading h1,
+    .page-title h1,
+    h1.page-title,
+    .page-header h1,
+    .main-page-title { display: none !important; }
+    /* Hide the section wrapper padding that creates a blank gray gap */
+    .shopify-section:has(.main-page-title) { display: none !important; }
+  </style>
+  {% endif %}
+
+  <script>
+    if (!window.bundleWidgetContext) {
+      window.shopCurrency = {{ shop.currency | json }};
+      window.shopMoneyFormat = {{ shop.money_format | json }};
+      window.shopifyMultiCurrency = {
+        shopBaseCurrency: {{ shop.currency | json }},
+        shopMoneyFormat: {{ shop.money_format | json }},
+        customerCurrency: {{ cart.currency.iso_code | json }},
+        customerMoneyFormat: {{ shop.money_format | json }},
+        isMultiCurrencyEnabled: {% if shop.enabled_currencies.size > 1 %}true{% else %}false{% endif %}
+      };
+      window.bundleWidgetContext = true;
+    }
+  </script>
+
+  <script>
+    {% assign app_namespace = '$app' %}
+    {% assign server_url_field = shop.metafields[app_namespace]['serverUrl'] %}
+    window.__BUNDLE_APP_URL__ = {% if server_url_field %}{{ server_url_field.value | json }}{% else %}null{% endif %};
+  </script>
+
+  <script>
+    // Section block is rendering — hide any body-embed duplicate to prevent two widgets
+    document.addEventListener('DOMContentLoaded', function() {
+      document.querySelectorAll('.shopify-block.shopify-app-block').forEach(function(el) {
+        if (el.querySelector('[data-bundle-type="full_page"]')) el.style.display = 'none';
+      });
+    });
+  </script>
+
+  {% # theme-check-disable RemoteAsset %}
+  <link
+    rel="stylesheet"
+    href="{{ shop.url }}/apps/product-bundles/api/design-settings/{{ shop.domain }}?bundleType=full_page"
+    type="text/css"
+  >
+  {% # theme-check-enable RemoteAsset %}
+
+  <link rel="stylesheet" href="{{ 'bundle-widget-full-page.css' | asset_url }}">
+  <script src="{{ 'bundle-widget-full-page-bundled.js' | asset_url }}" defer></script>
+
+{% else %}
+  <div class="bundle-widget-placeholder" style="padding: 40px; text-align: center; background: #f0f3eb; border-radius: 8px;">
+    <h3 style="margin: 0 0 10px;">Full-Page Bundle Widget</h3>
+    <p style="margin: 0; color: #666;">No bundle linked to this page. Use "Place Widget Now" in the Wolfpack app to connect a bundle.</p>
+  </div>
+{% endif %}
+
+{% schema %}
+{
+  "name": "Wolfpack Bundle Full Page",
+  "target": "section",
+  "enabled_on": {
+    "templates": ["page"]
+  },
+  "stylesheet": "bundle-widget-full-page.css",
+  "settings": [
+    {
+      "type": "paragraph",
+      "content": "Renders the full-page bundle widget. Bundle ID is set automatically when you use 'Place Widget Now' in the app."
+    },
+    {
+      "type": "text",
+      "id": "bundle_id",
+      "label": "Bundle ID (manual override)",
+      "info": "Leave blank — the app sets this automatically via page metafield."
+    },
+    {
+      "type": "header",
+      "content": "Display"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_bundle_title",
+      "label": "Show bundle title",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "show_bundle_description",
+      "label": "Show bundle description",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "show_category_tabs",
+      "label": "Show category tabs",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "hide_page_title",
+      "label": "Hide page title",
+      "info": "Hides the theme's page heading — the widget shows its own title",
+      "default": true
+    },
+    {
+      "type": "text",
+      "id": "custom_title",
+      "label": "Custom title override",
+      "info": "Leave blank to use the bundle name"
+    },
+    {
+      "type": "textarea",
+      "id": "custom_description",
+      "label": "Custom description override",
+      "info": "Leave blank to use the bundle description"
+    },
+    {
+      "type": "header",
+      "content": "Card Layout"
+    },
+    {
+      "type": "range",
+      "id": "product_card_spacing",
+      "label": "Product card spacing",
+      "info": "Space between product cards (px)",
+      "min": 10,
+      "max": 60,
+      "step": 5,
+      "default": 20,
+      "unit": "px"
+    },
+    {
+      "type": "range",
+      "id": "product_cards_per_row",
+      "label": "Cards per row (desktop)",
+      "min": 2,
+      "max": 6,
+      "step": 1,
+      "default": 4
+    },
+    {
+      "type": "header",
+      "content": "Promo Banner"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_promo_banner",
+      "label": "Show promo banner",
+      "default": true
+    },
+    {
+      "type": "text",
+      "id": "promo_banner_subtitle",
+      "label": "Banner subtitle",
+      "default": "Mix & Match"
+    },
+    {
+      "type": "text",
+      "id": "promo_banner_tagline",
+      "label": "Banner tagline (no discount)",
+      "default": "Create Your Perfect Bundle"
+    },
+    {
+      "type": "text",
+      "id": "promo_banner_note",
+      "label": "Banner note (no discount)",
+      "default": "Mix & Match Your Favorites"
+    },
+    {
+      "type": "header",
+      "content": "Pricing Tiers (Optional)"
+    },
+    {
+      "type": "text",
+      "id": "tier_1_label",
+      "label": "Tier 1 label"
+    },
+    {
+      "type": "text",
+      "id": "tier_1_bundle_id",
+      "label": "Tier 1 bundle ID",
+      "info": "Leave blank to use the page's bundle"
+    },
+    {
+      "type": "text",
+      "id": "tier_2_label",
+      "label": "Tier 2 label"
+    },
+    {
+      "type": "text",
+      "id": "tier_2_bundle_id",
+      "label": "Tier 2 bundle ID"
+    },
+    {
+      "type": "text",
+      "id": "tier_3_label",
+      "label": "Tier 3 label"
+    },
+    {
+      "type": "text",
+      "id": "tier_3_bundle_id",
+      "label": "Tier 3 bundle ID"
+    },
+    {
+      "type": "text",
+      "id": "tier_4_label",
+      "label": "Tier 4 label"
+    },
+    {
+      "type": "text",
+      "id": "tier_4_bundle_id",
+      "label": "Tier 4 bundle ID"
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
…block deleted in embed migration

The embed architecture migration (a67339d) deleted bundle-full-page.liquid (target: section) and replaced it with bundle-full-page-embed.liquid (target: body). The theme still references the old section block path, causing a render failure, and the body embed always injects after the footer.

Restored bundle-full-page.liquid as a section block (target: section) so the widget renders inside <main> (before the footer). Adds JS to hide the body-embed duplicate when the section block is active on the same page.