### PR TITLE
[fpb-empty-main-section-fix-1] fix: Relocate body embed into <main> v…

### DIFF
--- a/docs/issues-prod/fpb-empty-main-section-fix-1.md
+++ b/docs/issues-prod/fpb-empty-main-section-fix-1.md
@@ -42,6 +42,14 @@ hide the parent `shopify-section` using `.shopify-section:has(.main-page-title)`
   that renders inside <main> (before the footer)
 - Added JS in restored block to hide body-embed duplicate when section block is active
 
+### 2026-04-08 10:45 - Section block restore didn't work — UUID mismatch
+- The restored `bundle-full-page.liquid` file was deployed but Shopify still reports "does not exist"
+- Root cause: When a block is deleted and re-deployed, Shopify assigns a new internal UUID.
+  The theme template still references the OLD UUID registered on first deploy — permanent mismatch.
+- New fix: Add DOM-relocation JS to `bundle-full-page-embed.liquid` — moves the body-embed
+  block node into `<main>` on DOMContentLoaded so it renders before the footer visually.
+- This avoids needing to touch the theme customizer or block UUID at all.
+
 ## Related Documentation
 - `extensions/bundle-builder/blocks/bundle-full-page-embed.liquid`
 

--- a/extensions/bundle-builder/blocks/bundle-full-page-embed.liquid
+++ b/extensions/bundle-builder/blocks/bundle-full-page-embed.liquid
@@ -80,10 +80,31 @@
   h1.page-title,
   .page-header h1,
   .main-page-title { display: none !important; }
-  /* Hide the parent section wrapper — its padding creates a blank gray gap above the widget */
+  /* Hide the section wrapper padding that creates a blank gray gap above the widget */
   .shopify-section:has(.main-page-title) { display: none !important; }
 </style>
 {% endif %}
+
+<script>
+  // The body embed injects after the footer — move it inside <main> so it renders in the correct position.
+  // This runs synchronously before DOMContentLoaded to avoid a flash of misplaced content.
+  (function () {
+    function relocateWidget() {
+      var block = document.getElementById('shopify-block-{{ block.id }}') ||
+                  document.querySelector('.shopify-block.shopify-app-block:has(#bundle-builder-app)');
+      var main  = document.getElementById('MainContent');
+      if (!block || !main) return;
+      // Already inside main — nothing to do
+      if (main.contains(block)) return;
+      main.insertBefore(block, main.firstChild);
+    }
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', relocateWidget);
+    } else {
+      relocateWidget();
+    }
+  })();
+</script>
 
 <script>
   if (!window.bundleWidgetContext) {


### PR DESCRIPTION
…ia JS to fix widget below footer

The section block UUID approach failed — Shopify assigned a new UUID on re-deploy so the theme's saved reference always resolves to "does not exist".

Instead, add a DOM-relocation script to bundle-full-page-embed.liquid that moves the shopify-app-block node into #MainContent on DOMContentLoaded, placing the widget before the footer without any theme customizer changes.