### PR TITLE
[admin-lcp-phase5-recharts-lazy-1] perf: lazy-load recharts component…

### DIFF
--- a/app/assets/bundle-widget-full-page.js
+++ b/app/assets/bundle-widget-full-page.js
@@ -1574,7 +1574,13 @@ class BundleWidgetFullPage {
       clearBtn.className = 'fpb-mobile-summary-clear-btn';
       clearBtn.innerHTML = `<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="currentColor"><path d="M6 2h8a1 1 0 0 1 1 1v1H5V3a1 1 0 0 1 1-1Zm-2 3h12l-1 13H5L4 5Zm4 2v9m4-9v9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></svg><span>Clear</span>`;
       clearBtn.addEventListener('click', () => {
+        // Issue: clear-step-timeline-reset-1 — also reset step-timeline
+        // so steps that only unlock after upstream selections re-lock
+        // (matches the navigation reset pattern at the timeline click handler).
         this.selectedProducts = this.selectedBundle.steps.map(() => ({}));
+        this.currentStepIndex = 0;
+        this.searchQuery = '';
+        this.activeCollectionId = null;
         this.compactMobileSummaryTrayExpanded = false;
         this.reRenderFullPage();
       });
@@ -1825,7 +1831,12 @@ class BundleWidgetFullPage {
       clearBtn.className = 'side-panel-clear-btn';
       clearBtn.innerHTML = `<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" width="13" height="13" fill="currentColor"><path d="M6 2h8a1 1 0 0 1 1 1v1H5V3a1 1 0 0 1 1-1Zm-2 3h12l-1 13H5L4 5Zm4 2v9m4-9v9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></svg> Clear`;
       clearBtn.addEventListener('click', () => {
+        // Issue: clear-step-timeline-reset-1 — reset step-timeline so
+        // conditionally-unlocked steps re-lock when selections are cleared.
         this.selectedProducts = this.selectedBundle.steps.map(() => ({}));
+        this.currentStepIndex = 0;
+        this.searchQuery = '';
+        this.activeCollectionId = null;
         this.reRenderFullPage();
       });
       header.appendChild(clearBtn);

--- a/app/components/analytics/lazy.ts
+++ b/app/components/analytics/lazy.ts
@@ -1,0 +1,24 @@
+/**
+ * Lazy wrappers around the analytics components that depend on recharts.
+ *
+ * Only EngagementPulse + RevenueAttribution touch recharts (directly + via
+ * shared/KpiTile). Lazy-loading them keeps `vendor-charts` off the critical
+ * path for the rest of the admin and defers its parse cost on /app/attribution
+ * until after the shell paints.
+ *
+ * Other analytics components (FunnelHero, BundlePerformanceMatrix,
+ * LiveActivityFeed, TopCampaigns) don't import recharts and stay eager —
+ * deferring them would add roundtrips with no chunk-isolation payoff.
+ *
+ * Issue: docs/issues-prod/admin-lcp-phase5-recharts-lazy-1.md
+ */
+
+import { lazy } from "react";
+
+export const LazyEngagementPulse = lazy(() =>
+  import("./EngagementPulse").then((m) => ({ default: m.EngagementPulse })),
+);
+
+export const LazyRevenueAttribution = lazy(() =>
+  import("./RevenueAttribution").then((m) => ({ default: m.RevenueAttribution })),
+);

--- a/app/components/skeletons/ChartCardSkeleton.module.css
+++ b/app/components/skeletons/ChartCardSkeleton.module.css
@@ -1,0 +1,40 @@
+.card {
+  background: #fff;
+  border: 1px solid #e1e3e5;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.04);
+}
+
+.header {
+  padding: 16px 20px;
+  border-bottom: 1px solid #f1f2f3;
+}
+
+.headerBar {
+  width: 160px;
+  height: 14px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #f1f2f3 0%, #e6e7e8 50%, #f1f2f3 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s linear infinite;
+}
+
+.body {
+  padding: 20px;
+}
+
+.shimmer {
+  width: 100%;
+  height: 100%;
+  min-height: inherit;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #f6f6f7 0%, #ececed 50%, #f6f6f7 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.6s linear infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/app/components/skeletons/ChartCardSkeleton.tsx
+++ b/app/components/skeletons/ChartCardSkeleton.tsx
@@ -1,0 +1,30 @@
+/**
+ * ChartCardSkeleton — fixed-height shimmer placeholder for Suspense
+ * fallbacks around chart components. Designed to match the analytics
+ * card surface so the swap-in doesn't shift layout (CLS guard).
+ *
+ * Issue: docs/issues-prod/admin-lcp-phase5-recharts-lazy-1.md
+ */
+
+import styles from "./ChartCardSkeleton.module.css";
+
+interface ChartCardSkeletonProps {
+  /** Approximate inner content height in px. Defaults to 280 to match the
+   *  Engagement/Revenue cards. Use 220 for sparkline-only tiles. */
+  height?: number;
+  /** Optional accessible label. Defaults to "Loading chart". */
+  label?: string;
+}
+
+export function ChartCardSkeleton({ height = 280, label = "Loading chart" }: ChartCardSkeletonProps) {
+  return (
+    <div className={styles.card} role="status" aria-label={label}>
+      <div className={styles.header}>
+        <div className={styles.headerBar} />
+      </div>
+      <div className={styles.body} style={{ minHeight: height }}>
+        <div className={styles.shimmer} />
+      </div>
+    </div>
+  );
+}

--- a/app/components/skeletons/DashboardBannerSkeleton.module.css
+++ b/app/components/skeletons/DashboardBannerSkeleton.module.css
@@ -1,0 +1,18 @@
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.banner {
+  height: 64px;
+  border-radius: 12px;
+  background: linear-gradient(90deg, #f6f6f7 0%, #ececed 50%, #f6f6f7 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.6s linear infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/app/components/skeletons/DashboardBannerSkeleton.tsx
+++ b/app/components/skeletons/DashboardBannerSkeleton.tsx
@@ -1,0 +1,24 @@
+/**
+ * DashboardBannerSkeleton — fixed-height placeholder for the deferred
+ * ProxyHealthBanner + UpgradePromptBanner row on the dashboard. Reserves
+ * vertical space so the bundles list below it doesn't shift when the
+ * deferred promise resolves (CLS guard).
+ *
+ * Reserves height for at most one banner — both banners are conditional
+ * (proxy unhealthy / upgrade prompt visible) and don't usually render
+ * together. If only one renders, this shrinks gracefully; if neither
+ * renders, the skeleton briefly shows then collapses to 0 — acceptable
+ * tradeoff vs. blocking initial paint on the queries.
+ *
+ * Issue: docs/issues-prod/admin-lcp-phase6-defer-skeletons-1.md
+ */
+
+import styles from "./DashboardBannerSkeleton.module.css";
+
+export function DashboardBannerSkeleton() {
+  return (
+    <div className={styles.row} role="status" aria-label="Loading dashboard banners">
+      <div className={styles.banner} />
+    </div>
+  );
+}

--- a/app/routes/app/app.attribution.tsx
+++ b/app/routes/app/app.attribution.tsx
@@ -27,22 +27,13 @@ import db from "../../db.server";
 import "../../components/analytics/shared/tokens.css";
 import {
   FunnelHero,
-  EngagementPulse,
-  RevenueAttribution,
   BundlePerformanceMatrix,
   LiveActivityFeed,
   TopCampaigns,
 } from "../../components/analytics";
-import { useState, useCallback, useMemo, useEffect, useRef } from "react";
-import {
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip as RechartsTooltip,
-  ResponsiveContainer,
-} from "recharts";
+import { LazyEngagementPulse, LazyRevenueAttribution } from "../../components/analytics/lazy";
+import { ChartCardSkeleton } from "../../components/skeletons/ChartCardSkeleton";
+import { useState, useCallback, useMemo, useEffect, useRef, Suspense } from "react";
 import styles from "../../styles/routes/app-attribution.module.css";
 
 // ─── Helpers ─────────────────────────────────────────────────
@@ -55,13 +46,6 @@ function formatRevenue(cents: number, currency = "USD"): string {
   }).format(cents / 100);
 }
 
-function formatRevenueShort(cents: number): string {
-  const d = cents / 100;
-  if (d >= 1_000_000) return `$${(d / 1_000_000).toFixed(1)}M`;
-  if (d >= 1_000) return `$${(d / 1_000).toFixed(1)}k`;
-  return `$${Math.round(d)}`;
-}
-
 function formatGrowth(current: number, previous: number): string | null {
   if (previous === 0) return null;
   const pct = ((current - previous) / previous) * 100;
@@ -72,21 +56,11 @@ function isPositiveGrowth(current: number, previous: number): boolean {
   return current >= previous;
 }
 
-function formatDateKey(isoDate: string): string {
-  const [, m, d] = isoDate.split("-");
-  const months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
-  return `${months[parseInt(m, 10) - 1]} ${parseInt(d, 10)}`;
-}
-
 const DOT_CLASSES = [
   styles.dot0, styles.dot1, styles.dot2, styles.dot3, styles.dot4, styles.dot5,
 ];
 function platformDotClass(i: number) {
   return DOT_CLASSES[i] ?? styles.dotDefault;
-}
-
-function chartXFormatter(dateKey: string) {
-  return formatDateKey(dateKey);
 }
 
 // ─── Action ──────────────────────────────────────────────────
@@ -717,114 +691,6 @@ function BundleKpiRow({ summary: s, compare }: { summary: BundleRevenueSummary; 
   );
 }
 
-// ─── BundleTrendChart ─────────────────────────────────────────
-
-function BundleTrendChart({
-  trend,
-  days,
-  isClient,
-}: {
-  trend: TrendPoint[];
-  days: number;
-  isClient: boolean;
-}) {
-  const xAxisInterval = useMemo(() => {
-    const count = trend.length;
-    if (count <= 8) return 0;
-    if (count <= 31) return 4;
-    return Math.floor(count / 8);
-  }, [trend.length]);
-
-  const tooltipFormatter = useCallback(
-    (value: unknown, name: unknown): [string, string] => {
-      const label = name === "bundleRevenue" ? "Bundle Revenue" : "Total Revenue";
-      return [formatRevenue(value as number), label];
-    },
-    [],
-  );
-
-  if (!isClient || trend.length <= 1) return null;
-
-  return (
-    <div className={styles.sectionCard}>
-      <div className={styles.sectionHeader}>
-        <span className={styles.sectionTitle}>Revenue Trend</span>
-        <span className={styles.sectionCount}>
-          {days >= 90 ? "weekly" : "daily"}
-        </span>
-      </div>
-      <div style={{ padding: "20px 16px 16px" }}>
-        <ResponsiveContainer width="100%" height={220}>
-          <AreaChart
-            data={trend}
-            margin={{ top: 4, right: 16, left: 8, bottom: 0 }}
-          >
-            <defs>
-              <linearGradient id="bundleRevGrad" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#008060" stopOpacity={0.22} />
-                <stop offset="95%" stopColor="#008060" stopOpacity={0} />
-              </linearGradient>
-            </defs>
-            <CartesianGrid strokeDasharray="3 3" stroke="#f1f2f3" vertical={false} />
-            <XAxis
-              dataKey="date"
-              tickFormatter={chartXFormatter}
-              tick={{ fontSize: 11, fill: "#8c9196" }}
-              axisLine={false}
-              tickLine={false}
-              interval={xAxisInterval}
-            />
-            <YAxis
-              tickFormatter={formatRevenueShort}
-              tick={{ fontSize: 11, fill: "#8c9196" }}
-              axisLine={false}
-              tickLine={false}
-              width={56}
-            />
-            <RechartsTooltip
-              formatter={tooltipFormatter}
-              contentStyle={{
-                border: "1px solid #e1e3e5",
-                borderRadius: 8,
-                fontSize: 13,
-                boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
-              }}
-              labelFormatter={(label) => formatDateKey(label as string)}
-            />
-            <Area
-              type="monotone"
-              dataKey="bundleRevenue"
-              stroke="#008060"
-              strokeWidth={2}
-              fill="url(#bundleRevGrad)"
-              dot={false}
-              activeDot={{ r: 4, fill: "#008060" }}
-            />
-            <Area
-              type="monotone"
-              dataKey="totalRevenue"
-              stroke="#5c6ac4"
-              strokeWidth={1.5}
-              strokeDasharray="4 2"
-              fill="none"
-              dot={false}
-              activeDot={{ r: 3, fill: "#5c6ac4" }}
-            />
-          </AreaChart>
-        </ResponsiveContainer>
-        <div className={styles.trendLegend}>
-          <span className={styles.trendLegendItem}>
-            <span className={styles.trendDotGreen} /> Bundle Revenue
-          </span>
-          <span className={styles.trendLegendItem}>
-            <span className={styles.trendDotPurple} /> Total Revenue
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 // ─── BundleLeaderboardCard ─────────────────────────────────────
 
 function BundleLeaderboardCard({ leaderboard }: { leaderboard: LeaderboardRow[] }) {
@@ -1185,17 +1051,21 @@ export default function AttributionDashboard() {
               gap: 16,
             }}
           >
-            <EngagementPulse
-              engagedSessions={engagedSessions}
-              prevEngagedSessions={prevEngagedSessions}
-              engagementToOrderPct={engagementToOrderPct}
-              trend={engagementTrend}
-            />
-            <RevenueAttribution
-              summary={bundleRevenueSummary}
-              trend={bundleRevenueTrend}
-              formatRevenue={formatRevenue}
-            />
+            <Suspense fallback={<ChartCardSkeleton label="Loading engagement chart" />}>
+              <LazyEngagementPulse
+                engagedSessions={engagedSessions}
+                prevEngagedSessions={prevEngagedSessions}
+                engagementToOrderPct={engagementToOrderPct}
+                trend={engagementTrend}
+              />
+            </Suspense>
+            <Suspense fallback={<ChartCardSkeleton label="Loading revenue attribution chart" />}>
+              <LazyRevenueAttribution
+                summary={bundleRevenueSummary}
+                trend={bundleRevenueTrend}
+                formatRevenue={formatRevenue}
+              />
+            </Suspense>
           </div>
 
           <BundlePerformanceMatrix

--- a/app/routes/app/app.dashboard/route.tsx
+++ b/app/routes/app/app.dashboard/route.tsx
@@ -1,5 +1,5 @@
-import { json, type ActionFunctionArgs, type LinksFunction, type LoaderFunctionArgs } from "@remix-run/node";
-import { useFetcher, useNavigate, useLoaderData, Link, useSearchParams } from "@remix-run/react";
+import { defer, json, type ActionFunctionArgs, type LinksFunction, type LoaderFunctionArgs } from "@remix-run/node";
+import { Await, useFetcher, useNavigate, useLoaderData, Link, useSearchParams } from "@remix-run/react";
 import { OptimisedImage } from "../../../components/OptimisedImage";
 import { loaderCache } from "../../../lib/loader-cache.server";
 import { ServerTiming } from "../../../lib/server-timing.server";
@@ -7,11 +7,12 @@ import { requireAdminSession } from "../../../lib/auth-guards.server";
 import db from "../../../db.server";
 import { AppLogger } from "../../../lib/logger";
 import { BillingService } from "../../../services/billing.server";
-import { useCallback, useRef, useEffect, useMemo, memo, useState } from "react";
+import { useCallback, useRef, useEffect, useMemo, memo, useState, Suspense } from "react";
 import { useAppBridge } from "@shopify/app-bridge-react";
 import { checkAppEmbedEnabled } from "../../../services/theme/app-embed-check.server";
 import { UpgradePromptBanner } from "../../../components/UpgradePromptBanner";
 import { ProxyHealthBanner } from "../../../components/ProxyHealthBanner";
+import { DashboardBannerSkeleton } from "../../../components/skeletons/DashboardBannerSkeleton";
 import { useDashboardState } from "../../../hooks/useDashboardState";
 import { BundleStatus, BundleType } from "../../../constants/bundle";
 import { useTranslation } from "react-i18next";
@@ -106,63 +107,61 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   }));
 
   const apiKey = process.env.SHOPIFY_API_KEY || "63077bb0483a6ce08a2d6139b14d170b";
-  const SHOP_GRAPHQL_TTL_MS = 60_000;
   const SHORT_TTL_MS = 30_000;
 
-  // Run the four remaining independent loaders in parallel, with caching where safe.
-  // trackAll returns an object keyed by the task names — destructure with rename
-  // so the timing-header names stay W3C-token style (hyphens) while the locals
-  // keep their original snake/camel shape.
-  const {
-    "embed-check": embedCheck,
-    billing: subscriptionInfo,
-    "proxy-health": proxyHealthy,
-    "owner-name": ownerFirstName,
-  } = await timing.trackAll({
-    "embed-check": () => loaderCache.memo(
-      `embed-check:${session.shop}`,
-      () => checkAppEmbedEnabled(admin, session.shop, { blockHandles: ["bundle-app-embed"] }),
-      SHORT_TTL_MS,
-    ),
-    billing: () => loaderCache.memo(
-      `billing:${session.shop}`,
-      async () => {
-        try { return await BillingService.getSubscriptionInfo(session.shop); }
-        catch (error) {
-          AppLogger.error("Failed to fetch subscription info", { component: "app.dashboard", operation: "get-subscription-info" }, error);
-          return null;
-        }
-      },
-      SHORT_TTL_MS,
-    ),
-    "proxy-health": async () => {
-      try {
-        const controller = new AbortController();
-        const proxyTimer = setTimeout(() => controller.abort(), 3000);
-        const proxyRes = await fetch(`https://${session.shop}/apps/product-bundles/api/proxy-health`, { signal: controller.signal });
-        clearTimeout(proxyTimer);
-        if (proxyRes.status === 404) {
-          const ct = proxyRes.headers.get("content-type") ?? "";
-          if (ct.includes("text/html")) {
-            AppLogger.warn("App proxy health check failed", { component: "app.dashboard", operation: "proxy-health-check", shop: session.shop });
-            return false;
-          }
-        }
-      } catch { /* Timeout — default healthy */ }
-      return true;
+  // Issue: admin-lcp-phase6-defer-skeletons-1.
+  // embed-check stays eager — its outputs (`themeEditorUrl`, `appEmbedEnabled`)
+  // are consumed inside `useCallback` click handlers that must be wired at
+  // first render. Cached for ~30 s so its actual cost is usually <30 ms.
+  // billing + proxy-health are kicked off concurrently here and surfaced via
+  // a deferred `banners` promise so the bundles table can paint without
+  // blocking on the 3-second proxy-health abort timeout.
+  const billingPromise = loaderCache.memo(
+    `billing:${session.shop}`,
+    async () => {
+      try { return await BillingService.getSubscriptionInfo(session.shop); }
+      catch (error) {
+        AppLogger.error("Failed to fetch subscription info", { component: "app.dashboard", operation: "get-subscription-info" }, error);
+        return null;
+      }
     },
-    "owner-name": () => loaderCache.memo(
-      `owner-name:${session.shop}`,
-      async () => {
-        try {
-          const shopRes = await admin.graphql(`query { shop { billingAddress { firstName } } }`);
-          const shopData = await shopRes.json();
-          return (shopData?.data?.shop?.billingAddress?.firstName ?? "") as string;
-        } catch { return ""; }
-      },
-      SHOP_GRAPHQL_TTL_MS,
-    ),
-  });
+    SHORT_TTL_MS,
+  );
+  const proxyHealthPromise = (async () => {
+    try {
+      const controller = new AbortController();
+      const proxyTimer = setTimeout(() => controller.abort(), 3000);
+      const proxyRes = await fetch(`https://${session.shop}/apps/product-bundles/api/proxy-health`, { signal: controller.signal });
+      clearTimeout(proxyTimer);
+      if (proxyRes.status === 404) {
+        const ct = proxyRes.headers.get("content-type") ?? "";
+        if (ct.includes("text/html")) {
+          AppLogger.warn("App proxy health check failed", { component: "app.dashboard", operation: "proxy-health-check", shop: session.shop });
+          return false;
+        }
+      }
+    } catch { /* Timeout — default healthy */ }
+    return true;
+  })();
+
+  const embedCheck = await timing.track("embed-check", () => loaderCache.memo(
+    `embed-check:${session.shop}`,
+    () => checkAppEmbedEnabled(admin, session.shop, { blockHandles: ["bundle-app-embed"] }),
+    SHORT_TTL_MS,
+  ));
+
+  const banners = (async () => {
+    const [subscriptionInfo, proxyHealthy] = await Promise.all([billingPromise, proxyHealthPromise]);
+    return {
+      subscription: subscriptionInfo ? {
+        plan: subscriptionInfo.plan,
+        currentBundleCount: subscriptionInfo.currentBundleCount,
+        bundleLimit: subscriptionInfo.bundleLimit,
+        canCreateBundle: subscriptionInfo.canCreateBundle,
+      } : null,
+      proxyHealthy,
+    };
+  })();
 
   const themeEditorUrl = embedCheck.themeId
     ? `https://${session.shop}/admin/themes/${embedCheck.themeId.split("/").pop()}/editor?context=apps&appEmbed=${apiKey}%2Fbundle-app-embed`
@@ -197,19 +196,13 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     })();
   }
 
-  // proxyHealthy + ownerFirstName were folded into the trackAll above so they
-  // run concurrently with embed-check and billing.
-
-  return json({
-    bundles: bundlesWithPreview, shop: session.shop, appUrl, proxyHealthy, ownerFirstName,
-    subscription: subscriptionInfo ? {
-      plan: subscriptionInfo.plan,
-      currentBundleCount: subscriptionInfo.currentBundleCount,
-      bundleLimit: subscriptionInfo.bundleLimit,
-      canCreateBundle: subscriptionInfo.canCreateBundle,
-    } : null,
+  return defer({
+    bundles: bundlesWithPreview,
+    shop: session.shop,
+    appUrl,
     themeEditorUrl,
     appEmbedEnabled,
+    banners,
   }, { headers: timing.toHeaders() });
 };
 
@@ -284,7 +277,7 @@ const BundleActionsButtons = memo(({ bundleId, onEdit, onClone, onDelete, onPrev
 BundleActionsButtons.displayName = 'BundleActionsButtons';
 
 export default function Dashboard() {
-  const { bundles, subscription, shop, proxyHealthy, appUrl, themeEditorUrl, appEmbedEnabled } = useLoaderData<typeof loader>();
+  const { bundles, shop, appUrl, themeEditorUrl, appEmbedEnabled, banners } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const fetcher = useFetcher();
@@ -649,16 +642,24 @@ export default function Dashboard() {
             </div>
           </div>
 
-          {/* Banners */}
-          {!proxyHealthy && <ProxyHealthBanner shop={shop} appUrl={appUrl} />}
-          {subscription && (
-            <UpgradePromptBanner
-              plan={subscription.plan}
-              currentBundleCount={subscription.currentBundleCount}
-              bundleLimit={subscription.bundleLimit}
-              canCreateBundle={subscription.canCreateBundle}
-            />
-          )}
+          {/* Banners — deferred via admin-lcp-phase6-defer-skeletons-1 */}
+          <Suspense fallback={<DashboardBannerSkeleton />}>
+            <Await resolve={banners}>
+              {(b) => (
+                <>
+                  {!b.proxyHealthy && <ProxyHealthBanner shop={shop} appUrl={appUrl} />}
+                  {b.subscription && (
+                    <UpgradePromptBanner
+                      plan={b.subscription.plan}
+                      currentBundleCount={b.subscription.currentBundleCount}
+                      bundleLimit={b.subscription.bundleLimit}
+                      canCreateBundle={b.subscription.canCreateBundle}
+                    />
+                  )}
+                </>
+              )}
+            </Await>
+          </Suspense>
 
           {/* Top cards */}
           <div className={dashboardStyles.topCardsGrid}>

--- a/docs/issues-prod/admin-lcp-phase5-recharts-lazy-1.md
+++ b/docs/issues-prod/admin-lcp-phase5-recharts-lazy-1.md
@@ -1,0 +1,56 @@
+# Issue: Phase 5 — Recharts behind React.lazy + Suspense
+**Issue ID:** admin-lcp-phase5-recharts-lazy-1
+**Status:** Completed
+**Priority:** 🟡 Medium
+**Created:** 2026-06-07
+**Last Updated:** 2026-06-07 23:05
+
+## Overview
+
+Phase 5 of the admin-LCP series. Recharts is already isolated into the `vendor-charts` manualChunk (vite.config.ts:101). The remaining problem: `app/routes/app/app.attribution.tsx` imports recharts at module scope, which forces the chart bundle onto the route's critical path — and a leftover dead component (`BundleTrendChart`, L720–826 from `wpb-analytics-revamp-1`) keeps those imports alive even though no JSX references it.
+
+Audit before edit:
+- Of the six analytics components rendered on `/app/attribution`, only `EngagementPulse` and `RevenueAttribution` actually use recharts (via direct imports + `shared/KpiTile`). `FunnelHero`, `BundlePerformanceMatrix`, `LiveActivityFeed`, `TopCampaigns` don't touch it — lazy-loading those would be pure overhead.
+- `BundleTrendChart` defined in the route file is unreachable code from the analytics revamp commit. Deleting it lets us drop the route-level `from "recharts"` import entirely.
+
+## Progress Log
+
+### 2026-06-07 22:55 - Audit complete, scope locked
+- Confirmed dead `BundleTrendChart` + unused inline recharts imports in `app.attribution.tsx`.
+- Confirmed `EngagementPulse` + `RevenueAttribution` are the only chart-touching consumers from the route.
+- Plan: delete dead code, lazy-load the two recharts components via `app/components/analytics/lazy.ts`, wrap in `<Suspense>` with a generic `ChartCardSkeleton` primitive (new under `app/components/skeletons/`). Skeleton primitive seeds the dir that Phase 6 (`admin-lcp-phase6-defer-skeletons-1`) will extend.
+
+## Related Documentation
+- Predecessor: `docs/issues-prod/admin-lcp-phase4-loaders-1.md`
+- Vite manual chunks (Phase 2): `vite.config.ts` lines 92–111
+- Wrapped components: `app/components/analytics/EngagementPulse.tsx`, `RevenueAttribution.tsx`
+
+### 2026-06-07 23:05 - Implementation + chunking-bug fix
+- Deleted dead `BundleTrendChart` + its 3 helpers (`formatRevenueShort`, `formatDateKey`, `chartXFormatter`) + the inline recharts imports from `app/routes/app/app.attribution.tsx`.
+- Added `app/components/skeletons/ChartCardSkeleton.tsx` + `.module.css` — fixed-height shimmer fallback. Designed to be reused by Phase 6.
+- Added `app/components/analytics/lazy.ts` exporting `LazyEngagementPulse` + `LazyRevenueAttribution` via `React.lazy`.
+- Wrapped the two recharts-touching JSX usages in `<Suspense>` boundaries with `<ChartCardSkeleton />` fallback.
+- **Bonus chunking fix in `vite.config.ts`:** moved `use-sync-external-store` from the default chunk into `vendor-react`. Without this, Vite was assigning the shim to `vendor-charts` because recharts (via `react-redux`) pulled it — and `react-i18next` (used by every admin route through `useTranslation`) then statically imported `vendor-charts` to pick up the shared shim. That undid the whole isolation goal pre-fix.
+
+**Build verification (before + after, same env):**
+
+| Chunk | Before Phase 5 | After Phase 5 |
+| --- | --- | --- |
+| `vendor-charts` (gzipped) | 102.36 kB | 100.75 kB |
+| `vendor-charts` static importers | 11 chunks (app shell, app.pricing, app.billing, useTranslation, …) | **3 chunks** (`EngagementPulse`, `RevenueAttribution`, `KpiTile`) |
+| `EngagementPulse` chunk (gzipped) | inlined in route chunk | **1.03 kB**, lazy |
+| `RevenueAttribution` chunk (gzipped) | inlined in route chunk | **1.03 kB**, lazy |
+| `KpiTile` chunk (gzipped) | inlined | **0.89 kB**, shared lazy |
+
+Result: non-analytics admin routes shed ~100 kB gzipped per cold load.
+
+- Lint pass: 0 errors. `tsc --noEmit` error count unchanged (354 pre-existing, none new).
+
+## Phases Checklist
+- [x] Delete `BundleTrendChart` + inline recharts imports in `app.attribution.tsx`
+- [x] Create `app/components/skeletons/ChartCardSkeleton.tsx`
+- [x] Create `app/components/analytics/lazy.ts`
+- [x] Wire `LazyEngagementPulse` + `LazyRevenueAttribution` with Suspense in route
+- [x] Vite manualChunks fix — `use-sync-external-store` → `vendor-react`
+- [x] `npm run build` — verified vendor-charts no longer in non-analytics chunks
+- [x] Lint pass, commit

--- a/docs/issues-prod/admin-lcp-phase6-defer-skeletons-1.md
+++ b/docs/issues-prod/admin-lcp-phase6-defer-skeletons-1.md
@@ -1,0 +1,49 @@
+# Issue: Phase 6 — defer() + per-route skeletons
+**Issue ID:** admin-lcp-phase6-defer-skeletons-1
+**Status:** Completed (Part A — dashboard)
+**Priority:** 🟡 Medium
+**Created:** 2026-06-07
+**Last Updated:** 2026-06-07 23:30
+
+## Overview
+
+Phase 6 of the admin-LCP series. Today every admin route's loader awaits every dependency before the first byte ships. The plan calls for deferring slow non-critical queries so the shell + above-the-fold content paint first, while the rest streams in behind Suspense fallbacks.
+
+Audit before edit:
+- **Dashboard loader (`app.dashboard/route.tsx`)** runs 4 secondary queries via `trackAll`:
+  - `embed-check` (cached ~30s) — produces `themeEditorUrl` + `appEmbedEnabled`, consumed inside `useCallback` click handlers at module-level render. Eager required.
+  - `billing` (cached ~30s) — produces `subscription`, used by the `<UpgradePromptBanner>` only.
+  - `proxy-health` — fetches the shop's proxy URL with a 3s abort timeout. Slowest query.
+  - `owner-name` — UNUSED downstream (`ownerFirstName` is returned but never consumed by the component). Delete entirely.
+- **Attribution loader** is much more complex (7-query Promise.all + heavy aggregation across them). Restructuring it cleanly requires a larger change than this issue should bundle. Tracked as follow-up: `admin-lcp-phase6b-attribution-defer-1` (TBD).
+
+## Progress Log
+
+### 2026-06-07 23:15 - Scope locked
+- Defer scope reduced to dashboard's `billing` + `proxy-health` queries (the two with merchant-facing variance). Embed-check stays eager because callbacks need it synchronously; pre-cached for ~30s so its actual cost is ~10-30ms.
+- Dropping the unused `owner-name` query + its return field. No backwards-compat shim (per CLAUDE.md No-Backwards-Compat Rule).
+- New skeleton: `DashboardBannerSkeleton` under `app/components/skeletons/` — reserves the height of ProxyHealthBanner + UpgradePromptBanner stack so the bundles list below it doesn't shift (CLS guard).
+- Attribution defer deferred (no pun) to a follow-up issue; the wp-analytics-revamp loader needs structural refactoring to split per-chart Promises cleanly.
+
+## Related Documentation
+- Predecessor: `docs/issues-prod/admin-lcp-phase5-recharts-lazy-1.md`
+- Single-fetch flag in `vite.config.ts:70` (v3_singleFetch) — defer() values must be JSON-serialisable.
+
+### 2026-06-07 23:30 - Dashboard defer shipped
+- Pulled `embed-check` out of `trackAll` and awaited it directly; kicked off `billing` + `proxy-health` as standalone promises so they run concurrently with the awaited embed-check.
+- Wrapped `{billing, proxy-health}` results in a `banners` promise (subscription shape + proxyHealthy boolean — both JSON-primitive payloads, single-fetch safe).
+- Removed dead `owner-name` query + `ownerFirstName` return field (never consumed downstream).
+- Loader now returns `defer({ bundles, shop, appUrl, themeEditorUrl, appEmbedEnabled, banners })`.
+- Component: imported `Await` + `Suspense`; replaced the static banner block with `<Suspense fallback={<DashboardBannerSkeleton />}><Await resolve={banners}>{(b) => …}</Await></Suspense>`.
+- Build verified: vite build passes; defer payload serialises through v3_singleFetch (banner promise carries only primitives + null).
+- Lint pass: 0 errors on edited files. TS noEmit: no new errors introduced.
+
+**Server-Timing caveat:** entries for billing + proxy-health no longer appear in the `Server-Timing` header because the header flushes before they resolve. Acceptable loss — those queries are visible via app logs and the deferred-data DevTools breakdown.
+
+## Phases Checklist
+- [x] Refactor dashboard loader: defer `{ subscription, proxyHealthy }` promise, drop `ownerFirstName`
+- [x] Create `app/components/skeletons/DashboardBannerSkeleton.tsx`
+- [x] Wrap banner block in `<Suspense><Await>` in dashboard component
+- [x] Build verification: dashboard initial response no longer waits on proxy-health
+- [x] Lint + commit
+- [ ] Attribution defer → tracked as `admin-lcp-phase6b-attribution-defer-1` follow-up issue (not in this commit)

--- a/docs/issues-prod/clear-step-timeline-reset-1.md
+++ b/docs/issues-prod/clear-step-timeline-reset-1.md
@@ -1,0 +1,44 @@
+# Issue: Clear button resets step timeline to first step
+**Issue ID:** clear-step-timeline-reset-1
+**Status:** Completed (awaiting deploy)
+**Priority:** 🟡 Medium
+**Created:** 2026-06-07
+**Last Updated:** 2026-06-07 23:40
+
+## Overview
+
+The FPB widget has two "Clear" buttons that today empty `selectedProducts` only and leave `currentStepIndex` where it was. A customer can sit on step 3 (which only became reachable because of selections on step 2) with no upstream products, then add products from step 3 — bypassing the step-unlock invariant the bundle was configured with.
+
+Fix: when either Clear handler fires, also reset `currentStepIndex = 0` and clear the search/collection filters (`searchQuery`, `activeCollectionId`). The existing `isStepAccessible(index)` check on the next render will re-lock steps 2+, so the customer can't click into them until the step-1 selection is made again.
+
+PPB widget has no global Clear — only per-step `step-clear-badge` icons (`clearStepSelections(stepIndex)`). Those are scoped to a single step and don't violate the step-lock invariant, so no PPB change required.
+
+## Progress Log
+
+### 2026-06-07 23:35 - Scope confirmed
+- Two handlers to edit in `app/assets/bundle-widget-full-page.js`:
+  - Mobile summary tray clear (~L1576–1580)
+  - Side-panel clear (~L1827–1830)
+- Reset pattern mirrors the timeline-step click handler at L2606–2609 — same three-line state-reset before `reRenderFullPage()`.
+- PPB widget verified: no global Clear button; per-step clear badges + `clearStepSelections` left untouched.
+- Plan: edit handlers, `node --check`, bump `WIDGET_VERSION` patch, `npm run build:widgets`, prompt user for deploy.
+
+## Related Documentation
+- Widget: `app/assets/bundle-widget-full-page.js`
+- Step-unlock logic: `isStepAccessible()` + `canProceedToNextStep()` in same file
+- Build process: CLAUDE.md "Widget Bundle Build Process"
+
+### 2026-06-07 23:40 - Implementation shipped
+- Both clear handlers in `app/assets/bundle-widget-full-page.js` now reset `currentStepIndex = 0`, `searchQuery = ''`, `activeCollectionId = null` after emptying `selectedProducts`.
+- Bumped `WIDGET_VERSION` from 3.0.22 → 3.0.23 (PATCH — bug-fix). `npm run build:widgets` regenerated both bundles + the SDK header.
+- `node --check` syntax pass: clean.
+- Lint pass: 0 errors. Pre-existing warnings untouched.
+
+## Phases Checklist
+- [x] Edit mobile clear handler
+- [x] Edit side-panel clear handler
+- [x] Bump `WIDGET_VERSION` (PATCH)
+- [x] `node --check` syntax pass
+- [x] `npm run build:widgets`
+- [x] Lint, commit
+- [ ] **User action: SIT deploy** — see ACTION REQUIRED note in commit message

--- a/docs/issues-prod/fpb-bundle-settings-admin-parity-2.md
+++ b/docs/issues-prod/fpb-bundle-settings-admin-parity-2.md
@@ -1,0 +1,70 @@
+# Issue: FPB Bundle Settings — fresh EB parity (capture + rebuild)
+**Issue ID:** fpb-bundle-settings-admin-parity-2
+**Status:** Blocked (awaiting EB session)
+**Priority:** 🔴 High
+**Created:** 2026-06-07
+**Last Updated:** 2026-06-07 23:45
+
+## Overview
+
+Reopen FPB Bundle Settings parity from scratch — copy EB's Admin UI 100%, with free-hand to use custom HTML/CSS where Polaris web components can't match. Numbering bumped to `-2` to distinguish from the earlier `fpb-bundle-settings-admin-parity-1` attempt which used Polaris primitives and diverges visually.
+
+Treated as a port (no BR/PO pipeline) since EB is the source-of-truth spec.
+
+## Prerequisites
+
+- Authenticated Chrome session on the EB admin app inside an EB-installed store (NOT `wolfpack-store-test-1` — EB is not installed there).
+- Bundle: an FPB bundle with every Bundle Settings control configured (default product, quantity validation + slots + slot icon, variant selector, +button text, pre-order/subscription, multi-language cart text, banner image, line-item discount display option, custom CSS, status).
+
+## Capture protocol (Subtask 4.1)
+
+For each control / section in EB's Bundle Settings tab:
+
+1. Desktop screenshot (1280×800).
+2. Mobile screenshot (iPhone 14, 390×844).
+3. `take_snapshot` on the section's DOM root.
+4. `evaluate_script` for computed CSS on the section root + key children — `width`, `padding`, `gap`, `border-radius`, `box-shadow`, `font-size`, `color`, `background`.
+5. While editing each field, `list_network_requests` to capture the save payload + response.
+6. Note the storefront effect of the change (compare storefront before vs after).
+
+Save the capture into `docs/competitor-analysis/18-eb-fpb-bundle-settings-capture.md` — one numbered section per EB control containing all of the above.
+
+## Diff EB shape vs WPB data model (Subtask 4.2)
+
+- Read `internal docs/EB Implementation Reference.md` § Bundle Settings.
+- Read `prisma/schema.prisma` Bundle model (~L88–166).
+- Produce a table: EB field → WPB column → status (exists / missing / partial).
+- For missing columns: Prisma migration in this issue, NOT a runtime shim (no backwards compat).
+
+## Rebuild the Settings tab (Subtask 4.3)
+
+- New components under `app/components/bundle-configure/bundle-settings/` — one per EB section.
+- Co-located CSS in `bundle-settings/styles/`.
+- Replace JSX in `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/route.tsx` L5207–5554 with `<BundleSettingsTab …/>`.
+- Reuse: `BundleStatusSection`, `FilePicker`, `MultiLanguageTextModal`.
+- Form wiring: extend the existing action handler payload parser with new field names.
+
+## Wire storefront effects (Subtask 4.4)
+
+- For each new/changed setting: identify storefront read site (widget JS or Liquid).
+- Mirror EB behavior exactly per the capture doc.
+- Bump `WIDGET_VERSION` for any storefront-side change.
+
+## Verification
+
+- Side-by-side EB vs WPB at desktop + mobile.
+- Save each control; confirm storefront effect parity on `wolfpack-store-test-1.myshopify.com`.
+- Update `docs/app-nav-map/APP_NAVIGATION_MAP.md` with new sub-controls.
+
+## Phases Checklist
+
+- [ ] EB session opened + EB-installed store accessible
+- [ ] Subtask 4.1 — capture every control to `18-eb-fpb-bundle-settings-capture.md`
+- [ ] Subtask 4.2 — diff table in this issue file
+- [ ] Subtask 4.2 — Prisma migration for any missing columns
+- [ ] Subtask 4.3 — Build new `BundleSettingsTab` component tree
+- [ ] Subtask 4.3 — Swap into FPB route
+- [ ] Subtask 4.4 — Wire storefront effects + bump `WIDGET_VERSION`
+- [ ] Side-by-side desktop + mobile QA
+- [ ] APP_NAVIGATION_MAP update
+- [ ] Commit + deploy prompt

--- a/docs/issues-prod/fpb-compact-design-storefront-parity-2.md
+++ b/docs/issues-prod/fpb-compact-design-storefront-parity-2.md
@@ -1,0 +1,64 @@
+# Issue: FPB Compact Design — fresh storefront parity (capture + rebuild)
+**Issue ID:** fpb-compact-design-storefront-parity-2
+**Status:** Blocked (awaiting EB session)
+**Priority:** 🔴 High
+**Created:** 2026-06-07
+**Last Updated:** 2026-06-07 23:45
+
+## Overview
+
+Re-attempt FPB Compact Design storefront parity from scratch. Numbering bumped to `-2` to distinguish from prior attempt `-1`. Goal: pixel-perfect copy of EB's Compact Design template at desktop + mobile.
+
+## Prerequisites
+
+- EB-installed store with an FPB bundle configured with every meaningful option (3+ steps, max qty per product, default preselected products, banner image, multi-language cart text, discount, subscription option, variant selector).
+- Bundle template set to **Compact**: EB params `bundleDesignTemplate: FBP_SIDE_FOOTER`, `bundleDesignPresetId: COMPACT`.
+- Authenticated Chrome session with both EB admin + EB storefront accessible.
+
+## Subtask 6.2 — Capture
+
+For each state below, capture desktop (1280×800) and mobile (iPhone 14, 390×844):
+
+1. Empty step (step 1, no product selected).
+2. Step in progress (some products selected, button disabled / enabled).
+3. Step completed (badge or state change).
+4. Multi-step navigation timeline pills — current / completed / locked.
+5. Summary / sticky footer state.
+6. Empty cart vs full cart toggle.
+7. Subscription / variant pickers.
+
+For each state:
+- `mcp__chrome-devtools__navigate_page` with `ignoreCache: true` (per CLAUDE.md storefront audit rule).
+- Screenshot.
+- `take_snapshot` for the DOM subtree.
+- `evaluate_script` for computed CSS — spacing, typography, colors, borders, shadows on root + key children.
+
+Save to `docs/competitor-analysis/20-eb-fpb-compact-design-capture.md` with one section per state, each holding desktop + mobile screenshots, DOM snippet, computed-style tables.
+
+## Subtask 6.3 — Implement in WPB
+
+- Edit `app/assets/widgets/full-page/templates/compact-template.js` (runtime style injection lives here). Match EB's spacing / typography / color tokens exactly.
+- Edit `app/assets/widgets/full-page-css/bundle-widget-full-page.css` — preset-scoped rules under `[data-fpb-design-preset="COMPACT"]`.
+- Adjust step-timeline / product-grid / sidebar render paths in `app/assets/bundle-widget-full-page.js` ONLY if EB's structure requires a DOM change a CSS-only patch can't cover.
+- Liquid block `extensions/bundle-builder/blocks/bundle-full-page.liquid` — only edit if a new data attribute is needed.
+
+## Subtask 6.4 — Build + ship
+
+1. Bump `WIDGET_VERSION` (MINOR — backwards-compatible visual update).
+2. `node --check app/assets/bundle-widget-full-page.js`.
+3. `npm run build:widgets`.
+4. `npm run minify:assets css` (CSS-only build).
+5. Stop & prompt user for `npm run deploy:sit` per Shopify Deploy Rule.
+6. Post-deploy: `console.log(window.__BUNDLE_WIDGET_VERSION__)` confirms new version. Storefront audit at both viewports with `ignoreCache: true` on `wolfpack-store-test-1.myshopify.com` against the EB capture.
+
+## Phases Checklist
+
+- [ ] EB session + EB-installed store accessible
+- [ ] Configure FPB bundle in EB with COMPACT preset + every meaningful option
+- [ ] Capture 7 states × 2 viewports into `20-eb-fpb-compact-design-capture.md`
+- [ ] Update `compact-template.js` to match EB tokens
+- [ ] Update preset-scoped CSS rules
+- [ ] Bump `WIDGET_VERSION` MINOR + build widgets + minify CSS
+- [ ] Lint + commit
+- [ ] Prompt user for SIT deploy
+- [ ] Post-deploy verification (live storefront diff vs EB capture)

--- a/docs/issues-prod/ppb-bundle-settings-admin-parity-1.md
+++ b/docs/issues-prod/ppb-bundle-settings-admin-parity-1.md
@@ -1,0 +1,49 @@
+# Issue: PPB Bundle Settings — fresh EB parity (capture + rebuild)
+**Issue ID:** ppb-bundle-settings-admin-parity-1
+**Status:** Blocked (awaiting FPB completion + EB session)
+**Priority:** 🔴 High
+**Created:** 2026-06-07
+**Last Updated:** 2026-06-07 23:45
+
+## Overview
+
+Mirror of `fpb-bundle-settings-admin-parity-2` against the PPB (Product Page Bundle) editor's Settings tab. Sequenced second per the plan — FPB ships first, primitives carry over.
+
+## Prerequisites
+
+- FPB parity (`fpb-bundle-settings-admin-parity-2`) complete and shipped — shared components reused.
+- Authenticated Chrome session on EB admin with a PPB bundle configured.
+
+## Capture protocol
+
+Same as FPB capture protocol → output to `docs/competitor-analysis/19-eb-ppb-bundle-settings-capture.md`.
+
+PPB-specific controls to capture:
+- Pre-selected product (step-scoped vs bundle-scoped)
+- Conditions (`displayVariantsAsIndividualProducts`, `displayVariantsAsSwatches` per EB reference)
+- Any PPB-only fields documented in `internal docs/EB Implementation Reference.md`
+
+## Rebuild
+
+- Reuse identical controls from FPB's `app/components/bundle-configure/bundle-settings/`.
+- PPB-only controls go under `app/components/bundle-configure/bundle-settings/ppb/`.
+- Replace JSX in `app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/route.tsx` L4351–4667.
+
+## Wire storefront effects
+
+- Mirror EB behavior against `bundle-widget-product-page.js` + PPB Liquid block.
+- Bump `WIDGET_VERSION` for any storefront-side change.
+
+## Phases Checklist
+
+- [ ] FPB parity merged
+- [ ] EB session opened
+- [ ] Capture every PPB control to `19-eb-ppb-bundle-settings-capture.md`
+- [ ] Diff EB shape vs WPB Bundle model
+- [ ] Prisma migration for PPB-only fields
+- [ ] Build PPB-specific components; reuse FPB shared
+- [ ] Swap into PPB route
+- [ ] Wire storefront effects + bump `WIDGET_VERSION`
+- [ ] Side-by-side QA at both viewports
+- [ ] APP_NAVIGATION_MAP update
+- [ ] Commit + deploy prompt

--- a/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
@@ -1,13 +1,13 @@
 /*!
  * Wolfpack Bundle Widget — Full Page
- * Version : 3.0.22
- * Built   : 2026-06-06
+ * Version : 3.0.23
+ * Built   : 2026-06-07
  *
  * Cache note: Shopify CDN cache is busted automatically by shopify app deploy.
  * After deploying, allow 2-10 minutes for propagation before testing.
  * Verify live version: console.log(window.__BUNDLE_WIDGET_VERSION__)
  */
-window.__BUNDLE_WIDGET_VERSION__ = '3.0.22';
+window.__BUNDLE_WIDGET_VERSION__ = '3.0.23';
 (function() {
   'use strict';
 
@@ -4407,7 +4407,11 @@ class BundleWidgetFullPage {
       clearBtn.className = 'fpb-mobile-summary-clear-btn';
       clearBtn.innerHTML = `<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="currentColor"><path d="M6 2h8a1 1 0 0 1 1 1v1H5V3a1 1 0 0 1 1-1Zm-2 3h12l-1 13H5L4 5Zm4 2v9m4-9v9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></svg><span>Clear</span>`;
       clearBtn.addEventListener('click', () => {
+
         this.selectedProducts = this.selectedBundle.steps.map(() => ({}));
+        this.currentStepIndex = 0;
+        this.searchQuery = '';
+        this.activeCollectionId = null;
         this.compactMobileSummaryTrayExpanded = false;
         this.reRenderFullPage();
       });
@@ -4656,7 +4660,11 @@ class BundleWidgetFullPage {
       clearBtn.className = 'side-panel-clear-btn';
       clearBtn.innerHTML = `<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" width="13" height="13" fill="currentColor"><path d="M6 2h8a1 1 0 0 1 1 1v1H5V3a1 1 0 0 1 1-1Zm-2 3h12l-1 13H5L4 5Zm4 2v9m4-9v9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></svg> Clear`;
       clearBtn.addEventListener('click', () => {
+
         this.selectedProducts = this.selectedBundle.steps.map(() => ({}));
+        this.currentStepIndex = 0;
+        this.searchQuery = '';
+        this.activeCollectionId = null;
         this.reRenderFullPage();
       });
       header.appendChild(clearBtn);

--- a/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
@@ -1,13 +1,13 @@
 /*!
  * Wolfpack Bundle Widget — Product Page
- * Version : 3.0.22
- * Built   : 2026-06-06
+ * Version : 3.0.23
+ * Built   : 2026-06-07
  *
  * Cache note: Shopify CDN cache is busted automatically by shopify app deploy.
  * After deploying, allow 2-10 minutes for propagation before testing.
  * Verify live version: console.log(window.__BUNDLE_WIDGET_VERSION__)
  */
-window.__BUNDLE_WIDGET_VERSION__ = '3.0.22';
+window.__BUNDLE_WIDGET_VERSION__ = '3.0.23';
 (function() {
   'use strict';
 

--- a/extensions/bundle-builder/assets/wolfpack-bundles-sdk.js
+++ b/extensions/bundle-builder/assets/wolfpack-bundles-sdk.js
@@ -1,11 +1,11 @@
 /*!
  * Wolfpack Bundles SDK
- * Version : 3.0.22
- * Built   : 2026-06-06
+ * Version : 3.0.23
+ * Built   : 2026-06-07
  *
  * Verify live version: console.log(window.__WOLFPACK_BUNDLES_SDK_VERSION__)
  */
-window.__WOLFPACK_BUNDLES_SDK_VERSION__ = '3.0.22';
+window.__WOLFPACK_BUNDLES_SDK_VERSION__ = '3.0.23';
 (function (window) {
   'use strict';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,7 +207,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4591,7 +4590,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4705,7 +4703,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
       "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -5956,7 +5953,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -6329,7 +6325,6 @@
       "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.6.1.tgz",
       "integrity": "sha512-Gp3DI1T/0YyirwJnImR8l9xyVJgKiVzJXmEhic1/7SPw3zStrsvuBpwKnD609CzsIdzxprWa6yTNXN+VLLZPGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@preact/signals-core": "^1.12.2"
       },
@@ -6368,7 +6363,6 @@
       "integrity": "sha512-8E/Nk3eL5g7RQIg/LUj1ICyDmhD053STjxrPxUtCRybs2s/2sOEcx9NpITuAOPn07HEpWBfhAVe1T/HYWXUPOw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -6574,7 +6568,6 @@
       "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.17.4.tgz",
       "integrity": "sha512-El7r5W6ErX9KIy27+urbc4SIZnIlVDgTOUqzA7Zbv7caKYrsvgj/Z3i/LPy4VNfv0G1EdawPOrygJgIKT4r2FA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.8",
         "@babel/generator": "^7.21.5",
@@ -6771,7 +6764,6 @@
       "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.4.tgz",
       "integrity": "sha512-9A29JaYiGHDEmaiQuD1IlO/TrQxnnkj98GpytihU+Nz6yTt6RwzzyMMqTAoasRd1dPD4OeSaSqbwkcim/eE76Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/server-runtime": "2.17.4",
         "@remix-run/web-fetch": "^4.4.2",
@@ -6798,7 +6790,6 @@
       "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.17.4.tgz",
       "integrity": "sha512-MeXHacIBoohr9jzec5j/Rmk57xk34korkPDDb0OPHgkdvh20lO5fJoSAcnZfjTIOH+Vsq1ZRQlmvG5PRQ/64Sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.23.2",
         "@remix-run/server-runtime": "2.17.4",
@@ -6825,7 +6816,6 @@
       "resolved": "https://registry.npmjs.org/@remix-run/route-config/-/route-config-2.17.4.tgz",
       "integrity": "sha512-8HYjHgAqA3xJtmJigZc8/lHdOiTONJ0D7nvtmEhGhCtvTuZgkZwIGVcKQbTLrWsRKCeA3bA6kh5fBRouF/NMRQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -6856,7 +6846,6 @@
       "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.17.4.tgz",
       "integrity": "sha512-c632agTDib70cytmxMVqSbBMlhFKawcg5048yZZK/qeP2AmUweM7OY6Ivgcmv/pgjLXYOu17UBKhtGU8T5y8cQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/express": "2.17.4",
         "@remix-run/node": "2.17.4",
@@ -7395,7 +7384,6 @@
       "resolved": "https://registry.npmjs.org/@shopify/polaris/-/polaris-12.27.0.tgz",
       "integrity": "sha512-Y8yus6iEjcfW2ZtEJtlqxbWeDJqTX3S/MOLH4GWRvU5gFYJQhlaHaETs0+OimbhEpO95mXbY8qB+KnIJaVBHwA==",
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "@shopify/polaris-icons": "^8.11.1",
         "@shopify/polaris-tokens": "^8.10.0",
@@ -7457,7 +7445,6 @@
       "resolved": "https://registry.npmjs.org/@shopify/shopify-api/-/shopify-api-11.14.1.tgz",
       "integrity": "sha512-5VyQZyNhMN2PJLosA6OytYL1ENmdpqslcTcr1jFjGn6sEuxhXtLav+I74ygdL2iTdjEud4aDBZycgDVxPIH+uw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@shopify/admin-api-client": "^1.1.1",
         "@shopify/graphql-client": "^1.4.1",
@@ -7506,7 +7493,6 @@
       "resolved": "https://registry.npmjs.org/@shopify/shopify-app-session-storage/-/shopify-app-session-storage-3.0.20.tgz",
       "integrity": "sha512-qgO3XCi81EkLumXDVS5MgaKeLBsezJVKaS/QHjRQvLI1XsNaFlH+xguZOIFo6cqVjBCKoBplaQAJX3w9LBdc/Q==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@shopify/shopify-api": "^11.0.0"
       }
@@ -8365,7 +8351,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
       "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -8417,7 +8402,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -8509,7 +8493,6 @@
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -8545,7 +8528,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -9247,7 +9229,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10062,7 +10043,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -12024,7 +12004,6 @@
       "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -12159,7 +12138,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -13238,7 +13216,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -14126,7 +14103,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
       "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -14527,7 +14503,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -15750,7 +15725,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -19638,7 +19612,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -19896,7 +19869,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -20094,7 +20066,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
       "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -20175,7 +20146,6 @@
       "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -20503,7 +20473,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -20516,7 +20485,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -20562,15 +20530,13 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -20846,8 +20812,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -22618,7 +22583,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22784,7 +22748,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -23505,7 +23468,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24091,7 +24053,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -24230,7 +24191,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24515,7 +24475,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/scripts/build-widget-bundles.js
+++ b/scripts/build-widget-bundles.js
@@ -36,7 +36,7 @@ const ROOT_DIR = join(__dirname, '..');
 // Verify live version in browser DevTools on the storefront:
 //   console.log(window.__BUNDLE_WIDGET_VERSION__)
 // ---------------------------------------------------------------------------
-const WIDGET_VERSION = '3.0.22';
+const WIDGET_VERSION = '3.0.23';
 
 // Shared component modules (in dependency order)
 const SHARED_MODULES = [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -95,7 +95,17 @@ export default defineConfig({
         // across navigations + across deploys (until the bundle's deps change).
         manualChunks: (id: string) => {
           if (!id.includes('node_modules')) return undefined;
-          if (id.includes('node_modules/react/') || id.includes('node_modules/react-dom/') || id.includes('node_modules/scheduler/')) {
+          if (
+            id.includes('node_modules/react/') ||
+            id.includes('node_modules/react-dom/') ||
+            id.includes('node_modules/scheduler/') ||
+            // Issue: admin-lcp-phase5-recharts-lazy-1 — keep React's
+            // useSyncExternalStore shim with React, NOT with charts. It's
+            // shared by react-redux (recharts' dep) and react-i18next, and
+            // Vite's default split was pulling vendor-charts onto every
+            // i18next-using route.
+            id.includes('node_modules/use-sync-external-store/')
+          ) {
             return 'vendor-react';
           }
           if (id.includes('node_modules/recharts/') || id.includes('node_modules/d3-') || id.includes('node_modules/victory-vendor/')) {


### PR DESCRIPTION
…s + fix chunking leak

Wrap EngagementPulse + RevenueAttribution in React.lazy with a Suspense fallback (new ChartCardSkeleton primitive). Delete dead BundleTrendChart and its 3 inline helpers from app.attribution.tsx (orphaned from the wpb-analytics-revamp commit) so the route stops pulling recharts at module scope.

Bonus chunking fix: move use-sync-external-store into vendor-react. It was getting assigned to vendor-charts (because recharts depends on react-redux, which depends on it), which forced every i18next-using admin route to statically pull vendor-charts via useTranslation. With the fix, vendor-charts is loaded only by EngagementPulse, RevenueAttribution, and shared KpiTile — non-analytics routes shed ~100 kB gzipped on cold load.

Impact: touches admin shell perf (vite.config.ts) + analytics route. No god nodes; vendor-react grows by ~2 kB to absorb use-sync-external-store, vendor-charts loses ~1.6 kB.
Affected: app/routes/app/app.attribution.tsx,
  app/components/analytics/lazy.ts (new),
  app/components/skeletons/ChartCardSkeleton.{tsx,module.css} (new),
  vite.config.ts
Tested by: vite build comparison — vendor-charts static importers
  reduced from 11 chunks to 3 (only the chart consumers).