### PR TITLE
[offline-token-refresh-resilience-1] fix: handle invalid refresh toke…

### DIFF
--- a/app/lib/cached-session-storage.server.ts
+++ b/app/lib/cached-session-storage.server.ts
@@ -14,6 +14,7 @@ import {
   shouldRefreshOfflineSession,
   type OfflineSessionRecord,
 } from "../services/offline-token.server";
+import { AppLogger } from "./logger";
 
 const DEFAULT_TTL_MS = 10 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
@@ -71,6 +72,12 @@ export class CachedSessionStorage {
     }
 
     const hydratedRow = await this.refreshOfflineRowIfNeeded(row);
+    if (!hydratedRow) {
+      // Refresh failed because the refresh token was rejected by Shopify; the row
+      // has been deleted. Return undefined so the SDK performs fresh token exchange.
+      this.cache.delete(id);
+      return undefined;
+    }
     const session = this.rowToSession(hydratedRow);
     this.cache.set(id, {
       session,
@@ -124,9 +131,12 @@ export class CachedSessionStorage {
       orderBy: [{ expires: "desc" }],
     });
 
-    return Promise.all(
-      rows.map(async (row) => this.rowToSession(await this.refreshOfflineRowIfNeeded(row))),
+    const hydrated = await Promise.all(
+      rows.map((row) => this.refreshOfflineRowIfNeeded(row)),
     );
+    return hydrated
+      .filter((row): row is SessionRow => row !== null)
+      .map((row) => this.rowToSession(row));
   }
 
   async isReady(): Promise<boolean> {
@@ -144,16 +154,42 @@ export class CachedSessionStorage {
     return false;
   }
 
-  private async refreshOfflineRowIfNeeded(row: SessionRow): Promise<SessionRow> {
+  private async refreshOfflineRowIfNeeded(row: SessionRow): Promise<SessionRow | null> {
     if (row.isOnline || !shouldRefreshOfflineSession(row)) {
       return row;
     }
 
-    return (await refreshOfflineSession(
-      this.prisma,
-      row,
-      this,
-    )) as SessionRow;
+    try {
+      return (await refreshOfflineSession(this.prisma, row, this)) as SessionRow;
+    } catch (error) {
+      if (isRefreshTokenUnusable(error)) {
+        // Shopify rejected the refresh token. Drop the row so the SDK falls back
+        // to a fresh token exchange via id_token instead of looping on the bad
+        // refresh on every admin load.
+        AppLogger.warn(
+          "[CachedSessionStorage] Dropping session — refresh token rejected by Shopify",
+          { component: "cached-session-storage", shop: row.shop, sessionId: row.id },
+          error as Error,
+        );
+        this.cache.delete(row.id);
+        try {
+          await this.prisma.session.delete({ where: { id: row.id } });
+        } catch {
+          // Row may already be gone; nothing to do.
+        }
+        return null;
+      }
+
+      // Transient failure (network blip, Shopify 5xx, …). Keep the stale row so
+      // read-only requests can still proceed; downstream code surfaces re-auth
+      // when the access token itself is rejected.
+      AppLogger.warn(
+        "[CachedSessionStorage] Offline session refresh failed; serving stale row",
+        { component: "cached-session-storage", shop: row.shop, sessionId: row.id },
+        error as Error,
+      );
+      return row;
+    }
   }
 
   private cachedSessionNeedsRefresh(session: Session): boolean {
@@ -232,4 +268,12 @@ export class CachedSessionStorage {
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// requestOfflineToken formats errors as "Offline token request failed: {status} {description}".
+// A 401, or any response that explicitly names `invalid_grant`, signals that the
+// refresh token itself is no longer accepted — the row must be dropped, not retried.
+function isRefreshTokenUnusable(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /Offline token request failed:\s*401\b/.test(message) || /invalid_grant/i.test(message);
 }

--- a/docs/issues-prod/offline-token-refresh-resilience-1.md
+++ b/docs/issues-prod/offline-token-refresh-resilience-1.md
@@ -1,0 +1,99 @@
+# Issue: Offline Token Refresh Failures Crash `/app` SSR with 500
+
+**Issue ID:** offline-token-refresh-resilience-1
+**Status:** Completed
+**Priority:** 🔴 High
+**Created:** 2026-06-10
+**Last Updated:** 2026-06-10 23:55
+
+## Overview
+
+`authenticate.admin(request)` in `app/routes/app/app.tsx` throws an unhandled exception when a merchant's stored offline refresh token has been invalidated by Shopify. The Shopify SDK calls `CachedSessionStorage.loadSession()` / `findSessionsByShop()`, which in turn calls `refreshOfflineRowIfNeeded()` → `refreshOfflineSession()` → `requestOfflineToken()`. The OAuth endpoint returns `401 This request requires an active refresh_token`, `requestOfflineToken` throws, and the error propagates all the way up because **no caller swallows it**. Result: Remix shows `500 Unexpected Server Error` on every admin load for that shop until the row is deleted by hand.
+
+Verified live on SIT (`wolfpack-product-bundle-app-sit.onrender.com`) for `test-bundle-store123.myshopify.com`. Render log:
+
+```
+[shopify-app/INFO] Authenticating admin request | {shop: test-bundle-store123.myshopify.com}
+[APP:INFO][component=offline-token.server] [OFFLINE_TOKEN] Refreshing expiring offline session
+Error: Offline token request failed: 401 This request requires an active refresh_token
+    at requestOfflineToken (file:///app/build/server/index.js?t=1781110674000:165:11)
+```
+
+## Root Cause
+
+`app/lib/cached-session-storage.server.ts:147-157` — `refreshOfflineRowIfNeeded` calls `refreshOfflineSession` with no try/catch:
+
+```ts
+private async refreshOfflineRowIfNeeded(row: SessionRow): Promise<SessionRow> {
+  if (row.isOnline || !shouldRefreshOfflineSession(row)) {
+    return row;
+  }
+  return (await refreshOfflineSession(this.prisma, row, this)) as SessionRow;
+}
+```
+
+When the refresh token is invalid (401), the throw propagates through `loadSession`/`findSessionsByShop` → Shopify SDK → `authenticate.admin` → loader → Remix SSR error path → sanitized "Unexpected Server Error" returned to the iframe.
+
+## Fix Strategy
+
+Mirror the resilient pattern already used in `app/services/offline-token.server.ts:262-282` (`getOfflineSessionForShop`):
+
+1. Wrap `refreshOfflineSession` in `try/catch` inside `refreshOfflineRowIfNeeded`.
+2. Detect "refresh token is unusable" responses (HTTP 401, or `invalid_grant` in the error message) → **delete the stale session row from the DB, evict from cache, return `null`**. The SDK then sees "no session" and performs fresh token exchange via the `id_token` grant.
+3. Other failures (network, 5xx, unknown 4xx) → log warning, return the stale row unchanged. The access token may still be live for read-only requests; if not, downstream code surfaces a clean re-auth.
+4. Update `loadSession` to return `undefined` when refresh signals "delete me".
+5. Update `findSessionsByShop` to filter out deleted rows.
+
+## Phases Checklist
+
+- [x] Phase 1: Write unit tests for the four refresh-failure paths in `tests/unit/lib/cached-session-storage.test.ts` (Red) ✅
+- [x] Phase 2: Implement try/catch + delete-on-invalid-grant in `cached-session-storage.server.ts` (Green) ✅
+- [x] Phase 3: Verify lint + run unit tests ✅ (manual SIT re-verification: hand-off to user after deploy)
+
+## Progress Log
+
+### 2026-06-10 23:30 — Planning complete
+
+- Reproduced the 500 on SIT via Chrome DevTools MCP.
+- Traced stack via Render log to `requestOfflineToken` throw.
+- Confirmed via single-fetch probe (`/app.data`) that the root loader added in `461b1873` is healthy — this bug is independent of the app-bridge change.
+- Identified the resilient pattern in `getOfflineSessionForShop:262-282` as the reference to mirror.
+- Next: Phase 1 — write failing tests.
+
+### 2026-06-10 23:45 — Phase 1: Failing tests added (Red)
+
+- Added 4 new cases under `CachedSessionStorage refresh resilience` in `tests/unit/lib/cached-session-storage.test.ts:185+`:
+  - 401 refresh-token failure → undefined + row deleted
+  - `invalid_grant` failure → undefined + row deleted
+  - Transient `fetch failed` → stale row returned, no delete
+  - `findSessionsByShop` mixed-shop result excludes the bad row
+- Confirmed Red: 4 failed, 8 passed (baseline tests still green).
+
+### 2026-06-10 23:50 — Phase 2: Implementation (Green)
+
+- `app/lib/cached-session-storage.server.ts`:
+  - Imported `AppLogger`.
+  - Changed `refreshOfflineRowIfNeeded` return type to `Promise<SessionRow | null>`.
+  - Wrapped `refreshOfflineSession` in try/catch.
+  - On `isRefreshTokenUnusable(error)` (HTTP 401 or `invalid_grant`): evict cache, `prisma.session.delete`, return `null`.
+  - Other failures: warn-log, return the stale row (read-only requests still proceed).
+  - Updated `loadSession` to handle `null` → cache delete + return `undefined`.
+  - Updated `findSessionsByShop` to filter out `null` rows.
+  - Added `isRefreshTokenUnusable(error: unknown): boolean` helper at file bottom — matches `Offline token request failed:\s*401\b` or `invalid_grant` in the message.
+- All 12 tests in `cached-session-storage.test.ts` now pass.
+
+### 2026-06-10 23:55 — Phase 3: Lint + regression check
+
+- `npx eslint --max-warnings 9999 app/lib/cached-session-storage.server.ts tests/unit/lib/cached-session-storage.test.ts` → **0 errors**, 28 warnings (all pre-existing `prefer-nullish-coalescing` / `no-unsafe-argument` patterns identical to baseline).
+- Baselined `npx jest tests/unit/` against `main` via `git stash`: pre-existing failures = 29 suites / 105 tests. After my changes: same 29/105 fail + **+4 new tests pass**. Zero regressions.
+- Hand-off to user: deploy STAGING to SIT, then refresh the embedded app on `test-bundle-store123.myshopify.com`. SDK should fall through to fresh token exchange via id_token on next load.
+
+## Related Documentation
+
+- `app/services/offline-token.server.ts` — offline token request, refresh, and migration helpers.
+- `app/lib/cached-session-storage.server.ts` — Shopify session storage with in-memory TTL cache.
+- `app/routes/app/app.tsx` — the route whose loader calls `authenticate.admin(request)`.
+
+## Test Spec
+
+See `test-spec/cached-session-storage-refresh-resilience.spec.md`.

--- a/test-spec/cached-session-storage-refresh-resilience.spec.md
+++ b/test-spec/cached-session-storage-refresh-resilience.spec.md
@@ -1,0 +1,36 @@
+# Test Spec: CachedSessionStorage — Refresh Resilience
+
+**Spec ID:** cached-session-storage-refresh-resilience
+**Issue:** [offline-token-refresh-resilience-1]
+**Created:** 2026-06-10
+
+## Purpose
+
+Cover the failure paths of `refreshOfflineRowIfNeeded` so a Shopify-side refresh-token rejection no longer cascades to a Remix 500. Three behaviours need to hold:
+
+1. A 401 (`Offline token request failed: 401 …`) means the refresh token is unusable. The bad row must be deleted from the DB, evicted from cache, and the caller must observe "no session" so the SDK falls back to fresh token exchange.
+2. An `invalid_grant` failure has the same meaning — drop the row.
+3. Any other failure (network error, 5xx, unknown 4xx) is treated as transient. The stale row must be returned unchanged so the SDK can proceed; the access token may still be valid.
+
+## Test Cases
+
+### CachedSessionStorage.loadSession — refresh failures
+
+| # | Scenario | Input | Expected Output | Notes |
+|---|---|---|---|---|
+| 1 | 401 refresh-token failure | row with expiring offline session + refreshOfflineSession throws `Offline token request failed: 401 This request requires an active refresh_token` | `loadSession` returns `undefined`; `prisma.session.delete` called with the row's id; cache no longer holds the row | Mirrors the Render-log error seen in production |
+| 2 | `invalid_grant` failure | refreshOfflineSession throws `Offline token request failed: 400 invalid_grant` | `loadSession` returns `undefined`; row deleted | OAuth standard "refresh token invalidated" code |
+| 3 | Transient network failure | refreshOfflineSession throws `Error: fetch failed` (no HTTP status, no `invalid_grant`) | `loadSession` returns a `Session` built from the stale row; `prisma.session.delete` NOT called | Preserves uptime when Shopify is briefly unreachable |
+| 4 | Successful refresh | refreshOfflineSession resolves with a refreshed row | `loadSession` returns the refreshed session (existing behavior — must not regress) | Already covered by the existing test in this file |
+
+### CachedSessionStorage.findSessionsByShop — refresh failures
+
+| # | Scenario | Input | Expected Output | Notes |
+|---|---|---|---|---|
+| 5 | 401 refresh-token failure for one row in a multi-row shop | Two rows returned; one needs refresh and that refresh fails with 401 | Result contains only the healthy row; bad row deleted | Ensures the bad row doesn't poison the whole shop's session list |
+
+## Acceptance Criteria
+
+- [ ] All five test cases pass
+- [ ] No regression in the existing 8 tests of `cached-session-storage.test.ts`
+- [ ] No new ESLint errors introduced in `cached-session-storage.server.ts`

--- a/tests/unit/lib/cached-session-storage.test.ts
+++ b/tests/unit/lib/cached-session-storage.test.ts
@@ -181,3 +181,83 @@ describe("CachedSessionStorage passthrough methods", () => {
     expect(prisma.session.count).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("CachedSessionStorage refresh resilience", () => {
+  function makeExpiringRow() {
+    return makeRow({
+      expires: new Date(Date.now() + 1_000),
+      refreshToken: "refresh-token",
+      refreshTokenExpiresAt: new Date(Date.now() + 60_000),
+    });
+  }
+
+  it("drops the row and returns undefined when refresh fails with HTTP 401", async () => {
+    const prisma = makePrisma(makeExpiringRow());
+    const storage = new CachedSessionStorage(prisma as any, 60_000);
+    offlineTokenModule.refreshOfflineSession.mockRejectedValueOnce(
+      new Error(
+        "Offline token request failed: 401 This request requires an active refresh_token",
+      ),
+    );
+
+    const result = await storage.loadSession("offline_test.myshopify.com");
+
+    expect(result).toBeUndefined();
+    expect(prisma.session.delete).toHaveBeenCalledWith({
+      where: { id: "offline_test.myshopify.com" },
+    });
+  });
+
+  it("drops the row when refresh fails with invalid_grant", async () => {
+    const prisma = makePrisma(makeExpiringRow());
+    const storage = new CachedSessionStorage(prisma as any, 60_000);
+    offlineTokenModule.refreshOfflineSession.mockRejectedValueOnce(
+      new Error("Offline token request failed: 400 invalid_grant"),
+    );
+
+    const result = await storage.loadSession("offline_test.myshopify.com");
+
+    expect(result).toBeUndefined();
+    expect(prisma.session.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the stale row on a transient refresh failure (no delete)", async () => {
+    const prisma = makePrisma(makeExpiringRow());
+    const storage = new CachedSessionStorage(prisma as any, 60_000);
+    offlineTokenModule.refreshOfflineSession.mockRejectedValueOnce(
+      new Error("fetch failed"),
+    );
+
+    const result = await storage.loadSession("offline_test.myshopify.com");
+
+    expect(result?.accessToken).toBe("shpat_test");
+    expect(prisma.session.delete).not.toHaveBeenCalled();
+  });
+
+  it("filters out a bad row in findSessionsByShop while keeping the healthy one", async () => {
+    const badRow = {
+      ...makeExpiringRow(),
+      id: "offline_bad.myshopify.com",
+    };
+    const goodRow = makeRow({
+      id: "offline_good.myshopify.com",
+      accessToken: "shpat_good",
+    });
+    const prisma = makePrisma();
+    prisma.session.findMany.mockResolvedValue([badRow, goodRow]);
+    offlineTokenModule.refreshOfflineSession.mockRejectedValueOnce(
+      new Error(
+        "Offline token request failed: 401 This request requires an active refresh_token",
+      ),
+    );
+    const storage = new CachedSessionStorage(prisma as any, 60_000);
+
+    const result = await storage.findSessionsByShop("test.myshopify.com");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].accessToken).toBe("shpat_good");
+    expect(prisma.session.delete).toHaveBeenCalledWith({
+      where: { id: "offline_bad.myshopify.com" },
+    });
+  });
+});


### PR DESCRIPTION
…ns in CachedSessionStorage

When Shopify rejected the stored offline refresh token (HTTP 401 / invalid_grant), the throw from requestOfflineToken propagated through refreshOfflineRowIfNeeded → Shopify SDK → authenticate.admin → /app loader, hitting Remix's SSR error path and serving a 500 "Unexpected Server Error" to every embedded load until the row was deleted by hand. Verified on SIT for test-bundle-store123.myshopify.com.

Wrap refreshOfflineSession in try/catch in CachedSessionStorage. On a refresh- token-rejected response (401 or invalid_grant in the error message), delete the session row and evict the cache so the SDK falls back to fresh token exchange via id_token. On other failures (network, 5xx, unknown 4xx), serve the stale row — read-only requests can still proceed; access-token rejection downstream surfaces a clean re-auth. Mirrors the resilient pattern already in getOfflineSessionForShop:262-282.

Impact: touches Auth/Session community via the Shopify SDK session storage hook.
Affected: app/lib/cached-session-storage.server.ts
Tested by: tests/unit/lib/cached-session-storage.test.ts (+4 new cases; 12/12 green)
Spec: test-spec/cached-session-storage-refresh-resilience.spec.md