### PR TITLE
Prod

### DIFF
--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-constants.ts
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-constants.ts
@@ -53,7 +53,8 @@ export const stepSetupChildItems = [
 ];
 
 export const ADDON_MESSAGE_KEY = "addons-direct";
-export const ADDONS_HELP_ARTICLE_URL = "https://wolfpackapps.com";
+export const ADDONS_HELP_ARTICLE_URL =
+  "https://www.youtube.com/watch?v=5p_B81I7tWE";
 
 export const bundleVisibilityChildItems = [
   { id: "bundle_widget", label: "Bundle Widget" },

--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/FreeGiftAddonProductsCard.tsx
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/FreeGiftAddonProductsCard.tsx
@@ -42,9 +42,22 @@ export function FpbAddonProductsCard({
             </label>
             <button
               type="button"
-              className={fullPageBundleStyles.addonsHelpButton}
-              onClick={() => window.open(ADDONS_HELP_ARTICLE_URL, "_blank")}
+              className={fullPageBundleStyles.videoHelpButton}
+              onClick={() =>
+                window.open(
+                  ADDONS_HELP_ARTICLE_URL,
+                  "_blank",
+                  "noopener,noreferrer",
+                )
+              }
             >
+              <svg
+                className={fullPageBundleStyles.videoHelpIcon}
+                viewBox="0 0 10 10"
+                aria-hidden="true"
+              >
+                <path d="M2 1 L9 5 L2 9 Z" />
+              </svg>
               How to setup?
             </button>
           </div>

--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/StepSetupSection.tsx
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/StepSetupSection.tsx
@@ -38,9 +38,22 @@ export function StepSetupSection({
             </span>
             <button
               type="button"
-              className={fullPageBundleStyles.linkButton}
-              onClick={() => window.open("https://wolfpackapps.com", "_blank")}
+              className={fullPageBundleStyles.videoHelpButton}
+              onClick={() =>
+                window.open(
+                  "https://www.youtube.com/watch?v=5p_B81I7tWE",
+                  "_blank",
+                  "noopener,noreferrer",
+                )
+              }
             >
+              <svg
+                className={fullPageBundleStyles.videoHelpIcon}
+                viewBox="0 0 10 10"
+                aria-hidden="true"
+              >
+                <path d="M2 1 L9 5 L2 9 Z" />
+              </svg>
               How to setup?
             </button>
           </div>

--- a/app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/PpbFreeGiftAddonsSection.tsx
+++ b/app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/PpbFreeGiftAddonsSection.tsx
@@ -227,14 +227,26 @@ export function PpbFreeGiftAddonsSection() {
                   </div>
                   <s-stack direction="block" gap="small">
                     <s-stack direction="inline" gap="small">
-                      <s-button
-                        variant="secondary"
+                      <button
+                        type="button"
+                        className={productPageBundleStyles.videoHelpButton}
                         onClick={() =>
-                          window.open("https://wolfpackapps.com", "_blank")
+                          window.open(
+                            "https://www.youtube.com/watch?v=5ClNNtFybHo",
+                            "_blank",
+                            "noopener,noreferrer",
+                          )
                         }
                       >
+                        <svg
+                          className={productPageBundleStyles.videoHelpIcon}
+                          viewBox="0 0 10 10"
+                          aria-hidden="true"
+                        >
+                          <path d="M2 1 L9 5 L2 9 Z" />
+                        </svg>
                         How to setup?
-                      </s-button>
+                      </button>
                       <s-button variant="secondary" icon="globe" disabled>
                         Multi Language
                       </s-button>

--- a/app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/PpbStepFlowCard.tsx
+++ b/app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/PpbStepFlowCard.tsx
@@ -30,9 +30,22 @@ export function PpbStepFlowCard() {
           </span>
           <button
             type="button"
-            className={productPageBundleStyles.linkButton}
-            onClick={() => window.open("https://wolfpackapps.com", "_blank")}
+            className={productPageBundleStyles.videoHelpButton}
+            onClick={() =>
+              window.open(
+                "https://www.youtube.com/watch?v=5ClNNtFybHo",
+                "_blank",
+                "noopener,noreferrer",
+              )
+            }
           >
+            <svg
+              className={productPageBundleStyles.videoHelpIcon}
+              viewBox="0 0 10 10"
+              aria-hidden="true"
+            >
+              <path d="M2 1 L9 5 L2 9 Z" />
+            </svg>
             How to setup?
           </button>
         </div>

--- a/app/styles/routes/full-page-bundle-configure.module.css
+++ b/app/styles/routes/full-page-bundle-configure.module.css
@@ -204,6 +204,44 @@
   text-decoration: underline;
 }
 
+.videoHelpButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  padding: 4px 12px;
+  border: 1px solid #303030;
+  border-radius: 999px;
+  background: #303030;
+  color: #ffffff;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+}
+
+.videoHelpButton:hover,
+.videoHelpButton:focus-visible {
+  background: #1a1a1a;
+  border-color: #1a1a1a;
+  color: #ffffff;
+  text-decoration: none;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  outline: none;
+}
+
+.videoHelpIcon {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  fill: currentColor;
+}
+
 .leftCardTitle {
   margin: 0;
   color: #202223;

--- a/app/styles/routes/product-page-bundle-configure.module.css
+++ b/app/styles/routes/product-page-bundle-configure.module.css
@@ -229,6 +229,44 @@
   text-decoration: underline;
 }
 
+.videoHelpButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  padding: 4px 12px;
+  border: 1px solid #303030;
+  border-radius: 999px;
+  background: #303030;
+  color: #ffffff;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+}
+
+.videoHelpButton:hover,
+.videoHelpButton:focus-visible {
+  background: #1a1a1a;
+  border-color: #1a1a1a;
+  color: #ffffff;
+  text-decoration: none;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  outline: none;
+}
+
+.videoHelpIcon {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  fill: currentColor;
+}
+
 .leftCardTitle {
   margin: 0;
   color: #202223;


### PR DESCRIPTION
## Summary
- Restyle "How to setup?" links on the FPB and PPB configure pages as a filled dark pill with a play-icon glyph so it reads clearly as a distinct button (not confused with adjacent Polaris `s-button` variants).
- Point the FPB "How to setup?" buttons to the full-page walkthrough video: https://www.youtube.com/watch?v=5p_B81I7tWE
- Point the PPB "How to setup?" buttons to the product-page walkthrough video: https://www.youtube.com/watch?v=5ClNNtFybHo
- Previously both opened `wolfpackapps.com`.
- Applied on both the Step Flow card and the Free Gift / Add-Ons card on each page. The PPB Subscriptions "How to setup?" continues to toggle its inline setup guide and is intentionally unchanged.

## Files changed
- `app/styles/routes/full-page-bundle-configure.module.css` — new `.videoHelpButton` + `.videoHelpIcon`
- `app/styles/routes/product-page-bundle-configure.module.css` — new `.videoHelpButton` + `.videoHelpIcon`
- `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-constants.ts` — `ADDONS_HELP_ARTICLE_URL` → FPB video
- `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/StepSetupSection.tsx`
- `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/FreeGiftAddonProductsCard.tsx`
- `app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/PpbStepFlowCard.tsx`
- `app/routes/app/app.bundles.product-page-bundle.configure.$bundleId/PpbFreeGiftAddonsSection.tsx` (swapped `s-button` for native `<button>` using the new class)

## Impact Analysis
- **Communities touched**: Bundle configure Admin UI (FPB + PPB configure pages)
- **God nodes affected**: none
- **Downstream risk**: cosmetic + navigation only; no data or storefront-widget behaviour is affected. The PPB Subscriptions inline reveal is untouched, so its existing test (`ppb-subscriptions-setup-guide.test.ts`) is unaffected.
- **Test coverage**: none required — CSS + link URL swap. Per `CLAUDE.md`, no unit tests for styling / class names / placement.

## Test plan
- [ ] Open the FPB configure page in SIT and confirm the "How to setup?" pill in the Step Flow card and Add-Ons card open https://www.youtube.com/watch?v=5p_B81I7tWE in a new tab.
- [ ] Open the PPB configure page in SIT and confirm the "How to setup?" pill in the Step Flow card and Add-Ons card open https://www.youtube.com/watch?v=5ClNNtFybHo in a new tab.
- [ ] Confirm the pill is visually distinct from surrounding `s-button` and step-chip buttons (dark filled pill + play icon).
- [ ] Confirm PPB Subscriptions "How to setup?" still toggles its inline setup guide (unchanged).
