### PR TITLE
[feedback-jun26-8] fix: preserve condition value 0 in admin save hand…

### DIFF
--- a/app/lib/parse-condition-value.ts
+++ b/app/lib/parse-condition-value.ts
@@ -1,0 +1,14 @@
+/**
+ * Normalize a raw condition value from form data into a number, preserving 0.
+ *
+ * The historical inline form was `value ? parseInt(value) || null : null` which
+ * silently dropped `conditionValue: 0` to null because `0 || null` evaluates to
+ * null. Use this helper instead.
+ */
+export function parseConditionValue(raw: unknown): number | null {
+  if (raw == null) return null;
+  const str = typeof raw === "string" ? raw.trim() : String(raw);
+  if (str === "") return null;
+  const n = Number(str);
+  return Number.isFinite(n) ? n : null;
+}

--- a/app/routes/app/app.bundles.create_.configure.$bundleId/route.tsx
+++ b/app/routes/app/app.bundles.create_.configure.$bundleId/route.tsx
@@ -33,6 +33,7 @@ import { BundleReadinessOverlay, type BundleReadinessItem } from "../../../compo
 import { WIZARD_CONFIGURE_TOUR_STEPS } from "../../../components/bundle-configure/tourSteps";
 import { getBundleWizardConfigurePath } from "../../../lib/bundle-navigation";
 import { buildWizardPreviewUrl } from "../../../lib/wizard-preview-url";
+import { parseConditionValue } from "../../../lib/parse-condition-value";
 import { useEnablePreviewGate } from "../../../hooks/useEnablePreviewGate";
 import { EnablePreviewModal } from "../../../components/EnablePreviewModal";
 import { StepSummary } from "./StepSummary";
@@ -589,9 +590,9 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
         ws.collections && ws.collections.length > 0 ? (ws.collections as any) : null,
       conditionType: c1?.conditionType || null,
       conditionOperator: c1?.conditionOperator || null,
-      conditionValue: c1?.conditionValue ? parseInt(c1.conditionValue, 10) : null,
+      conditionValue: parseConditionValue(c1?.conditionValue),
       conditionOperator2: c2?.conditionOperator || null,
-      conditionValue2: c2?.conditionValue ? parseInt(c2.conditionValue, 10) : null,
+      conditionValue2: parseConditionValue(c2?.conditionValue),
       filters: ws.filters && ws.filters.length > 0 ? (ws.filters as any) : null,
     };
 

--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/handlers.server.ts
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/handlers.server.ts
@@ -25,6 +25,7 @@ import {
   updateProductStandardMetafields,
 } from "../../../../services/bundles/standard-metafields.server";
 import { getBundleProductVariantId } from "../../../../utils/variant-lookup.server";
+import { parseConditionValue } from "../../../../lib/parse-condition-value";
 import { mapDiscountMethod } from "../../../../utils/discount-mappers";
 import {
   normaliseShopifyProductId,
@@ -442,9 +443,9 @@ function buildFpbBaseConfig(
       enabled: step.enabled !== false,
       conditionType: stepConditionsData[step.id]?.[0]?.type || null,
       conditionOperator: stepConditionsData[step.id]?.[0]?.operator || null,
-      conditionValue: stepConditionsData[step.id]?.[0]?.value ? parseInt(stepConditionsData[step.id][0].value) || null : null,
+      conditionValue: parseConditionValue(stepConditionsData[step.id]?.[0]?.value),
       conditionOperator2: stepConditionsData[step.id]?.[1]?.operator || null,
-      conditionValue2: stepConditionsData[step.id]?.[1]?.value ? parseInt(stepConditionsData[step.id][1].value) || null : null,
+      conditionValue2: parseConditionValue(stepConditionsData[step.id]?.[1]?.value),
       products: (step.StepProduct || []).map((product: any) => ({
         id: product.id,
         title: product.title || product.name || 'Product',
@@ -795,9 +796,9 @@ export async function handleSaveBundle(admin: ShopifyAdmin, session: Session, bu
                 // Apply condition data if available
                 conditionType: firstCondition?.type || null,
                 conditionOperator: firstCondition?.operator || null,
-                conditionValue: firstCondition?.value ? parseInt(firstCondition.value) || null : null,
+                conditionValue: parseConditionValue(firstCondition?.value),
                 conditionOperator2: secondCondition?.operator || null,
-                conditionValue2: secondCondition?.value ? parseInt(secondCondition.value) || null : null,
+                conditionValue2: parseConditionValue(secondCondition?.value),
                 // Create StepProduct records for selected products
                 StepProduct: {
                   create: (step.StepProduct || []).map((product: any, productIndex: number) => {

--- a/app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/handlers/handlers.server.ts
+++ b/app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/handlers/handlers.server.ts
@@ -24,6 +24,7 @@ import {
   updateProductStandardMetafields,
 } from "../../../../services/bundles/standard-metafields.server";
 import { getBundleProductVariantId } from "../../../../utils/variant-lookup.server";
+import { parseConditionValue } from "../../../../lib/parse-condition-value";
 import { mapDiscountMethod } from "../../../../utils/discount-mappers";
 import { parsePPBGiftMessages, parsePPBBundleVisibility, parsePPBBundleSettings, parseBundleDesignTemplate } from "./parsers";
 import {
@@ -420,9 +421,9 @@ function buildBundleBaseConfig(
     enabled: step.enabled !== false,
     conditionType: stepConditionsData[step.id]?.[0]?.type || null,
     conditionOperator: stepConditionsData[step.id]?.[0]?.operator || null,
-    conditionValue: stepConditionsData[step.id]?.[0]?.value ? parseInt(stepConditionsData[step.id][0].value) || null : null,
+    conditionValue: parseConditionValue(stepConditionsData[step.id]?.[0]?.value),
     conditionOperator2: stepConditionsData[step.id]?.[1]?.operator || null,
-    conditionValue2: stepConditionsData[step.id]?.[1]?.value ? parseInt(stepConditionsData[step.id][1].value) || null : null,
+    conditionValue2: parseConditionValue(stepConditionsData[step.id]?.[1]?.value),
     products: (step.StepProduct || []).map((product: any) => ({
       id: product.id,
       title: product.title || product.name || 'Product',
@@ -1123,9 +1124,9 @@ export async function handleSaveBundle(admin: ShopifyAdmin, session: Session, bu
                 // Apply condition data if available
                 conditionType: firstCondition?.type || null,
                 conditionOperator: firstCondition?.operator || null,
-                conditionValue: firstCondition?.value ? parseInt(firstCondition.value) || null : null,
+                conditionValue: parseConditionValue(firstCondition?.value),
                 conditionOperator2: secondCondition?.operator || null,
-                conditionValue2: secondCondition?.value ? parseInt(secondCondition.value) || null : null,
+                conditionValue2: parseConditionValue(secondCondition?.value),
                 filters: Array.isArray(step.filters) ? step.filters : null,
                 imageUrl: step.imageUrl ?? null,
                 bannerImageUrl: step.bannerImageUrl ?? null,

--- a/docs/issues-prod/feedback-jun26-8.md
+++ b/docs/issues-prod/feedback-jun26-8.md
@@ -1,0 +1,74 @@
+# Issue: Quantity Rules Enforcement (Partial — Repro Needed)
+
+**Issue ID:** feedback-jun26-8
+**Status:** Partial — defensive fix landed; live repro needed for any remaining bug
+**Priority:** 🟡 Medium
+**Created:** 2026-05-29
+**Last Updated:** 2026-05-29
+
+## Overview
+
+PDF feedback: "Rules not working for quantity". The Loom URL was not watched in this session; without a specific reproduction the original "rules don't work" claim couldn't be confirmed against current code.
+
+## What I verified statically
+
+Both widgets DO gate ATC on validation:
+
+- FPB (`app/assets/bundle-widget-full-page.js:3952`): `addBundleToCart` calls `areBundleConditionsMet()` → `isStepCompleted(index)` → `ConditionValidator.isStepConditionSatisfied(step, stepSelections)`.
+- PPB (`app/assets/bundle-widget-product-page.js:3315`): `addToCart` calls `validateStep(index)` → `ConditionValidator.isStepConditionSatisfied(step, currentSelections)`.
+
+The save path persists `conditionType`, `conditionOperator`, and `conditionValue` to flat columns. The server formatter (`app/lib/bundle-formatter.server.ts:176`) emits them to the storefront. The 97 unit tests in `tests/unit/assets/condition-validator.test.ts` exercise every operator + edge case.
+
+## What I fixed defensively
+
+Admin save handlers used the pattern `value ? parseInt(value) || null : null` which silently drops `conditionValue: 0` to null. If a merchant set a rule like "quantity equal_to 0", the rule was lost. Replaced with a small `parseConditionValue` helper that uses `Number(value)` + finite check + accepts `0`.
+
+Occurrences fixed:
+- `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/handlers.server.ts` lines 445, 447, 798, 800
+- `app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/handlers/handlers.server.ts` lines 423, 425, 1126, 1128
+- `app/routes/app/app.bundles.create_.configure.$bundleId/route.tsx` lines 592, 594
+
+(The wizard's pre-existing `c1?.conditionValue ? parseInt(c1.conditionValue, 10) : null` form is OK for "0" because the ternary uses the original string in the falsy branch and doesn't follow with `|| null` — but I still routed through the shared helper for consistency.)
+
+## What still needs the user's input
+
+If "rules not working for quantity" describes a specific failure mode beyond the `0` case (e.g., a particular operator misbehaves, the ATC button isn't disabled, the toast doesn't appear), I need either:
+
+1. A reproducible setup on Wolfpack SIT (bundle ID + step rule config + ATC steps to fail), OR
+2. The Loom from the PDF watched + specific timestamps for the failing behavior.
+
+Until then this commit is a defensive cleanup; the headline bug remains unverified.
+
+## Files Changed
+
+- `app/lib/parse-condition-value.ts` (new) — pure helper.
+- `tests/unit/lib/parse-condition-value.test.ts` (new).
+- FPB handlers, PPB handlers, CREATE wizard route — drop the `|| null` pattern, use the helper.
+
+## Tests
+
+- `parseConditionValue("0")` → `0` (the bug fix).
+- `parseConditionValue("3")` → `3`.
+- `parseConditionValue("")` → `null`.
+- `parseConditionValue(null)` → `null`.
+- `parseConditionValue("abc")` → `null` (NaN).
+
+## Phases Checklist
+
+- [x] Phase 1: Audit save paths, confirm widget ATC gates wire to validators
+- [x] Phase 2: Identify defensive parseInt bug, write helper + tests
+- [x] Phase 3: Apply across admin save handlers
+- [ ] Phase 4: Live repro of the original PDF claim (deferred — needs user input)
+- [x] Phase 5: Commit + document partial completion
+
+**Status:** Partial. Defensive fix landed. Headline bug pending repro.
+
+## Progress Log
+
+### 2026-05-29 — Partial implementation complete
+- Confirmed both widget ATC paths gate on validation.
+- Helper + 5 unit tests + replaced all occurrences in three save paths.
+- No `WIDGET_VERSION` bump — admin-side save only; no widget code changed.
+
+### 2026-05-29 — Starting investigation
+- Code trace started.

--- a/tests/unit/lib/parse-condition-value.test.ts
+++ b/tests/unit/lib/parse-condition-value.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for parseConditionValue.
+ *
+ * Issue: feedback-jun26-8
+ */
+import { parseConditionValue } from "../../../app/lib/parse-condition-value";
+
+describe("parseConditionValue", () => {
+  it("preserves 0 instead of dropping to null", () => {
+    expect(parseConditionValue("0")).toBe(0);
+    expect(parseConditionValue(0)).toBe(0);
+  });
+
+  it("parses positive integers", () => {
+    expect(parseConditionValue("3")).toBe(3);
+    expect(parseConditionValue(7)).toBe(7);
+  });
+
+  it("parses decimals", () => {
+    expect(parseConditionValue("2.5")).toBe(2.5);
+  });
+
+  it("trims whitespace", () => {
+    expect(parseConditionValue("  4  ")).toBe(4);
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseConditionValue("")).toBeNull();
+    expect(parseConditionValue("   ")).toBeNull();
+  });
+
+  it("returns null for null / undefined", () => {
+    expect(parseConditionValue(null)).toBeNull();
+    expect(parseConditionValue(undefined)).toBeNull();
+  });
+
+  it("returns null for non-numeric strings", () => {
+    expect(parseConditionValue("abc")).toBeNull();
+    expect(parseConditionValue("3abc")).toBeNull();
+  });
+});


### PR DESCRIPTION
…lers

Partial fix for the "rules not working for quantity" feedback. The original Loom wasn't watched; without a reproducible setup the headline claim couldn't be confirmed against current code.

What I verified statically:
- Both FPB (bundle-widget-full-page.js:3952) and PPB (bundle-widget-product-page.js:3315) ATC handlers gate on ConditionValidator.isStepConditionSatisfied via areBundleConditionsMet / validateStep respectively.
- The save path persists conditionType/Operator/Value to flat columns.
- bundle-formatter.server.ts emits them to the storefront.
- 97 condition-validator unit tests cover every operator + edge case.

Defensive bug fix:
- Admin save handlers used `value ? parseInt(value) || null : null`, which silently dropped conditionValue: 0 to null. If a merchant set a rule like "quantity equal_to 0" the rule was lost.
- New pure helper app/lib/parse-condition-value.ts uses Number + finite check and preserves 0.
- Replaced all occurrences in FPB handlers (2 sites), PPB handlers (2 sites), and the CREATE wizard route (2 sites).

Headline bug remains unverified — needs either a reproducible SIT setup or a watch of the original Loom with specific failure steps. Documented in docs/issues-prod/feedback-jun26-8.md.

Impact: admin save only; no widget redeploy.
Affected: app/lib/parse-condition-value.ts (new),
  FPB + PPB handlers, CREATE wizard route
Tested by: tests/unit/lib/parse-condition-value.test.ts