### PR TITLE
[chromedevtools-commit-test-plan-1] docs: extend regression result (w…

### DIFF
--- a/docs/issues-prod/chromedevtools-commit-test-plan-1.md
+++ b/docs/issues-prod/chromedevtools-commit-test-plan-1.md
@@ -31,6 +31,13 @@ Create a Chrome DevTools test handoff for the latest five commits so the combine
 ### 2026-06-03 19:38 - Post-rebase version update
 - Updating the final staging plan to expect widget version `2.9.55` after rebasing onto the newer upstream widget build.
 
+### 2026-06-03 - Regression run continued (App Embed + widget version verified, new Save 500 finding)
+- Retraction: the earlier "Slot Icon sibling card" finding was a visual misread. Source (`full-page-bundle/.../route.tsx:4953–5030` and `product-page-bundle/.../route.tsx:4373–4449`) confirms Slot Icon is nested inside the same `<s-section>` as Enable Quantity Validation. No code change needed; corrected in result file.
+- Enabled the Wolfpack Bundle App Embed in the OS2 theme editor on `test-bundle-store123` and saved.
+- Verified live widget version on `/pages/preview-sit-regression-fpb`: `window.__BUNDLE_WIDGET_VERSION__ === "2.9.55"` ✓ (matches plan target).
+- **New blocker found:** Bundle Settings Save action returns HTTP 500 (`{"success":false,"error":"An error occurred"}`) when enabling `productSlotsEnabled` + `validateQuantityPerProduct` on the SIT backend. Save UI hangs on spinner with no surfaced error. Likely missing migration for new columns on SIT DB or a Render-side runtime error. Storefront Scenarios 4/5 and the FPB persistence sweep are blocked behind this fix. PPB pass deferred for the same reason.
+- Result file updated with all findings; checklist rows updated; follow-up list reprioritised to triage the Save 500 first.
+
 ### 2026-06-03 - Regression run executed (partial)
 - Ran the staging regression plan via Chrome DevTools MCP against `test-bundle-store123.myshopify.com` (plan's `wolfpack-store-test-1` was not open; user approved the substitution).
 - Created `SIT Regression FPB` from scratch (Amber Essence product) to enable scenario coverage.

--- a/docs/testing/staging-regression-result-1.md
+++ b/docs/testing/staging-regression-result-1.md
@@ -3,7 +3,7 @@
 **Executed:** 2026-06-03
 **Executed by:** Claude Code (Chrome DevTools MCP, live admin session)
 **Plan:** `docs/testing/chromedevtools-staging-regression-plan.md`
-**Status:** **Partial PASS** — All admin-side scenarios (1, 2, 3, 6, 7) verified on a fresh FPB. PPB and storefront scenarios deferred (see scope notes).
+**Status:** **Partial PASS with a new staging blocker** — Admin scenarios 1, 2, 3, 6, 7 pass on a fresh FPB; widget version 2.9.55 confirmed live on the storefront after enabling App Embed. Scenarios 4 and 5 are blocked by a backend Save 500 that prevents toggling Quantity Validation / Product Slots — see "Save 500 — NEW staging issue to escalate" below. PPB pass deferred behind the save fix.
 
 ## Deployment checked
 
@@ -11,7 +11,7 @@
 - **Admin URL:** `https://admin.shopify.com/store/test-bundle-store123/apps/wolfpack-product-bundles-sit/app/`
 - **App backend:** `https://wolfpack-product-bundle-app-sit.onrender.com`
 - **Storefront URL:** `https://test-bundle-store123.myshopify.com/`
-- **Widget version:** **Not verified** — App Embed is OFF and the storefront is password-protected (`1`). Bundle preview URL pattern observed: `/pages/preview-{bundle-slug}`.
+- **Widget version (re-run after enabling embed):** **`2.9.55` ✓** — read via `window.__BUNDLE_WIDGET_VERSION__` on `/pages/preview-sit-regression-fpb`. Asset URL: `https://cdn.shopify.com/extensions/019e8e0b-69ea-796d-ac90-b5d766d0e80f/wolfpack-product-bundles-sit-303/assets/bundle-widget-full-page-bundled.js`. App Embed is now ENABLED in the OS2 theme and saved.
 
 ## Scope notes
 
@@ -42,7 +42,11 @@ The bundle product was auto-created with parent status **Unlisted** when the bun
   4. **Slot Icon card** with heading "Slot Icon", subtitle "You can change the default icon that renders in the empty slots", buttons **Change Icon** and **Reset**, and note "Note: Only applicable when rules are based on quantity"
   5. Variant Selector, Show Text on + Button, Bundle Cart, etc.
 
-**Minor structural note:** the plan describes the Slot Icon as "inside the Enable Quantity Validation card". In the actual UI Slot Icon is its own `<h3>` card *adjacent to* Enable Quantity Validation / Product Slots, not nested inside it. The "Only applicable when rules are based on quantity" note keeps the semantic linkage. The substantive fix (per-bundle Slot Icon control, separated from Step Config) is in place.
+**Correction (post-review):** Earlier this report flagged Slot Icon as a "sibling card" of Enable Quantity Validation. That was a visual misread. The source confirms a single `<s-section>` wrapping EQV + max-qty input + Pro Tip banner + Product Slots sub-stack + Slot Icon sub-stack:
+- FPB: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/route.tsx` lines 4953–5030
+- PPB: `app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/route.tsx` lines 4373–4449
+
+A re-verified browser screenshot shows all three sub-headings inside one rounded white card. The Slot Icon **is** nested inside the Enable Quantity Validation card exactly as the plan describes. **No code change needed.**
 
 **Step Config does NOT contain a Slot Icon control** (per-step Step Config card on the Step Setup tab has only `Step Title` input + `Upload file` button — no Change Icon / Reset).
 
@@ -87,14 +91,25 @@ There is no separate "Step Summary" step in this wizard; the Step Summary appear
 
 ## Storefront evidence
 
-### Scenario 4 — Storefront Quantity Validation — **BLOCKED**
-App Embed is OFF; the storefront page does not load the bundle widget. Storefront also gated by password (`1`).
+### App Embed — **ENABLED** ✓
+Wolfpack Bundle app embed toggled ON and saved in the OS2 theme editor (`App embeds` panel). Visible to storefront.
 
-### Scenario 5 — Storefront Product Slots & Slot Icon — **BLOCKED**
-Same reason as Scenario 4.
+### Widget version check — **PASS** ✓
+On `https://test-bundle-store123.myshopify.com/pages/preview-sit-regression-fpb` (after entering storefront password `1`), `window.__BUNDLE_WIDGET_VERSION__` returned **`"2.9.55"`** — exact match to the plan. Widget asset loaded from `cdn.shopify.com/extensions/019e8e0b-69ea-796d-ac90-b5d766d0e80f/wolfpack-product-bundles-sit-303/assets/bundle-widget-full-page-bundled.js`. Widget DOM is built (`#bundle-builder-app.bundle-widget-container.bundle-widget-full-page` with 2 product cards in `.bundle-steps.full-page-layout`).
 
-### Widget version — **BLOCKED**
-`window.__BUNDLE_WIDGET_VERSION__` cannot be read until a bundle storefront page actually renders the widget.
+### Scenario 4 — Storefront Quantity Validation — **PARTIAL / BLOCKED on save backend**
+- Widget asset loads on the preview page (verified via DOM).
+- Bundle widget container is rendered (~4365 chars of inner HTML) but currently sized 0×0 because the bundle is `Draft` and parent product is `Unlisted`. Setting it to `Active` requires a successful Save.
+- **NEW FINDING: Save returns HTTP 500.** Attempted to enable Quantity Validation + Product Slots in Bundle Settings → click Save. Backend POST `…/configure/{id}?_data=routes/app/app.bundles.full-page-bundle.configure.$bundleId` returned `500` with body `{"success":false,"error":"An error occurred"}`. The save UI hangs on a spinner without surfacing the error. This blocks exercising the Quantity Validation max-quantity behavior on the storefront.
+
+### Scenario 5 — Storefront Product Slots & Slot Icon — **PARTIAL / BLOCKED on save backend**
+- Same blocker as Scenario 4: cannot enable `productSlotsEnabled` because the underlying save is 500-ing.
+- Slot Icon source UI was verified in the admin (see Scenario 2) — `Change Icon` opens the local file picker in-place, but persistence cannot be confirmed end-to-end without a successful save.
+
+### Save 500 — **NEW staging issue to escalate**
+- Failed request body (excerpt): `intent=saveBundle&…&productSlotsEnabled=true&maxQtyPerProduct=1&productSlotIconUrl=&validateQuantityPerProduct={"isEnabled":true,"allowedQuantity":1}`
+- Failed response: `500 {"success":false,"error":"An error occurred"}` (X-Render-Origin-Server: Render; X-Remix-Response: yes).
+- No detail in client console; backend error message is generic. Likely candidates: missing DB migration for new columns (`productSlotsEnabled` / `maxQtyPerProduct` / `productSlotIconUrl` / `validateQuantityPerProduct`) on the SIT DB, or a Render-side runtime error. Worth checking SIT Render logs for the corresponding stack trace at `2026-06-03T17:08:36Z`.
 
 ## PPB pass — **DEFERRED**
 Recommended for a separate session. FPB and PPB share the same code paths for the Slot Icon, Quantity Validation, and Product Slots fixes — FPB result is the reference.
@@ -115,11 +130,11 @@ No hard stop conditions were tripped. Blockers above are scope limitations of th
 | Area | Pass/Fail | Notes |
 |---|---|---|
 | Staging app loads in embedded Admin | **Pass** | Dashboard + wizard + configure page all functional |
-| Widget version is `2.9.55` | **Blocked** | App Embed off; storefront not exercised |
+| Widget version is `2.9.55` | **Pass** | Verified live via `window.__BUNDLE_WIDGET_VERSION__` after enabling App Embed |
 | Unlisted banner button says `Manage` | **Pass** | Verified on the FPB configure page |
 | `Manage` opens Shopify Products modal | **Pass** | Modal opens in-app, URL unchanged |
 | Bundle Product `Edit Product` opens same modal | **Pass** | Same product id `7938149056602`, identical dialog |
-| FPB Slot Icon location matches plan ("inside Enable Quantity Validation card") | **Partial — needs plan author sign-off** | Slot Icon is rendered as a sibling H3 card *adjacent to* Enable Quantity Validation, not nested inside it. "Note: Only applicable when rules are based on quantity" keeps the semantic linkage. Unclear if the plan wording is loose ("inside" ≈ "near") or if a structural change is expected. |
+| FPB Slot Icon location matches plan ("inside Enable Quantity Validation card") | **Pass (corrected)** | Earlier flagged as "sibling card" — that was a misread of the visual. Source (FPB route.tsx:4953–5030) confirms a single `<s-section>` containing EQV + max-qty input + Pro Tip banner + Product Slots + Slot Icon. Re-verified screenshot shows one rounded card containing all three sub-headings. |
 | FPB Slot Icon Change Icon does not redirect | **Pass** | Slot Icon picker modal opens in-place, URL unchanged |
 | PPB Slot Icon Change Icon does not redirect | **Deferred** | Same code path expected to pass; needs separate PPB pass |
 | Slot Icon persists after save/reload | **Not exercised** | Structural placement verified; persistence sweep skipped |
@@ -129,26 +144,26 @@ No hard stop conditions were tripped. Blockers above are scope limitations of th
 | PPB quantity validation persists | **Deferred** | |
 | FPB product slots persist | **Not exercised (structural pass)** | Independent checkbox confirmed |
 | PPB product slots persist | **Deferred** | |
-| FPB quantity max enforced on storefront desktop | **Blocked** | App Embed off |
-| FPB quantity max enforced on storefront mobile | **Blocked** | App Embed off |
-| PPB quantity max enforced on storefront desktop | **Blocked** | App Embed off |
-| PPB quantity max enforced on storefront mobile | **Blocked** | App Embed off |
-| FPB product slots toggle empty placeholders | **Blocked** | App Embed off |
-| PPB product slots toggle empty placeholders | **Blocked** | App Embed off |
-| FPB custom Slot Icon appears on storefront | **Blocked** | App Embed off |
-| PPB custom Slot Icon appears on storefront | **Blocked** | App Embed off |
+| FPB quantity max enforced on storefront desktop | **Blocked (save 500)** | Embed is now on, but Save 500 prevents enabling Quantity Validation / Product Slots |
+| FPB quantity max enforced on storefront mobile | **Blocked (save 500)** | Embed is now on, but Save 500 prevents enabling Quantity Validation / Product Slots |
+| PPB quantity max enforced on storefront desktop | **Blocked (save 500)** | Embed is now on, but Save 500 prevents enabling Quantity Validation / Product Slots |
+| PPB quantity max enforced on storefront mobile | **Blocked (save 500)** | Embed is now on, but Save 500 prevents enabling Quantity Validation / Product Slots |
+| FPB product slots toggle empty placeholders | **Blocked (save 500)** | Embed is now on, but Save 500 prevents enabling Quantity Validation / Product Slots |
+| PPB product slots toggle empty placeholders | **Blocked (save 500)** | Embed is now on, but Save 500 prevents enabling Quantity Validation / Product Slots |
+| FPB custom Slot Icon appears on storefront | **Blocked (save 500)** | Embed is now on, but Save 500 prevents enabling Quantity Validation / Product Slots |
+| PPB custom Slot Icon appears on storefront | **Blocked (save 500)** | Embed is now on, but Save 500 prevents enabling Quantity Validation / Product Slots |
 | Create wizard Preview appears in header | **Pass** | Configuration, Pricing, Assets — all three |
 | Create wizard footer has no Preview | **Pass** | Back/Next only on each step |
 | Step Summary has no Preview | **Pass (by absence)** | Wizard has no separate Step Summary step |
 | Old Design Control Panel is not used for Slot Icon | **Pass** | Slot Icon picker is local file modal, no DCP navigation |
 | No new uncaught Admin console errors | **Pass** | Only the pre-existing noise items above |
-| No new uncaught storefront console errors | **Blocked** | Storefront not exercised |
+| No new uncaught storefront console errors | **Pass (preview page only)** | Loaded `/pages/preview-sit-regression-fpb`; widget asset loaded; no new uncaught errors observed in this run |
 
 ## Recommended follow-ups
 
-1. **PPB pass** for Scenarios 2/3 on this store — fast, same flows.
-2. **Enable App Embed** in the OS2 theme editor and re-run Scenarios 4, 5, and the widget version check on both desktop and mobile.
-3. **Persistence sweep** on FPB Slot Icon / Quantity Validation / Product Slots (turn on, save, reload, confirm; Reset, save, reload, confirm).
+1. **🚨 Triage the Save 500 first.** Pull SIT Render logs for `POST …/app/bundles/full-page-bundle/configure/{id}?_data=…$bundleId` at `2026-06-03T17:08:36Z`. Likely the SIT DB is missing a migration for `productSlotsEnabled` / `maxQtyPerProduct` / `productSlotIconUrl` / `validateQuantityPerProduct` columns. Until that's fixed, Scenarios 4/5 can't be exercised on staging.
+2. **PPB pass** for Scenarios 2/3 — same code paths as FPB; quick once the save backend is healthy.
+3. **Persistence sweep** on FPB Slot Icon / Quantity Validation / Product Slots (turn on, save, reload, confirm; Reset, save, reload, confirm) — blocked by item 1.
 4. **Preview button branches**: investigate why "Enable Preview modal" did not appear for a saved bundle when embed is off — the click navigated straight to the preview URL. Confirm intended behavior matches plan text.
 5. **Cleanup**: the Add Products picker on this store shows leftover synced "Bundle"-titled products from prior runs (`1234`, `213`, `564`, `5678`, `abcdef`, etc.). Worth sweeping during the next round.
 6. **Cross-store sanity**: run the same regression on `wolfpack-store-test-1.myshopify.com` where bundles and embed are likely already configured — much faster execution.


### PR DESCRIPTION
…idget 2.9.55 verified, save 500 finding)

Continued the staging regression on test-bundle-store123 after enabling App Embed. Verified live widget version is `2.9.55` via window.__BUNDLE_WIDGET_VERSION__ on /pages/preview-sit-regression-fpb.

Retracts the earlier "Slot Icon sibling card" finding — source confirms Slot Icon is nested inside the same <s-section> as Enable Quantity Validation on both FPB and PPB; the earlier flag was a visual misread.

Documents a new staging blocker: the Bundle Settings save action returns HTTP 500 with `{"success":false,"error":"An error occurred"}` when toggling `productSlotsEnabled` + `validateQuantityPerProduct`. Storefront scenarios 4/5 and the PPB pass are deferred behind a fix.