### PR TITLE
[preview-bundle-gate-1] feat: DB cache for app embed check — EB pariy (Option B)

### DIFF
--- a/app/lib/bundle-configure-loader.server.ts
+++ b/app/lib/bundle-configure-loader.server.ts
@@ -8,6 +8,7 @@
 
 import { AppLogger } from "./logger";
 import { checkAppEmbedEnabled } from "../services/theme/app-embed-check.server";
+import db from "../db.server";
 
 const GET_BUNDLE_PRODUCT = `
   query GetBundleProduct($id: ID!) {
@@ -110,17 +111,67 @@ export async function fetchShopLocales(
   }
 }
 
+const EMBED_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes — matches EB's HTTP ETag cache pattern
+
 export async function fetchEmbedData(
   admin: any,
   shop: string,
   apiKey: string,
   embedBlockHandle = "bundle-app-embed",
 ): Promise<{ appEmbedEnabled: boolean; themeEditorUrl: string | null }> {
+  // Check DB cache first — avoids hitting Shopify's settings_data.json on every page load
+  const shopRecord = await db.shop.findUnique({
+    where: { shopDomain: shop },
+    select: { appEmbedEnabled: true, appEmbedCheckedAt: true, appEmbedThemeId: true },
+  });
+
+  const isCacheFresh =
+    shopRecord?.appEmbedCheckedAt !== null &&
+    shopRecord?.appEmbedEnabled !== null &&
+    shopRecord?.appEmbedCheckedAt !== undefined &&
+    Date.now() - shopRecord.appEmbedCheckedAt.getTime() < EMBED_CACHE_TTL_MS;
+
+  if (isCacheFresh) {
+    const themeEditorUrl = shopRecord!.appEmbedThemeId
+      ? buildThemeEditorUrl(shop, shopRecord!.appEmbedThemeId, apiKey, embedBlockHandle)
+      : null;
+    return { appEmbedEnabled: shopRecord!.appEmbedEnabled!, themeEditorUrl };
+  }
+
+  // Cache miss or stale — fetch from Shopify
   const embedCheck = await checkAppEmbedEnabled(admin, shop, {
     blockHandles: [embedBlockHandle],
   });
+
+  // Only persist when Shopify returned a valid theme ID (guards against network errors
+  // returning { enabled: false, themeId: null } which would poison the cache)
+  if (embedCheck.themeId !== null) {
+    try {
+      await db.shop.update({
+        where: { shopDomain: shop },
+        data: {
+          appEmbedEnabled: embedCheck.enabled,
+          appEmbedCheckedAt: new Date(),
+          appEmbedThemeId: embedCheck.themeId,
+        },
+      });
+    } catch (err) {
+      AppLogger.warn("fetchEmbedData: failed to update app embed cache", { shop, err });
+    }
+  }
+
   const themeEditorUrl = embedCheck.themeId
-    ? `https://${shop}/admin/themes/${embedCheck.themeId.split("/").pop()}/editor?context=apps&appEmbed=${apiKey}%2F${embedBlockHandle}`
+    ? buildThemeEditorUrl(shop, embedCheck.themeId, apiKey, embedBlockHandle)
     : null;
   return { appEmbedEnabled: embedCheck.enabled, themeEditorUrl };
+}
+
+function buildThemeEditorUrl(
+  shop: string,
+  themeGid: string,
+  apiKey: string,
+  blockHandle: string,
+): string {
+  const themeNumericId = themeGid.split("/").pop();
+  return `https://${shop}/admin/themes/${themeNumericId}/editor?context=apps&appEmbed=${apiKey}%2F${blockHandle}`;
 }

--- a/docs/issues-prod/preview-bundle-gate-1.md
+++ b/docs/issues-prod/preview-bundle-gate-1.md
@@ -1,6 +1,6 @@
 # Issue: Preview Bundle Gate — Incorrect App Embed Block
 **Issue ID:** preview-bundle-gate-1
-**Status:** Completed
+**Status:** In Progress
 **Priority:** 🔴 High
 **Created:** 2026-05-31
 **Last Updated:** 2026-05-31
@@ -23,7 +23,22 @@ Change the JSON parse failure to fail-open: return `{ enabled: true, themeId }` 
 - Updated JSDoc comment to reflect new behavior
 - Updated log message to indicate fail-open behavior
 
+### 2026-05-31 — Option B: DB cache for app embed check (EB parity)
+
+- Confirmed EB uses `GET /api/utility/isAppEmbedEnabled` with HTTP ETag caching (5-min TTL)
+- Added `appEmbedEnabled Boolean?`, `appEmbedCheckedAt DateTime?`, `appEmbedThemeId String?` to `Shop` model
+- Migration `20260531154158_add_app_embed_cache_to_shop` applied to SIT DB
+- Updated `fetchEmbedData` in `bundle-configure-loader.server.ts` with 5-min DB cache:
+  - Cache hit → skip Shopify API entirely
+  - Cache miss/stale → call `checkAppEmbedEnabled`, update cache (only when themeId non-null)
+  - Network error (themeId:null) → skip cache update, don't poison cache
+- Added 5 new unit tests for cache behavior; all 17 tests pass
+- `buildThemeEditorUrl` extracted as standalone helper
+
 ## Phases Checklist
 - [x] Identify root cause
 - [x] Fix fail-closed → fail-open in `checkAppEmbedEnabled`
+- [x] Option B: DB cache (schema + migration + code + tests)
 - [x] Lint + commit
+- [ ] Replicate EB preview gate modal copy + design
+- [ ] E2E verification on SIT store

--- a/prisma/migrations/20260531154158_add_app_embed_cache_to_shop/migration.sql
+++ b/prisma/migrations/20260531154158_add_app_embed_cache_to_shop/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Shop" ADD COLUMN     "appEmbedCheckedAt" TIMESTAMP(3),
+ADD COLUMN     "appEmbedEnabled" BOOLEAN,
+ADD COLUMN     "appEmbedThemeId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -557,6 +557,9 @@ model Shop {
   firstCreateTourEligible Boolean        @default(false) // True only for newly installed shops until their first create flow
   subscriptions           Subscription[] // Subscription history
   currentSubscriptionId   String? // Current active subscription
+  appEmbedEnabled         Boolean? // Cached app embed block status (refreshed every 5 min)
+  appEmbedCheckedAt       DateTime? // When appEmbedEnabled was last fetched from Shopify
+  appEmbedThemeId         String? // Cached theme GID for building theme editor URLs
   createdAt               DateTime       @default(now())
   updatedAt               DateTime       @updatedAt
 

--- a/tests/unit/lib/bundle-configure-loader.test.ts
+++ b/tests/unit/lib/bundle-configure-loader.test.ts
@@ -1,4 +1,5 @@
-import { fetchBundleProduct } from "../../../app/lib/bundle-configure-loader.server";
+import { fetchBundleProduct, fetchEmbedData } from "../../../app/lib/bundle-configure-loader.server";
+import { checkAppEmbedEnabled } from "../../../app/services/theme/app-embed-check.server";
 
 jest.mock("../../../app/lib/logger", () => ({
   AppLogger: {
@@ -9,6 +10,100 @@ jest.mock("../../../app/lib/logger", () => ({
 jest.mock("../../../app/services/theme/app-embed-check.server", () => ({
   checkAppEmbedEnabled: jest.fn(),
 }));
+
+const mockShopUpdate = jest.fn().mockResolvedValue({});
+const mockShopFindUnique = jest.fn();
+
+jest.mock("../../../app/db.server", () => ({
+  __esModule: true,
+  default: {
+    shop: {
+      findUnique: (...args: unknown[]) => mockShopFindUnique(...args),
+      update: (...args: unknown[]) => mockShopUpdate(...args),
+    },
+  },
+}));
+
+const THEME_GID = "gid://shopify/OnlineStoreTheme/123456";
+const SHOP = "test.myshopify.com";
+const API_KEY = "abc123";
+
+describe("fetchEmbedData — DB cache", () => {
+  const mockAdmin = {};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns cached value and skips Shopify API when cache is fresh", async () => {
+    mockShopFindUnique.mockResolvedValue({
+      appEmbedEnabled: true,
+      appEmbedCheckedAt: new Date(), // just now = fresh
+      appEmbedThemeId: THEME_GID,
+    });
+
+    const result = await fetchEmbedData(mockAdmin, SHOP, API_KEY);
+
+    expect(result.appEmbedEnabled).toBe(true);
+    expect(result.themeEditorUrl).toContain("123456");
+    expect(checkAppEmbedEnabled).not.toHaveBeenCalled();
+    expect(mockShopUpdate).not.toHaveBeenCalled();
+  });
+
+  it("calls Shopify API and updates cache when cache is stale", async () => {
+    const staleDate = new Date(Date.now() - 10 * 60 * 1000); // 10 min ago
+    mockShopFindUnique.mockResolvedValue({
+      appEmbedEnabled: true,
+      appEmbedCheckedAt: staleDate,
+      appEmbedThemeId: THEME_GID,
+    });
+    (checkAppEmbedEnabled as jest.Mock).mockResolvedValue({ enabled: true, themeId: THEME_GID });
+
+    const result = await fetchEmbedData(mockAdmin, SHOP, API_KEY);
+
+    expect(checkAppEmbedEnabled).toHaveBeenCalledTimes(1);
+    expect(mockShopUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ appEmbedEnabled: true }) }),
+    );
+    expect(result.appEmbedEnabled).toBe(true);
+  });
+
+  it("calls Shopify API and updates cache when no cache exists", async () => {
+    mockShopFindUnique.mockResolvedValue(null);
+    (checkAppEmbedEnabled as jest.Mock).mockResolvedValue({ enabled: false, themeId: THEME_GID });
+
+    const result = await fetchEmbedData(mockAdmin, SHOP, API_KEY);
+
+    expect(checkAppEmbedEnabled).toHaveBeenCalledTimes(1);
+    expect(mockShopUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ appEmbedEnabled: false }) }),
+    );
+    expect(result.appEmbedEnabled).toBe(false);
+  });
+
+  it("does not poison cache when Shopify returns themeId:null (network/error result)", async () => {
+    mockShopFindUnique.mockResolvedValue(null);
+    (checkAppEmbedEnabled as jest.Mock).mockResolvedValue({ enabled: false, themeId: null });
+
+    await fetchEmbedData(mockAdmin, SHOP, API_KEY);
+
+    expect(mockShopUpdate).not.toHaveBeenCalled();
+  });
+
+  it("builds correct theme editor URL from cached themeId", async () => {
+    mockShopFindUnique.mockResolvedValue({
+      appEmbedEnabled: true,
+      appEmbedCheckedAt: new Date(),
+      appEmbedThemeId: THEME_GID,
+    });
+
+    const result = await fetchEmbedData(mockAdmin, SHOP, API_KEY, "bundle-app-embed");
+
+    expect(result.themeEditorUrl).toBe(
+      `https://${SHOP}/admin/themes/123456/editor?context=apps&appEmbed=${API_KEY}%2Fbundle-app-embed`,
+    );
+  });
+});
 
 describe("fetchBundleProduct", () => {
   it("queries current Shopify product media for the Admin bundle product card", async () => {

--- a/tests/unit/services/app-embed-check.test.ts
+++ b/tests/unit/services/app-embed-check.test.ts
@@ -143,7 +143,9 @@ describe("checkAppEmbedEnabled", () => {
     expect(result.enabled).toBe(false);
   });
 
-  it("returns false when settings_data.json is malformed JSON", async () => {
+  it("returns enabled:true when settings_data.json is malformed JSON (fail-open — likely truncation)", async () => {
+    // settings_data.json can exceed Shopify's ~1MB limit and arrive truncated.
+    // We cannot confirm embed is disabled from a malformed file, so we fail-open.
     const admin = makeAdmin([
       THEME_LIST_RESPONSE,
       {
@@ -164,7 +166,7 @@ describe("checkAppEmbedEnabled", () => {
 
     const result = await checkAppEmbedEnabled(admin as any, "test.myshopify.com");
 
-    expect(result.enabled).toBe(false);
+    expect(result.enabled).toBe(true);
     expect(result.themeId).toBe("gid://shopify/OnlineStoreTheme/123456");
   });
 


### PR DESCRIPTION


EB calls GET /api/utility/isAppEmbedEnabled with HTTP ETag caching (~5 min TTL), avoiding a Shopify API hit on every page load. WPB now does the same via DB cache.

Schema: appEmbedEnabled, appEmbedCheckedAt, appEmbedThemeId on Shop model Logic: fetchEmbedData checks DB first; only calls checkAppEmbedEnabled on cache
       miss/stale; skips cache update when themeId is null (network error guard)
Tests: 5 new cache behavior tests + updated fail-open assertion (17 total, all pass)