### PR TITLE
[fpb-default-product-selection-1] fix: Default products now appear se…

### DIFF
--- a/app/assets/bundle-widget-full-page.js
+++ b/app/assets/bundle-widget-full-page.js
@@ -1192,7 +1192,7 @@ class BundleWidgetFullPage {
     const isLastStep = this.currentStepIndex === this.selectedBundle.steps.length - 1;
     const canProceed = this.canProceedToNextStep();
     const conditionless = this.bundleHasNoConditions();
-    const hasSelection = conditionless && this.getAllSelectedProductsData().filter(p => !p.isDefault).length > 0;
+    const hasSelection = conditionless && this.getAllSelectedProductsData().length > 0;
 
     const nextBtn = document.createElement('button');
     nextBtn.className = 'side-panel-btn side-panel-btn-next';
@@ -1255,11 +1255,13 @@ class BundleWidgetFullPage {
       tab.dataset.stepIndex = index;
 
       // Determine step state
+      const isDefaultStep = step.isDefault === true;
       const isCompleted = this.isStepCompleted(index);
       const isCurrent = index === this.currentStepIndex;
       const isAccessible = this.isStepAccessible(index);
 
-      if (isCompleted) tab.classList.add('completed');
+      if (isDefaultStep) tab.classList.add('step-tab--included');
+      if (isCompleted && !isDefaultStep) tab.classList.add('completed');
       if (isCurrent) tab.classList.add('active');
       if (!isAccessible) tab.classList.add('locked');
 
@@ -1275,7 +1277,25 @@ class BundleWidgetFullPage {
       // Tab content structure
       let tabContent = '';
 
-      if (hasSelections) {
+      // Default (included) step — always shown as locked with "Included" label
+      if (isDefaultStep) {
+        const productImages = hasSelections ? this.getStepProductImages(index) : [];
+        const imagesHtml = productImages.slice(0, 3).map(img =>
+          `<img src="${img.url}" alt="${this._escapeHTML(img.alt)}" class="tab-product-image">`
+        ).join('');
+        tabContent = `
+          ${imagesHtml ? `<div class="tab-images">${imagesHtml}</div>` : `<div class="tab-number">${index + 1}</div>`}
+          <div class="tab-info">
+            <span class="tab-name">${escapedName}</span>
+            <span class="tab-count tab-count--included">Included</span>
+          </div>
+          <div class="tab-lock tab-lock--included">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <path d="M12 7H11V5C11 3.34 9.66 2 8 2C6.34 2 5 3.34 5 5V7H4C3.45 7 3 7.45 3 8V13C3 13.55 3.45 14 4 14H12C12.55 14 13 13.55 13 13V8C13 7.45 12.55 7 12 7ZM8 11C7.45 11 7 10.55 7 10C7 9.45 7.45 9 8 9C8.55 9 9 9.45 9 10C9 10.55 8.55 11 8 11ZM9.1 7H6.9V5C6.9 4.39 7.39 3.9 8 3.9C8.61 3.9 9.1 4.39 9.1 5V7Z" fill="currentColor"/>
+            </svg>
+          </div>
+        `;
+      } else if (hasSelections) {
         // Show product images if available
         const productImages = this.getStepProductImages(index);
         if (productImages.length > 0) {
@@ -1933,8 +1953,21 @@ class BundleWidgetFullPage {
     wrapper.innerHTML = htmlString.trim();
     const cardElement = wrapper.firstChild;
 
-    // Free gift step: add "Free" badge and override price display to $0.00
+    // Default (included) step: add "Included" badge and disable interaction controls
     const currentStepData = (this.selectedBundle?.steps || [])[stepIndex];
+    if (currentStepData?.isDefault) {
+      cardElement.classList.add('fpb-card--default-included');
+      const imgEl = cardElement.querySelector('.product-image, .product-img, img');
+      if (imgEl && imgEl.parentElement) {
+        imgEl.parentElement.classList.add('fpb-card-image-wrapper');
+        const badge = document.createElement('span');
+        badge.className = 'fpb-included-badge';
+        badge.textContent = 'Included';
+        imgEl.parentElement.appendChild(badge);
+      }
+    }
+
+    // Free gift step: add "Free" badge and override price display to $0.00
     if (currentStepData?.isFreeGift) {
       const imgEl = cardElement.querySelector('.product-image, .product-img, img');
       if (imgEl && imgEl.parentElement) {
@@ -1974,6 +2007,9 @@ class BundleWidgetFullPage {
 
   // Attach event listeners to product card
   attachProductCardListeners(cardElement, product, stepIndex) {
+    // Default steps are read-only — no add/remove/quantity interaction allowed
+    if ((this.selectedBundle?.steps || [])[stepIndex]?.isDefault) return;
+
     const productId = product.variantId || product.id;
 
     // Quantity controls (both old-style and inline-style buttons)
@@ -2233,7 +2269,7 @@ class BundleWidgetFullPage {
     toggleBtn.className = 'footer-toggle';
     toggleBtn.setAttribute('type', 'button');
     const hasConditions = !this.bundleHasNoConditions();
-    const totalSelected = allSelectedProducts.filter(p => !p.isDefault).length;
+    const totalSelected = allSelectedProducts.length;
     const toggleText = hasConditions
       ? `${totalQuantity}/${totalRequired} Steps`
       : `${totalSelected} Product${totalSelected !== 1 ? 's' : ''}`;
@@ -2275,7 +2311,7 @@ class BundleWidgetFullPage {
     ctaBtn.className = 'footer-cta-btn';
     ctaBtn.setAttribute('type', 'button');
     const conditionless = this.bundleHasNoConditions();
-    const hasSelection = conditionless && this.getAllSelectedProductsData().filter(p => !p.isDefault).length > 0;
+    const hasSelection = conditionless && this.getAllSelectedProductsData().length > 0;
     ctaBtn.textContent = (conditionless || isLastStep) ? (this.config.addToCartText || 'Add to Cart') : 'Next';
     if (conditionless ? !hasSelection : (isLastStep ? !this.areBundleConditionsMet() : !this.canProceedToNextStep())) {
       ctaBtn.disabled = true;
@@ -2667,9 +2703,10 @@ class BundleWidgetFullPage {
       );
       if (product) {
         if (!this.selectedProducts[stepIndex]) this.selectedProducts[stepIndex] = {};
-        // Store quantity as a number (1) so every consumer that reads selectedProducts
-        // with `if (quantity > 0)` correctly includes the default product.
-        this.selectedProducts[stepIndex][step.defaultVariantId] = 1;
+        // Normalize to numeric ID (strips GID prefix) so the key matches the variantId
+        // produced by processProductsForStep() via extractId().
+        const normalizedId = this.extractId(step.defaultVariantId) || step.defaultVariantId;
+        this.selectedProducts[stepIndex][normalizedId] = 1;
       }
     });
   }
@@ -3848,6 +3885,8 @@ class BundleWidgetFullPage {
   }
 
   isStepAccessible(stepIndex) {
+    // Default steps are always accessible (read-only, pre-selected)
+    if (this.selectedBundle?.steps[stepIndex]?.isDefault) return true;
     // Free gift step is only accessible when all paid steps are complete
     if (!this.canNavigateToStep(stepIndex)) return false;
     // Check if all previous steps are completed

--- a/docs/issues-prod/fpb-default-product-selection-1.md
+++ b/docs/issues-prod/fpb-default-product-selection-1.md
@@ -1,0 +1,45 @@
+# Issue: FPB Default Product Selection — Grid, Footer & Tab UX
+
+**Issue ID:** fpb-default-product-selection-1
+**Status:** In Progress
+**Priority:** 🔴 High
+**Created:** 2026-04-09
+**Last Updated:** 2026-04-09 16:30
+
+## Overview
+When a step is configured as a default step (`isDefault: true`, `defaultVariantId` set), the pre-selected
+product is only shown on the step tab count ("1 selected") but NOT in the product grid, NOT in the footer,
+and the user CAN remove it via the footer. Root cause: variant ID format mismatch in `_initDefaultProducts()`.
+
+Also: default step tabs have no visual distinction, and the step is incorrectly locked when previous steps
+are incomplete.
+
+## Root Cause (confirmed via Chrome DevTools)
+
+`_initDefaultProducts()` stores: `selectedProducts[1]["gid://shopify/ProductVariant/52734772805926"] = 1`
+
+`processProductsForStep()` builds card variantId via `extractId()` → `"52734772805926"` (numeric only)
+
+Key mismatch → `currentQuantity = 0` → card appears unselected; `getAllSelectedProductsData()` can't find the
+product → footer shows "0 Products" with wrong total.
+
+## Progress Log
+
+### 2026-04-09 16:30 - Phase 1 Completed
+- ✅ Fixed ID normalization in `_initDefaultProducts()`: now uses `this.extractId()` to store numeric key, matching the key produced by `processProductsForStep()`. Fixes the root cause — default product now appears selected in the grid.
+- ✅ Made default steps always accessible in `isStepAccessible()`: early return `if (steps[stepIndex]?.isDefault) return true` so the tab is never locked even when previous steps are incomplete.
+- ✅ Added "Included" tab styling: default step tabs get `step-tab--included` class, dashed border, "Included" green badge, green lock icon, product images shown.
+- ✅ Added read-only product card behavior: `createProductCard()` adds `fpb-card--default-included` class + "Included" badge; `attachProductCardListeners()` early-returns for default steps (no add/remove/qty interaction).
+- ✅ Fixed footer count: removed `filter(p => !p.isDefault)` from both the toggle text count and the CTA `hasSelection` check so default products are included.
+- ✅ Added CSS for all new classes (`.step-tab--included`, `.tab-count--included`, `.tab-lock--included`, `.fpb-card--default-included`, `.fpb-included-badge`).
+- ✅ Rebuilt: `npm run build:widgets` — 256.5 KB FPB bundle. CSS 95,859 B (under 100 KB limit).
+- ✅ Lint: 0 errors.
+- Files Modified:
+  - `app/assets/bundle-widget-full-page.js` (lines ~1257, ~1672, ~1906, ~1975, ~1195, ~2314, ~3850)
+  - `extensions/bundle-builder/assets/bundle-widget-full-page.css` (lines ~4156 — new section)
+  - `extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js` (rebuilt)
+- Next: Deploy to SIT, verify via Chrome DevTools
+
+## Phases Checklist
+- [x] Phase 1: Fix ID mismatch + accessibility + tab UX + card UX + footer count ✅
+- [ ] Phase 2: Deploy + Chrome DevTools verification

--- a/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
@@ -1,7 +1,7 @@
 /*!
  * Wolfpack Bundle Widget — Full Page
  * Version : 2.4.7
- * Built   : 2026-04-06
+ * Built   : 2026-04-09
  *
  * Cache note: Shopify CDN cache is busted automatically by shopify app deploy.
  * After deploying, allow 2-10 minutes for propagation before testing.
@@ -3636,7 +3636,7 @@ class BundleWidgetFullPage {
     const isLastStep = this.currentStepIndex === this.selectedBundle.steps.length - 1;
     const canProceed = this.canProceedToNextStep();
     const conditionless = this.bundleHasNoConditions();
-    const hasSelection = conditionless && this.getAllSelectedProductsData().filter(p => !p.isDefault).length > 0;
+    const hasSelection = conditionless && this.getAllSelectedProductsData().length > 0;
 
     const nextBtn = document.createElement('button');
     nextBtn.className = 'side-panel-btn side-panel-btn-next';
@@ -3699,11 +3699,13 @@ class BundleWidgetFullPage {
       tab.dataset.stepIndex = index;
 
       // Determine step state
+      const isDefaultStep = step.isDefault === true;
       const isCompleted = this.isStepCompleted(index);
       const isCurrent = index === this.currentStepIndex;
       const isAccessible = this.isStepAccessible(index);
 
-      if (isCompleted) tab.classList.add('completed');
+      if (isDefaultStep) tab.classList.add('step-tab--included');
+      if (isCompleted && !isDefaultStep) tab.classList.add('completed');
       if (isCurrent) tab.classList.add('active');
       if (!isAccessible) tab.classList.add('locked');
 
@@ -3719,7 +3721,25 @@ class BundleWidgetFullPage {
       // Tab content structure
       let tabContent = '';
 
-      if (hasSelections) {
+      // Default (included) step — always shown as locked with "Included" label
+      if (isDefaultStep) {
+        const productImages = hasSelections ? this.getStepProductImages(index) : [];
+        const imagesHtml = productImages.slice(0, 3).map(img =>
+          `<img src="${img.url}" alt="${this._escapeHTML(img.alt)}" class="tab-product-image">`
+        ).join('');
+        tabContent = `
+          ${imagesHtml ? `<div class="tab-images">${imagesHtml}</div>` : `<div class="tab-number">${index + 1}</div>`}
+          <div class="tab-info">
+            <span class="tab-name">${escapedName}</span>
+            <span class="tab-count tab-count--included">Included</span>
+          </div>
+          <div class="tab-lock tab-lock--included">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <path d="M12 7H11V5C11 3.34 9.66 2 8 2C6.34 2 5 3.34 5 5V7H4C3.45 7 3 7.45 3 8V13C3 13.55 3.45 14 4 14H12C12.55 14 13 13.55 13 13V8C13 7.45 12.55 7 12 7ZM8 11C7.45 11 7 10.55 7 10C7 9.45 7.45 9 8 9C8.55 9 9 9.45 9 10C9 10.55 8.55 11 8 11ZM9.1 7H6.9V5C6.9 4.39 7.39 3.9 8 3.9C8.61 3.9 9.1 4.39 9.1 5V7Z" fill="currentColor"/>
+            </svg>
+          </div>
+        `;
+      } else if (hasSelections) {
         // Show product images if available
         const productImages = this.getStepProductImages(index);
         if (productImages.length > 0) {
@@ -4377,8 +4397,21 @@ class BundleWidgetFullPage {
     wrapper.innerHTML = htmlString.trim();
     const cardElement = wrapper.firstChild;
 
-    // Free gift step: add "Free" badge and override price display to $0.00
+    // Default (included) step: add "Included" badge and disable interaction controls
     const currentStepData = (this.selectedBundle?.steps || [])[stepIndex];
+    if (currentStepData?.isDefault) {
+      cardElement.classList.add('fpb-card--default-included');
+      const imgEl = cardElement.querySelector('.product-image, .product-img, img');
+      if (imgEl && imgEl.parentElement) {
+        imgEl.parentElement.classList.add('fpb-card-image-wrapper');
+        const badge = document.createElement('span');
+        badge.className = 'fpb-included-badge';
+        badge.textContent = 'Included';
+        imgEl.parentElement.appendChild(badge);
+      }
+    }
+
+    // Free gift step: add "Free" badge and override price display to $0.00
     if (currentStepData?.isFreeGift) {
       const imgEl = cardElement.querySelector('.product-image, .product-img, img');
       if (imgEl && imgEl.parentElement) {
@@ -4418,6 +4451,9 @@ class BundleWidgetFullPage {
 
   // Attach event listeners to product card
   attachProductCardListeners(cardElement, product, stepIndex) {
+    // Default steps are read-only — no add/remove/quantity interaction allowed
+    if ((this.selectedBundle?.steps || [])[stepIndex]?.isDefault) return;
+
     const productId = product.variantId || product.id;
 
     // Quantity controls (both old-style and inline-style buttons)
@@ -4677,7 +4713,7 @@ class BundleWidgetFullPage {
     toggleBtn.className = 'footer-toggle';
     toggleBtn.setAttribute('type', 'button');
     const hasConditions = !this.bundleHasNoConditions();
-    const totalSelected = allSelectedProducts.filter(p => !p.isDefault).length;
+    const totalSelected = allSelectedProducts.length;
     const toggleText = hasConditions
       ? `${totalQuantity}/${totalRequired} Steps`
       : `${totalSelected} Product${totalSelected !== 1 ? 's' : ''}`;
@@ -4719,7 +4755,7 @@ class BundleWidgetFullPage {
     ctaBtn.className = 'footer-cta-btn';
     ctaBtn.setAttribute('type', 'button');
     const conditionless = this.bundleHasNoConditions();
-    const hasSelection = conditionless && this.getAllSelectedProductsData().filter(p => !p.isDefault).length > 0;
+    const hasSelection = conditionless && this.getAllSelectedProductsData().length > 0;
     ctaBtn.textContent = (conditionless || isLastStep) ? (this.config.addToCartText || 'Add to Cart') : 'Next';
     if (conditionless ? !hasSelection : (isLastStep ? !this.areBundleConditionsMet() : !this.canProceedToNextStep())) {
       ctaBtn.disabled = true;
@@ -5111,9 +5147,10 @@ class BundleWidgetFullPage {
       );
       if (product) {
         if (!this.selectedProducts[stepIndex]) this.selectedProducts[stepIndex] = {};
-        // Store quantity as a number (1) so every consumer that reads selectedProducts
-        // with `if (quantity > 0)` correctly includes the default product.
-        this.selectedProducts[stepIndex][step.defaultVariantId] = 1;
+        // Normalize to numeric ID (strips GID prefix) so the key matches the variantId
+        // produced by processProductsForStep() via extractId().
+        const normalizedId = this.extractId(step.defaultVariantId) || step.defaultVariantId;
+        this.selectedProducts[stepIndex][normalizedId] = 1;
       }
     });
   }
@@ -6292,6 +6329,8 @@ class BundleWidgetFullPage {
   }
 
   isStepAccessible(stepIndex) {
+    // Default steps are always accessible (read-only, pre-selected)
+    if (this.selectedBundle?.steps[stepIndex]?.isDefault) return true;
     // Free gift step is only accessible when all paid steps are complete
     if (!this.canNavigateToStep(stepIndex)) return false;
     // Check if all previous steps are completed

--- a/extensions/bundle-builder/assets/bundle-widget-full-page.css
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page.css
@@ -4153,6 +4153,43 @@ body.modal-open {
   display: block;
 }
 
+/* ---- Default (Included) Step — Tab Styling ---- */
+.step-tab--included {
+  border-style: dashed;
+  opacity: 0.9;
+}
+
+.step-tab--included .tab-count--included {
+  background: rgba(16, 185, 129, 0.12);
+  color: #059669;
+}
+
+.step-tab--included .tab-lock--included svg {
+  opacity: 1;
+  color: #059669;
+}
+
+/* ---- Default (Included) Step — Card Styling ---- */
+.fpb-card--default-included .product-add-btn,
+.fpb-card--default-included .qty-increase,
+.fpb-card--default-included .qty-decrease {
+  display: none !important;
+}
+
+.fpb-included-badge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  background: #10B981;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 4px;
+  z-index: 1;
+  pointer-events: none;
+}
+
 /* ---- Free Gift Step Heading ---- */
 .fpb-step-free-heading {
   font-size: 18px;


### PR DESCRIPTION
…lected in grid, tab, and footer

- Normalize GID → numeric key in _initDefaultProducts() to match extractId() output
- Default steps always accessible in isStepAccessible() regardless of prior step state
- Default step tabs show "Included" badge with dashed border and green lock icon
- Product cards on default steps are read-only (no add/remove/qty interaction)
- Footer count and CTA hasSelection now include default products