### PR TITLE
fix: optimize FPB save and storefront product data

### DIFF
--- a/app/assets/bundle-modal-component.js
+++ b/app/assets/bundle-modal-component.js
@@ -273,7 +273,16 @@ class BundleProductModal {
 
     // Keep the description row mounted so the modal layout remains stable.
     const descriptionEl = document.getElementById('modal-product-description');
-    descriptionEl.textContent = this.currentProduct.description || '';
+    const descriptionHtml = typeof this.currentProduct.descriptionHtml === 'string'
+      ? this.currentProduct.descriptionHtml.trim()
+      : '';
+    descriptionEl.textContent = '';
+    descriptionEl.innerHTML = '';
+    if (descriptionHtml) {
+      descriptionEl.innerHTML = descriptionHtml;
+    } else {
+      descriptionEl.textContent = this.currentProduct.description || '';
+    }
 
     // Load image
     this.loadImage();

--- a/app/assets/widgets/full-page/methods/product-processing-methods.js
+++ b/app/assets/widgets/full-page/methods/product-processing-methods.js
@@ -155,6 +155,12 @@ function normalizeProductDescription(product) {
   return (scratch.textContent || '').trim();
 }
 
+function normalizeProductDescriptionHtml(product) {
+  return typeof product?.descriptionHtml === 'string'
+    ? product.descriptionHtml.trim()
+    : '';
+}
+
 function collectCategoryProducts(step) {
   if (!Array.isArray(step?.categories)) return [];
 
@@ -287,6 +293,7 @@ export function normalizeFullPageDirectDefaultProduct(product) {
     }],
     images: imageUrl ? [{ src: imageUrl }] : [],
     description: normalizeProductDescription(product),
+    descriptionHtml: normalizeProductDescriptionHtml(product),
   };
 }
 
@@ -838,7 +845,8 @@ processProductsForStep(products, step) {
             variants: processedVariants,
             options: processedOptions,
             images: product.images || (product.imageUrl ? [{ src: product.imageUrl }] : []),
-            description: normalizeProductDescription(product)
+            description: normalizeProductDescription(product),
+            descriptionHtml: normalizeProductDescriptionHtml(product)
           };
         });
     } else {
@@ -887,7 +895,8 @@ processProductsForStep(products, step) {
         options: processedOptions,
         // Preserve the first image candidates for the product details modal.
         images: product.images || (product.imageUrl ? [{ src: product.imageUrl }] : []),
-        description: normalizeProductDescription(product)
+        description: normalizeProductDescription(product),
+        descriptionHtml: normalizeProductDescriptionHtml(product)
       }];
     }
   });
@@ -990,7 +999,7 @@ async enrichMissingProductDescriptions(products) {
   if (!Array.isArray(products) || products.length === 0) return products;
 
   const missingProductIds = Array.from(new Set(products
-    .filter(product => !normalizeProductDescription(product))
+    .filter(product => !normalizeProductDescriptionHtml(product))
     .map(productGraphqlId)
     .filter(Boolean)));
 
@@ -1014,17 +1023,27 @@ async enrichMissingProductDescriptions(products) {
     const descriptionsByProductId = new Map();
     (Array.isArray(data.products) ? data.products : []).forEach(product => {
       const description = normalizeProductDescription(product);
+      const descriptionHtml = normalizeProductDescriptionHtml(product);
       const key = productLookupKey(product);
-      if (key && description) descriptionsByProductId.set(key, description);
+      if (key && (description || descriptionHtml)) {
+        descriptionsByProductId.set(key, { description, descriptionHtml });
+      }
     });
 
     if (descriptionsByProductId.size === 0) return products;
 
     return products.map(product => {
-      if (normalizeProductDescription(product)) return product;
+      if (normalizeProductDescriptionHtml(product)) return product;
       const key = productLookupKey(product);
-      const description = key ? descriptionsByProductId.get(key) : '';
-      return description ? { ...product, description } : product;
+      const descriptions = key ? descriptionsByProductId.get(key) : null;
+      if (!descriptions) return product;
+
+      const existingDescription = normalizeProductDescription(product);
+      return {
+        ...product,
+        description: existingDescription || descriptions.description || '',
+        descriptionHtml: descriptions.descriptionHtml || '',
+      };
     });
   } catch (error) {
     return products;

--- a/app/assets/widgets/full-page/methods/tier-floating-runtime-methods.js
+++ b/app/assets/widgets/full-page/methods/tier-floating-runtime-methods.js
@@ -340,20 +340,16 @@ async _scheduleLayoutRefresh() {
     const data = await response.json();
     if (!data?.bundle) return;
 
-    const freshLayout = this.resolveFullPageLayout(data.bundle);
-    const currentLayout = this.resolveFullPageLayout();
     const freshTemplate = data.bundle.bundleDesignTemplate ?? null;
     const currentTemplate = this.selectedBundle?.bundleDesignTemplate ?? null;
     const freshPreset = data.bundle.bundleDesignPresetId ?? null;
     const currentPreset = this.selectedBundle?.bundleDesignPresetId ?? null;
 
-    if ((freshLayout !== currentLayout || freshTemplate !== currentTemplate || freshPreset !== currentPreset) && this.selectedBundle) {
-      this.selectedBundle.fullPageLayout = data.bundle.fullPageLayout;
+    if ((freshTemplate !== currentTemplate || freshPreset !== currentPreset) && this.selectedBundle) {
       this.selectedBundle.bundleDesignTemplate = data.bundle.bundleDesignTemplate ?? this.selectedBundle.bundleDesignTemplate;
       this.selectedBundle.bundleDesignPresetId = data.bundle.bundleDesignPresetId ?? this.selectedBundle.bundleDesignPresetId;
       this.selectedBundle.bundleDesignTemplateData = data.bundle.bundleDesignTemplateData ?? this.selectedBundle.bundleDesignTemplateData;
       if (this.bundleData?.[bundleId]) {
-        this.bundleData[bundleId].fullPageLayout = data.bundle.fullPageLayout;
         this.bundleData[bundleId].bundleDesignTemplate = data.bundle.bundleDesignTemplate ?? this.bundleData[bundleId].bundleDesignTemplate;
         this.bundleData[bundleId].bundleDesignPresetId = data.bundle.bundleDesignPresetId ?? this.bundleData[bundleId].bundleDesignPresetId;
         this.bundleData[bundleId].bundleDesignTemplateData = data.bundle.bundleDesignTemplateData ?? this.bundleData[bundleId].bundleDesignTemplateData;

--- a/app/assets/widgets/product-page/methods/product-data-methods.js
+++ b/app/assets/widgets/product-page/methods/product-data-methods.js
@@ -207,7 +207,8 @@ processProductsForStep(products, step) {
             variants: processedVariants,
             options: processedOptions,
             images: product.images || (product.imageUrl ? [{ src: product.imageUrl }] : []),
-            description: product.description || ''
+            description: product.description || '',
+            descriptionHtml: product.descriptionHtml || ''
           };
         });
     } else {
@@ -248,7 +249,8 @@ processProductsForStep(products, step) {
         options: processedOptions,
         // Preserve the first image candidates for the product details modal.
         images: product.images || (product.imageUrl ? [{ src: product.imageUrl }] : []),
-        description: product.description || ''
+        description: product.description || '',
+        descriptionHtml: product.descriptionHtml || ''
       }];
     }
   });

--- a/app/hooks/useBundleConfigurationState.ts
+++ b/app/hooks/useBundleConfigurationState.ts
@@ -39,7 +39,7 @@ import { useBundleForm } from "./useBundleForm";
 import { useBundleSteps } from "./useBundleSteps";
 import { useBundleConditions } from "./useBundleConditions";
 import { useBundlePricing } from "./useBundlePricing";
-import { FullPageLayout, type BundleStatus } from "../constants/bundle";
+import { type BundleStatus } from "../constants/bundle";
 import { normalizePricingRuleMessages } from "../lib/pricing-display-options";
 
 // ============================================
@@ -55,7 +55,6 @@ export interface BundleData {
   status: BundleStatus;
   bundleType: string;
   templateName?: string;
-  fullPageLayout?: string | null;
   shopifyProductId?: string;
   shopifyPageHandle?: string;
   shopifyPageId?: string;
@@ -124,7 +123,6 @@ export function useBundleConfigurationState({
       description: bundle.description || "",
       status: bundle.status,
       templateName: bundle.templateName || "",
-      fullPageLayout: bundle.fullPageLayout || FullPageLayout.FOOTER_BOTTOM,
     },
     onStateChange: markAsDirty
   });
@@ -367,7 +365,6 @@ export function useBundleConfigurationState({
     name: formState.bundleName,
     description: formState.bundleDescription,
     templateName: formState.templateName,
-    fullPageLayout: formState.fullPageLayout,
     steps: JSON.stringify(transformedSteps),
     discountEnabled: pricingState.discountEnabled,
     discountType: pricingState.discountType,
@@ -394,7 +391,6 @@ export function useBundleConfigurationState({
       formState.setBundleName(originalValues.name);
       formState.setBundleDescription(originalValues.description);
       formState.setTemplateName(originalValues.templateName);
-      formState.setFullPageLayout(originalValues.fullPageLayout);
 
       // Reset steps
       const originalSteps = JSON.parse(originalValues.steps);
@@ -452,7 +448,6 @@ export function useBundleConfigurationState({
       name: formState.bundleName,
       description: formState.bundleDescription,
       templateName: formState.templateName,
-      fullPageLayout: formState.fullPageLayout,
       steps: JSON.stringify(stepsState.steps),
       discountEnabled: pricingState.discountEnabled,
       discountType: pricingState.discountType,

--- a/app/hooks/useBundleForm.ts
+++ b/app/hooks/useBundleForm.ts
@@ -16,7 +16,6 @@ interface BundleFormData {
   description: string;
   status: BundleStatus;
   templateName: string;
-  fullPageLayout: string;
 }
 
 interface UseBundleFormProps {
@@ -30,7 +29,6 @@ export function useBundleForm({ initialData, onStateChange }: UseBundleFormProps
   const [bundleDescription, setBundleDescriptionRaw] = useState(initialData.description);
   const [bundleStatus, setBundleStatusRaw] = useState<BundleStatus>(initialData.status);
   const [templateName, setTemplateNameRaw] = useState(initialData.templateName);
-  const [fullPageLayout, setFullPageLayoutRaw] = useState(initialData.fullPageLayout);
 
   // UI state (doesn't trigger dirty flag)
   const [activeSection, setActiveSection] = useState("step_setup");
@@ -56,18 +54,12 @@ export function useBundleForm({ initialData, onStateChange }: UseBundleFormProps
     onStateChange?.();
   }, [onStateChange]);
 
-  const setFullPageLayout = useCallback((value: string | ((prev: string) => string)) => {
-    setFullPageLayoutRaw(value);
-    onStateChange?.();
-  }, [onStateChange]);
-
   return {
     // State
     bundleName,
     bundleDescription,
     bundleStatus,
     templateName,
-    fullPageLayout,
     activeSection,
 
     // Setters
@@ -75,7 +67,6 @@ export function useBundleForm({ initialData, onStateChange }: UseBundleFormProps
     setBundleDescription,
     setBundleStatus,
     setTemplateName,
-    setFullPageLayout,
     setActiveSection,
   };
 }

--- a/app/lib/bundle-formatter.server.ts
+++ b/app/lib/bundle-formatter.server.ts
@@ -24,7 +24,6 @@ export interface FormattedBundle {
   description: string | null;
   status: string;
   bundleType: string;
-  fullPageLayout: string | null;
   bundleDesignTemplate: string | null;
   bundleDesignPresetId: string | null;
   bundleDesignTemplateData: { templateId: string } | null;
@@ -263,7 +262,6 @@ export function formatBundleForWidget(bundle: any): FormattedBundle {
     description: bundle.description,
     status: bundle.status,
     bundleType: bundle.bundleType,
-    fullPageLayout: bundle.fullPageLayout ?? null,
     bundleDesignTemplate,
     bundleDesignPresetId,
     bundleDesignTemplateData,

--- a/app/routes/api/api.storefront-collections.tsx
+++ b/app/routes/api/api.storefront-collections.tsx
@@ -59,6 +59,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
                     title
                     handle
                     description
+                    descriptionHtml
                     featuredImage {
                       url
                     }
@@ -150,6 +151,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
             title: product.title,
             handle: product.handle,
             description: product.description || '',
+            descriptionHtml: product.descriptionHtml || '',
             imageUrl: product.featuredImage?.url || '',
             options: (product.options || []).map((option: any) => ({
               name: option.name,

--- a/app/routes/api/api.storefront-products.tsx
+++ b/app/routes/api/api.storefront-products.tsx
@@ -170,7 +170,7 @@ function buildProductsQuery(country: string | null, hasInventoryScope: boolean) 
     ? `query getProducts($ids: [ID!]!, $country: CountryCode!) @inContext(country: $country) {
         nodes(ids: $ids) {
           ... on Product {
-            id title handle description featuredImage { url }
+            id title handle description descriptionHtml featuredImage { url }
             variants(first: 1) {
               edges {
                 node {
@@ -187,7 +187,7 @@ function buildProductsQuery(country: string | null, hasInventoryScope: boolean) 
     : `query getProducts($ids: [ID!]!) {
         nodes(ids: $ids) {
           ... on Product {
-            id title handle description featuredImage { url }
+            id title handle description descriptionHtml featuredImage { url }
             variants(first: 1) {
               edges {
                 node {
@@ -332,6 +332,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
             title: product.title,
             handle: product.handle,
             description: product.description || '',
+            descriptionHtml: product.descriptionHtml || '',
             imageUrl: product.featuredImage?.url || '',
             variants: variantEdges.map(mapStorefrontVariant)
           };
@@ -344,6 +345,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
             title: product.title,
             handle: product.handle,
             description: product.description || '',
+            descriptionHtml: product.descriptionHtml || '',
             imageUrl: product.featuredImage?.url || '',
             variants: fallbackVariants
           };

--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureHiddenInputs.tsx
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureHiddenInputs.tsx
@@ -1,4 +1,5 @@
 import type { ConfigureBundleFlowContext } from "./useConfigureBundleFlow";
+import { serializeFpbSaveSteps } from "./fpb-save-transport";
 
 export function ConfigureHiddenInputs({
   flow,
@@ -15,6 +16,7 @@ export function ConfigureHiddenInputs({
     pricingState,
     ruleMessages,
     ruleMessagesByLocale,
+    selectedCollections,
     serializePricingDisplayOptions,
     stepsState,
     tierTextByLocaleByRuleId,
@@ -39,7 +41,9 @@ export function ConfigureHiddenInputs({
       <input
         type="hidden"
         name="stepsData"
-        value={JSON.stringify(stepsState.steps)}
+        value={JSON.stringify(
+          serializeFpbSaveSteps(stepsState.steps, selectedCollections),
+        )}
       />
       <input
         type="hidden"

--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/fpb-save-transport.ts
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/fpb-save-transport.ts
@@ -1,0 +1,278 @@
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function keepStringOrNumber(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  keys: string[],
+) {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string" && value.trim()) target[key] = value;
+    if (typeof value === "number" && Number.isFinite(value)) target[key] = value;
+  }
+}
+
+function keepBoolean(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  keys: string[],
+) {
+  for (const key of keys) {
+    if (typeof source[key] === "boolean") target[key] = source[key];
+  }
+}
+
+function compactImage(value: unknown): Record<string, unknown> | null {
+  const image = asRecord(value);
+  if (!image) return null;
+  for (const key of ["src", "url", "originalSrc"]) {
+    const imageUrl = image[key];
+    if (typeof imageUrl === "string" && imageUrl.trim()) {
+      return key === "originalSrc" ? { originalSrc: imageUrl } : { [key]: imageUrl };
+    }
+  }
+  return null;
+}
+
+function compactImages(value: unknown): Record<string, unknown>[] {
+  return asArray(value)
+    .map(compactImage)
+    .filter((image): image is Record<string, unknown> => image !== null)
+    .slice(0, 1);
+}
+
+function compactVariantImage(value: unknown): Record<string, unknown> | null {
+  const image = compactImage(value);
+  const src = image?.src ?? image?.url ?? image?.originalSrc;
+  return typeof src === "string" && src.trim() ? { src } : null;
+}
+
+function selectedOptionValue(source: Record<string, unknown>, index: number): string | null {
+  const selectedOption = asRecord(asArray(source.selectedOptions)[index - 1]);
+  const value = selectedOption?.value;
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function compactOptions(value: unknown): Array<string | Record<string, unknown>> {
+  return asArray(value)
+    .map((option) => {
+      if (typeof option === "string" && option.trim()) return option;
+      const optionRecord = asRecord(option);
+      if (!optionRecord) return null;
+
+      const compact: Record<string, unknown> = {};
+      const name = optionRecord.name;
+      if (typeof name === "string" && name.trim()) compact.name = name;
+      if (Array.isArray(optionRecord.values)) {
+        compact.values = optionRecord.values.filter(
+          (value) => typeof value === "string" || typeof value === "number",
+        );
+      }
+      return Object.keys(compact).length > 0 ? compact : null;
+    })
+    .filter((option): option is string | Record<string, unknown> => option !== null);
+}
+
+function compactVariant(value: unknown): Record<string, unknown> | null {
+  const source = asRecord(value);
+  if (!source) return null;
+
+  const compact: Record<string, unknown> = {};
+  keepStringOrNumber(compact, source, [
+    "id",
+    "variantId",
+    "variantGraphqlId",
+    "graphqlId",
+    "title",
+    "price",
+    "compareAtPrice",
+    "weight",
+  ]);
+  keepStringOrNumber(compact, source, ["weightUnit", "option1", "option2", "option3"]);
+
+  if (source.available === true || source.availableForSale === true) compact.available = true;
+  if (source.available === false || source.availableForSale === false) compact.available = false;
+  if (typeof source.quantityAvailable === "number" && Number.isFinite(source.quantityAvailable)) {
+    compact.quantityAvailable = source.quantityAvailable;
+  }
+  if (source.currentlyNotInStock === true) compact.currentlyNotInStock = true;
+
+  for (const key of ["option1", "option2", "option3"] as const) {
+    if (compact[key]) continue;
+    const selectedValue = selectedOptionValue(source, Number(key.replace("option", "")));
+    if (selectedValue) compact[key] = selectedValue;
+  }
+
+  const image = compactVariantImage(source.image) ?? compactVariantImage(source.imageUrl);
+  if (image) compact.image = image;
+  if (Array.isArray(source.sellingPlanAllocations) && source.sellingPlanAllocations.length > 0) {
+    compact.sellingPlanAllocations = source.sellingPlanAllocations;
+  }
+
+  return Object.keys(compact).length > 0 ? compact : null;
+}
+
+function compactVariants(value: unknown): Record<string, unknown>[] {
+  return asArray(value)
+    .map(compactVariant)
+    .filter((variant): variant is Record<string, unknown> => variant !== null);
+}
+
+function compactProduct(value: unknown): Record<string, unknown> | null {
+  const source = asRecord(value);
+  if (!source) return null;
+
+  const compact: Record<string, unknown> = {};
+  keepStringOrNumber(compact, source, [
+    "id",
+    "productId",
+    "graphqlId",
+    "handle",
+    "title",
+    "name",
+    "imageUrl",
+    "description",
+    "descriptionHtml",
+    "price",
+    "compareAtPrice",
+    "weight",
+    "weightUnit",
+    "minQuantity",
+    "maxQuantity",
+  ]);
+  keepBoolean(compact, source, ["available", "availableForSale"]);
+
+  const images = compactImages(source.images);
+  if (images.length > 0) compact.images = images;
+
+  const variants = compactVariants(source.variants);
+  if (variants.length > 0) compact.variants = variants;
+
+  const options = compactOptions(source.options);
+  if (options.length > 0) compact.options = options;
+
+  for (const key of ["featuredImage", "image"]) {
+    const image = compactImage(source[key]);
+    if (image) compact[key] = image;
+  }
+
+  return Object.keys(compact).length > 0 ? compact : null;
+}
+
+function compactProducts(value: unknown): Record<string, unknown>[] {
+  return asArray(value)
+    .map(compactProduct)
+    .filter((product): product is Record<string, unknown> => product !== null);
+}
+
+function compactCollection(value: unknown): Record<string, unknown> | null {
+  const source = asRecord(value);
+  if (!source) return null;
+
+  const compact: Record<string, unknown> = {};
+  keepStringOrNumber(compact, source, [
+    "id",
+    "collectionId",
+    "admin_graphql_api_id",
+    "handle",
+    "title",
+  ]);
+  return Object.keys(compact).length > 0 ? compact : null;
+}
+
+function compactCollections(value: unknown): Record<string, unknown>[] {
+  return asArray(value)
+    .map(compactCollection)
+    .filter((collection): collection is Record<string, unknown> => collection !== null);
+}
+
+function compactCategory(value: unknown): Record<string, unknown> | null {
+  const source = asRecord(value);
+  if (!source) return null;
+
+  const compact: Record<string, unknown> = {};
+  keepStringOrNumber(compact, source, [
+    "id",
+    "categoryId",
+    "name",
+    "title",
+    "subTitle",
+    "sortOrder",
+    "categoryRank",
+    "categoryBanner",
+    "categoryImg",
+  ]);
+  keepBoolean(compact, source, [
+    "autoNextStepOnConditionMet",
+    "displayVariantsAsIndividualProducts",
+    "displayVariantsAsSwatches",
+  ]);
+
+  compact.products = compactProducts(source.products);
+  compact.selectedProducts = compactProducts(source.selectedProducts);
+  compact.collections = compactCollections(source.collections);
+  compact.collectionsData = compactCollections(source.collectionsData);
+  compact.collectionsSelectedData = compactCollections(source.collectionsSelectedData);
+  compact.conditions = asArray(source.conditions);
+
+  const multiLangData = asRecord(source.multiLangData);
+  compact.multiLangData = multiLangData ?? null;
+
+  return compact;
+}
+
+function compactCategories(value: unknown): Record<string, unknown>[] {
+  return asArray(value)
+    .map(compactCategory)
+    .filter((category): category is Record<string, unknown> => category !== null);
+}
+
+export function serializeFpbSaveSteps(
+  steps: unknown[] = [],
+  selectedCollectionsByStepId: Record<string, unknown[]> = {},
+) {
+  return steps.map((step) => {
+    const source = asRecord(step) ?? {};
+    const stepId = typeof source.id === "string" ? source.id : "";
+    const selectedCollections = stepId ? selectedCollectionsByStepId[stepId] : undefined;
+    const collections = selectedCollections ?? source.collections ?? [];
+
+    return {
+      id: source.id,
+      name: source.name,
+      pageTitle: source.pageTitle ?? null,
+      multiLangData: asRecord(source.multiLangData) ?? {},
+      stepImage: source.stepImage ?? source.timelineIconUrl ?? null,
+      minQuantity: source.minQuantity ?? 1,
+      maxQuantity: source.maxQuantity ?? 1,
+      enabled: source.enabled !== false,
+      displayVariantsAsIndividual: source.displayVariantsAsIndividual ?? false,
+      products: compactProducts(source.products),
+      collections: compactCollections(collections),
+      filters: Array.isArray(source.filters) ? source.filters : null,
+      isFreeGift: false,
+      freeGiftName: null,
+      addonLabel: null,
+      addonTitle: null,
+      addonAddText: null,
+      addonReplaceText: null,
+      addonIconUrl: null,
+      addonDisplayFree: false,
+      addonTiers: [],
+      addonUnlockAfterCompletion: true,
+      isDefault: source.isDefault === true,
+      defaultVariantId: source.defaultVariantId ?? null,
+      imageUrl: source.imageUrl ?? null,
+      bannerImageUrl: source.bannerImageUrl ?? null,
+      StepProduct: compactProducts(source.StepProduct),
+      StepCategory: compactCategories(source.StepCategory),
+    };
+  });
+}

--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/save-bundle-form.server.ts
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/save-bundle-form.server.ts
@@ -1,4 +1,3 @@
-import { FullPageLayout } from "../../../../constants/bundle";
 import { processCss } from "../../../../lib/css-sanitizer";
 import { parseIndividualSellingPlanSelection } from "./shared.server";
 
@@ -53,8 +52,6 @@ export function parseFpbSaveBundleForm(formData: FormData) {
   const bundleDescription = formData.get("bundleDescription") as string;
   const bundleStatus = formData.get("bundleStatus") as string;
   const templateName = (formData.get("templateName") as string) || null;
-  const fullPageLayout =
-    (formData.get("fullPageLayout") as string) || FullPageLayout.FOOTER_BOTTOM;
   const promoBannerBgImageRaw = formData.get("promoBannerBgImage") as string;
   const promoBannerBgImage = promoBannerBgImageRaw || null;
   const loadingGifRaw = formData.get("loadingGif") as string;
@@ -182,7 +179,6 @@ export function parseFpbSaveBundleForm(formData: FormData) {
     discountData,
     floatingBadgeEnabled,
     floatingBadgeText,
-    fullPageLayout,
     individualSellingPlanSelection,
     loadingGif,
     maxQtyPerProduct,

--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/save-bundle.server.ts
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/save-bundle.server.ts
@@ -81,7 +81,6 @@ export async function handleSaveBundle(
       discountData,
       floatingBadgeEnabled,
       floatingBadgeText,
-      fullPageLayout,
       individualSellingPlanSelection,
       loadingGif,
       maxQtyPerProduct,
@@ -279,7 +278,6 @@ export async function handleSaveBundle(
         shopifyProductId:
           bundleProductData?.id || existingBundle?.shopifyProductId || null,
         templateName: templateName,
-        fullPageLayout: fullPageLayout as any,
         promoBannerBgImage: promoBannerBgImage,
         loadingGif: loadingGif,
         showStepTimeline: showStepTimelineParsed,

--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/shared.server.ts
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/handlers/shared.server.ts
@@ -5,7 +5,6 @@ import { safeJsonParse } from "../../../../services/bundles/bundle-configure-han
 import {
   BundleStatus,
   BundleType,
-  FullPageLayout,
 } from "../../../../constants/bundle";
 import {
   formatProductReferencesForRuntime,
@@ -245,7 +244,6 @@ export function buildFullPageBundleMetafieldConfig(
     description: bundle.description || "",
     status: bundle.status,
     bundleType: bundle.bundleType || BundleType.FULL_PAGE,
-    fullPageLayout: bundle.fullPageLayout || FullPageLayout.FOOTER_BOTTOM,
     templateName: bundle.templateName || null,
     shopifyProductId: bundle.shopifyProductId || null,
     shopifyPageHandle:
@@ -271,7 +269,6 @@ export function buildFpbBaseConfig(
     description: string | null;
     status: string;
     bundleType: string;
-    fullPageLayout: string | null;
     templateName: string | null;
     shopifyProductId: string | null;
     shopifyPageHandle: string | null;
@@ -351,8 +348,6 @@ export function buildFpbBaseConfig(
     description: updatedBundle.description,
     status: updatedBundle.status,
     bundleType: updatedBundle.bundleType,
-    fullPageLayout:
-      updatedBundle.fullPageLayout || FullPageLayout.FOOTER_BOTTOM,
     templateName: updatedBundle.templateName,
     steps: optimizedSteps,
     pricing: {

--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/types.ts
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/types.ts
@@ -45,7 +45,6 @@ export interface BundleData {
   bundleType: string;
   status: BundleStatus;
   templateName?: string;
-  fullPageLayout?: string | null;
   promoBannerBgImage?: string | null;
   loadingGif?: string | null;
   steps: BundleStep[];

--- a/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureSaveController.ts
+++ b/app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureSaveController.ts
@@ -6,6 +6,7 @@ import { markBundlePreviewComplete } from "../../../lib/bundle-preview-readiness
 import { DiscountMethod } from "../../../types/pricing";
 import { ADDON_MESSAGE_KEY } from "./configure-constants";
 import type { ConfigureBundleFlowDraft } from "./configure-flow-types";
+import { serializeFpbSaveSteps } from "./fpb-save-transport";
 
 export function useConfigureSaveController(flow: ConfigureBundleFlowDraft) {
   const buildDefaultProductsData = useCallback(() => {
@@ -69,20 +70,7 @@ export function useConfigureSaveController(flow: ConfigureBundleFlowDraft) {
       formData.append("bundleName", flow.formState.bundleName);
       formData.append("bundleDescription", flow.formState.bundleDescription);
       formData.append("templateName", flow.formState.templateName);
-      formData.append("fullPageLayout", flow.formState.fullPageLayout);
       formData.append("bundleStatus", flow.formState.bundleStatus);
-      const stepsWithCollections = flow.stepsState.steps.map((step: any) => ({
-        ...step,
-        isFreeGift: false,
-        freeGiftName: null,
-        addonLabel: null,
-        addonTitle: null,
-        addonIconUrl: null,
-        addonDisplayFree: false,
-        addonTiers: [],
-        collections:
-          flow.selectedCollections[step.id] || step.collections || [],
-      }));
       const pricingMessages = serializePricingDisplayOptions({
         existingMessages: {
           showDiscountMessaging: flow.pricingState.discountMessagingEnabled,
@@ -90,7 +78,12 @@ export function useConfigureSaveController(flow: ConfigureBundleFlowDraft) {
         },
         options: flow.normalizedPricingDisplayOptions,
       });
-      formData.append("stepsData", JSON.stringify(stepsWithCollections));
+      formData.append(
+        "stepsData",
+        JSON.stringify(
+          serializeFpbSaveSteps(flow.stepsState.steps, flow.selectedCollections),
+        ),
+      );
       const enrichedRuleMessages = Object.fromEntries(
         Object.entries(flow.normalizedRuleMessages).map(([id, msg]: any) => [
           id,
@@ -258,7 +251,6 @@ export function useConfigureSaveController(flow: ConfigureBundleFlowDraft) {
             name: flow.formState.bundleName,
             description: flow.formState.bundleDescription,
             templateName: flow.formState.templateName,
-            fullPageLayout: flow.formState.fullPageLayout,
             steps: JSON.stringify(flow.stepsState.steps),
             discountEnabled: flow.pricingState.discountEnabled,
             discountType: flow.pricingState.discountType,

--- a/app/services/bundles/metafield-sync/operations/component-product.server.ts
+++ b/app/services/bundles/metafield-sync/operations/component-product.server.ts
@@ -14,6 +14,26 @@ import type { ComponentParentsData } from "../types";
 import { buildPriceAdjustmentConfig } from "../utils/price-adjustment";
 import { collectAddonComponentVariants } from "../utils/addon-components";
 
+function normalizeProductVariantGid(value: unknown): string | null {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+
+  const raw = String(value).trim();
+  if (!raw) return null;
+  if (raw.startsWith("gid://shopify/ProductVariant/")) return raw;
+  if (/^\d+$/.test(raw)) return `gid://shopify/ProductVariant/${raw}`;
+  return null;
+}
+
+function getCachedVariantGid(variant: any): string | null {
+  return normalizeProductVariantGid(
+    variant?.id
+      ?? variant?.variantId
+      ?? variant?.variantGraphqlId
+      ?? variant?.graphqlId
+      ?? variant?.admin_graphql_api_id,
+  );
+}
+
 /**
  * Updates component product variants with component_parents metafield (Shopify Standard)
  *
@@ -86,9 +106,10 @@ export async function updateComponentProductMetafields(
           // Writing component_parents to every variant ensures Cart Transform can apply
           // the bundle discount regardless of which variant the customer selects.
           for (const variant of dbVariants) {
-            if (variant.id && !isUUID(variant.id)) {
-              componentVariantIds.add(variant.id);
-              componentReferences.push(variant.id);
+            const variantId = getCachedVariantGid(variant);
+            if (variantId && !isUUID(variantId)) {
+              componentVariantIds.add(variantId);
+              componentReferences.push(variantId);
               componentQuantities.push(step.minQuantity || 1);
             }
           }
@@ -110,9 +131,10 @@ export async function updateComponentProductMetafields(
 
           if (cachedVariants.length > 0) {
             for (const variant of cachedVariants) {
-              if (variant.id && !isUUID(variant.id)) {
-                componentVariantIds.add(variant.id);
-                componentReferences.push(variant.id);
+              const variantId = getCachedVariantGid(variant);
+              if (variantId && !isUUID(variantId)) {
+                componentVariantIds.add(variantId);
+                componentReferences.push(variantId);
                 componentQuantities.push(step.minQuantity || 1);
               }
             }
@@ -192,9 +214,10 @@ export async function updateComponentProductMetafields(
 
           if (cachedVariants.length > 0) {
             for (const variant of cachedVariants) {
-              if (variant.id && !isUUID(variant.id)) {
-                componentVariantIds.add(variant.id);
-                componentReferences.push(variant.id);
+              const variantId = getCachedVariantGid(variant);
+              if (variantId && !isUUID(variantId)) {
+                componentVariantIds.add(variantId);
+                componentReferences.push(variantId);
                 componentQuantities.push(step.minQuantity || 1);
               }
             }
@@ -278,9 +301,11 @@ export async function updateComponentProductMetafields(
 
       if (result?.success && Array.isArray(result.variantIds) && result.variantIds.length > 0) {
         result.variantIds.forEach(variantId => {
-          componentReferences.push(variantId);
+          const normalizedVariantId = normalizeProductVariantGid(variantId);
+          if (!normalizedVariantId) return;
+          componentReferences.push(normalizedVariantId);
           componentQuantities.push(item.stepMinQuantity);
-          componentVariantIds.add(variantId);
+          componentVariantIds.add(normalizedVariantId);
         });
       } else {
         AppLogger.warn("Could not get variant for component product", {

--- a/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-full-page-bundled.js
@@ -1,13 +1,13 @@
 /*!
  * Wolfpack Bundle Widget — Full Page
- * Version : 5.0.90
- * Built   : 2026-07-07
+ * Version : 5.0.92
+ * Built   : 2026-07-08
  *
  * Cache note: Shopify CDN cache is busted automatically by shopify app deploy.
  * After deploying, allow 2-10 minutes for propagation before testing.
  * Verify live version: console.log(window.__BUNDLE_WIDGET_VERSION__)
  */
-window.__BUNDLE_WIDGET_VERSION__ = '5.0.90';
+window.__BUNDLE_WIDGET_VERSION__ = '5.0.92';
 (function() {
   'use strict';
 
@@ -4032,7 +4032,16 @@ class BundleProductModal {
     document.getElementById('modal-product-title').textContent = displayTitle;
 
     const descriptionEl = document.getElementById('modal-product-description');
-    descriptionEl.textContent = this.currentProduct.description || '';
+    const descriptionHtml = typeof this.currentProduct.descriptionHtml === 'string'
+      ? this.currentProduct.descriptionHtml.trim()
+      : '';
+    descriptionEl.textContent = '';
+    descriptionEl.innerHTML = '';
+    if (descriptionHtml) {
+      descriptionEl.innerHTML = descriptionHtml;
+    } else {
+      descriptionEl.textContent = this.currentProduct.description || '';
+    }
 
     this.loadImage();
 
@@ -11339,6 +11348,12 @@ function normalizeProductDescription(product) {
   return (scratch.textContent || '').trim();
 }
 
+function normalizeProductDescriptionHtml(product) {
+  return typeof product?.descriptionHtml === 'string'
+    ? product.descriptionHtml.trim()
+    : '';
+}
+
 function collectCategoryProducts(step) {
   if (!Array.isArray(step?.categories)) return [];
 
@@ -11471,6 +11486,7 @@ function normalizeFullPageDirectDefaultProduct(product) {
     }],
     images: imageUrl ? [{ src: imageUrl }] : [],
     description: normalizeProductDescription(product),
+    descriptionHtml: normalizeProductDescriptionHtml(product),
   };
 }
 
@@ -12000,7 +12016,8 @@ processProductsForStep(products, step) {
             variants: processedVariants,
             options: processedOptions,
             images: product.images || (product.imageUrl ? [{ src: product.imageUrl }] : []),
-            description: normalizeProductDescription(product)
+            description: normalizeProductDescription(product),
+            descriptionHtml: normalizeProductDescriptionHtml(product)
           };
         });
     } else {
@@ -12044,7 +12061,8 @@ processProductsForStep(products, step) {
         options: processedOptions,
 
         images: product.images || (product.imageUrl ? [{ src: product.imageUrl }] : []),
-        description: normalizeProductDescription(product)
+        description: normalizeProductDescription(product),
+        descriptionHtml: normalizeProductDescriptionHtml(product)
       }];
     }
   });
@@ -12145,7 +12163,7 @@ async enrichMissingProductDescriptions(products) {
   if (!Array.isArray(products) || products.length === 0) return products;
 
   const missingProductIds = Array.from(new Set(products
-    .filter(product => !normalizeProductDescription(product))
+    .filter(product => !normalizeProductDescriptionHtml(product))
     .map(productGraphqlId)
     .filter(Boolean)));
 
@@ -12169,17 +12187,27 @@ async enrichMissingProductDescriptions(products) {
     const descriptionsByProductId = new Map();
     (Array.isArray(data.products) ? data.products : []).forEach(product => {
       const description = normalizeProductDescription(product);
+      const descriptionHtml = normalizeProductDescriptionHtml(product);
       const key = productLookupKey(product);
-      if (key && description) descriptionsByProductId.set(key, description);
+      if (key && (description || descriptionHtml)) {
+        descriptionsByProductId.set(key, { description, descriptionHtml });
+      }
     });
 
     if (descriptionsByProductId.size === 0) return products;
 
     return products.map(product => {
-      if (normalizeProductDescription(product)) return product;
+      if (normalizeProductDescriptionHtml(product)) return product;
       const key = productLookupKey(product);
-      const description = key ? descriptionsByProductId.get(key) : '';
-      return description ? { ...product, description } : product;
+      const descriptions = key ? descriptionsByProductId.get(key) : null;
+      if (!descriptions) return product;
+
+      const existingDescription = normalizeProductDescription(product);
+      return {
+        ...product,
+        description: existingDescription || descriptions.description || '',
+        descriptionHtml: descriptions.descriptionHtml || '',
+      };
     });
   } catch (error) {
     return products;
@@ -13804,20 +13832,16 @@ async _scheduleLayoutRefresh() {
     const data = await response.json();
     if (!data?.bundle) return;
 
-    const freshLayout = this.resolveFullPageLayout(data.bundle);
-    const currentLayout = this.resolveFullPageLayout();
     const freshTemplate = data.bundle.bundleDesignTemplate ?? null;
     const currentTemplate = this.selectedBundle?.bundleDesignTemplate ?? null;
     const freshPreset = data.bundle.bundleDesignPresetId ?? null;
     const currentPreset = this.selectedBundle?.bundleDesignPresetId ?? null;
 
-    if ((freshLayout !== currentLayout || freshTemplate !== currentTemplate || freshPreset !== currentPreset) && this.selectedBundle) {
-      this.selectedBundle.fullPageLayout = data.bundle.fullPageLayout;
+    if ((freshTemplate !== currentTemplate || freshPreset !== currentPreset) && this.selectedBundle) {
       this.selectedBundle.bundleDesignTemplate = data.bundle.bundleDesignTemplate ?? this.selectedBundle.bundleDesignTemplate;
       this.selectedBundle.bundleDesignPresetId = data.bundle.bundleDesignPresetId ?? this.selectedBundle.bundleDesignPresetId;
       this.selectedBundle.bundleDesignTemplateData = data.bundle.bundleDesignTemplateData ?? this.selectedBundle.bundleDesignTemplateData;
       if (this.bundleData?.[bundleId]) {
-        this.bundleData[bundleId].fullPageLayout = data.bundle.fullPageLayout;
         this.bundleData[bundleId].bundleDesignTemplate = data.bundle.bundleDesignTemplate ?? this.bundleData[bundleId].bundleDesignTemplate;
         this.bundleData[bundleId].bundleDesignPresetId = data.bundle.bundleDesignPresetId ?? this.bundleData[bundleId].bundleDesignPresetId;
         this.bundleData[bundleId].bundleDesignTemplateData = data.bundle.bundleDesignTemplateData ?? this.bundleData[bundleId].bundleDesignTemplateData;

--- a/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
+++ b/extensions/bundle-builder/assets/bundle-widget-product-page-bundled.js
@@ -1,13 +1,13 @@
 /*!
  * Wolfpack Bundle Widget — Product Page
- * Version : 5.0.90
- * Built   : 2026-07-07
+ * Version : 5.0.92
+ * Built   : 2026-07-08
  *
  * Cache note: Shopify CDN cache is busted automatically by shopify app deploy.
  * After deploying, allow 2-10 minutes for propagation before testing.
  * Verify live version: console.log(window.__BUNDLE_WIDGET_VERSION__)
  */
-window.__BUNDLE_WIDGET_VERSION__ = '5.0.90';
+window.__BUNDLE_WIDGET_VERSION__ = '5.0.92';
 (function() {
   'use strict';
 
@@ -6317,7 +6317,8 @@ processProductsForStep(products, step) {
             variants: processedVariants,
             options: processedOptions,
             images: product.images || (product.imageUrl ? [{ src: product.imageUrl }] : []),
-            description: product.description || ''
+            description: product.description || '',
+            descriptionHtml: product.descriptionHtml || ''
           };
         });
     } else {
@@ -6353,7 +6354,8 @@ processProductsForStep(products, step) {
         options: processedOptions,
 
         images: product.images || (product.imageUrl ? [{ src: product.imageUrl }] : []),
-        description: product.description || ''
+        description: product.description || '',
+        descriptionHtml: product.descriptionHtml || ''
       }];
     }
   });

--- a/extensions/bundle-builder/assets/wolfpack-bundles-sdk.js
+++ b/extensions/bundle-builder/assets/wolfpack-bundles-sdk.js
@@ -1,11 +1,11 @@
 /*!
  * Wolfpack Bundles SDK
- * Version : 5.0.90
- * Built   : 2026-07-07
+ * Version : 5.0.92
+ * Built   : 2026-07-08
  *
  * Verify live version: console.log(window.__WOLFPACK_BUNDLES_SDK_VERSION__)
  */
-window.__WOLFPACK_BUNDLES_SDK_VERSION__ = '5.0.90';
+window.__WOLFPACK_BUNDLES_SDK_VERSION__ = '5.0.92';
 (function (window) {
   'use strict';
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - wolfpack-product-bundles  (2026-07-07)
+# Graph Report - wolfpack-product-bundles  (2026-07-08)
 
 ## Corpus Check
-- 6808 files · ~4,731,326 words
+- 6819 files · ~4,802,419 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 40478 nodes · 47609 edges · 3827 communities (3261 shown, 566 thin omitted)
+- 40563 nodes · 47745 edges · 3827 communities (3300 shown, 527 thin omitted)
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS · INFERRED: 144 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `956be359`
+- Built from commit: `322f3431`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -918,6 +918,7 @@
 - [[_COMMUNITY_Community 900|Community 900]]
 - [[_COMMUNITY_Community 901|Community 901]]
 - [[_COMMUNITY_Community 902|Community 902]]
+- [[_COMMUNITY_Community 903|Community 903]]
 - [[_COMMUNITY_Community 904|Community 904]]
 - [[_COMMUNITY_Community 905|Community 905]]
 - [[_COMMUNITY_Community 906|Community 906]]
@@ -3164,25 +3165,25 @@
 - [[_COMMUNITY_Community 3157|Community 3157]]
 - [[_COMMUNITY_Community 3158|Community 3158]]
 - [[_COMMUNITY_Community 3159|Community 3159]]
-- [[_COMMUNITY_Community 3160|Community 3160]]
 - [[_COMMUNITY_Community 3161|Community 3161]]
 - [[_COMMUNITY_Community 3162|Community 3162]]
-- [[_COMMUNITY_Community 3163|Community 3163]]
 - [[_COMMUNITY_Community 3164|Community 3164]]
 - [[_COMMUNITY_Community 3165|Community 3165]]
-- [[_COMMUNITY_Community 3166|Community 3166]]
 - [[_COMMUNITY_Community 3167|Community 3167]]
 - [[_COMMUNITY_Community 3168|Community 3168]]
-- [[_COMMUNITY_Community 3169|Community 3169]]
-- [[_COMMUNITY_Community 3170|Community 3170]]
-- [[_COMMUNITY_Community 3171|Community 3171]]
-- [[_COMMUNITY_Community 3172|Community 3172]]
-- [[_COMMUNITY_Community 3173|Community 3173]]
-- [[_COMMUNITY_Community 3174|Community 3174]]
 - [[_COMMUNITY_Community 3175|Community 3175]]
+- [[_COMMUNITY_Community 3178|Community 3178]]
+- [[_COMMUNITY_Community 3180|Community 3180]]
 - [[_COMMUNITY_Community 3181|Community 3181]]
 - [[_COMMUNITY_Community 3185|Community 3185]]
+- [[_COMMUNITY_Community 3190|Community 3190]]
+- [[_COMMUNITY_Community 3191|Community 3191]]
+- [[_COMMUNITY_Community 3194|Community 3194]]
 - [[_COMMUNITY_Community 3195|Community 3195]]
+- [[_COMMUNITY_Community 3196|Community 3196]]
+- [[_COMMUNITY_Community 3240|Community 3240]]
+- [[_COMMUNITY_Community 3252|Community 3252]]
+- [[_COMMUNITY_Community 3253|Community 3253]]
 - [[_COMMUNITY_Community 3296|Community 3296]]
 - [[_COMMUNITY_Community 3406|Community 3406]]
 - [[_COMMUNITY_Community 3441|Community 3441]]
@@ -3799,36 +3800,36 @@
 ## Surprising Connections (you probably didn't know these)
 - `Issue: Replace GCP Pub/Sub Worker with Direct HTTP Webhook Receiver` --references--> `Service: webhooks/processor.server.ts`  [EXTRACTED]
   docs/issues-prod/pubsub-to-render-webhook-migration-1.md → app/services/webhooks/processor.server.ts
+- `Issue: Unlisted Bundle Widget & Theme Template API Bugs` --modifies--> `Source: bundle-data-manager.js (Shared Widget Module)`  [EXTRACTED]
+  docs/issues-prod/unlisted-bundle-widget-fix-1.md → app/assets/widgets/shared/bundle-data-manager.js
 - `Remove Pixel Auto-Activation from afterAuth` --references--> `app/shopify.server.ts (Shopify Auth & Lifecycle Hooks)`  [INFERRED]
   docs/analytics-pixel-toggle/03-architecture.md → app/shopify.server.ts
 - `Issue: Ad-Ready Bundle Infrastructure — Phase 2 & Phase 3` --creates--> `Route: api.attribution.tsx`  [EXTRACTED]
   docs/issues-prod/ad-ready-phase2-phase3-1.md → app/routes/api/api.attribution.tsx
 - `Issue: Ad-Ready Bundle Infrastructure — Phase 2 & Phase 3` --creates--> `Extension: wolfpack-utm-pixel/src/index.ts`  [EXTRACTED]
   docs/issues-prod/ad-ready-phase2-phase3-1.md → extensions/wolfpack-utm-pixel/src/index.ts
-- `Issue: Admin UI Tier Configuration for Full-Page Bundle Widget` --modifies--> `API Route: api.bundle.$bundleId.json.tsx`  [EXTRACTED]
-  docs/issues-prod/admin-tier-config-1.md → app/routes/api/api.bundle.$bundleId[.]json.tsx
 
 ## Import Cycles
 - 1-file cycle: `extensions/bundle-cart-transform-rs/src/helpers.rs -> extensions/bundle-cart-transform-rs/src/helpers.rs`
 - 1-file cycle: `extensions/bundle-cart-transform-rs/tests/integration_test.rs -> extensions/bundle-cart-transform-rs/tests/integration_test.rs`
 - 1-file cycle: `extensions/bundle-cart-transform-rs/src/run.rs -> extensions/bundle-cart-transform-rs/src/run.rs`
 - 1-file cycle: `extensions/bundle-discount-function/src/cart_lines_discounts_generate_run.rs -> extensions/bundle-discount-function/src/cart_lines_discounts_generate_run.rs`
-- 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureSidebar.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureSidebar.tsx`
-- 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureHiddenInputs.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureHiddenInputs.tsx`
-- 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleSettingsSection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
+- 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/ImagesVisibilitySection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
 - 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureCanvasHeader.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureCanvasHeader.tsx`
+- 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureHiddenInputs.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureHiddenInputs.tsx`
+- 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureSidebar.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/ConfigureSidebar.tsx`
+- 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleSettingsSection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
 - 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleWidgetSection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
 - 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/ConfigureRouteModals.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
 - 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/DiscountPricingSection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
 - 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/FreeGiftAddonsSection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
-- 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/ImagesVisibilitySection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
 - 3-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/StepSetupSection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
-- 3-file cycle: `app/lib/auth-guards.server.ts -> app/shopify.server.ts -> app/services/theme-colors.server.ts -> app/lib/auth-guards.server.ts`
 - 3-file cycle: `app/lib/auth-guards.server.ts -> app/shopify.server.ts -> app/services/billing.server.ts -> app/lib/auth-guards.server.ts`
-- 4-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/ConfigureRouteModals.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/ConfigureSyncAndLanguageModals.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
-- 4-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/ConfigureRouteModals.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/ConfigureGlobalOverlays.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
-- 4-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleSettingsSection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleSettingsDefaultProducts.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
-- 4-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleSettingsSection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleSettingsQuantity.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
+- 3-file cycle: `app/lib/auth-guards.server.ts -> app/shopify.server.ts -> app/services/theme-colors.server.ts -> app/lib/auth-guards.server.ts`
+- 4-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleSettingsSection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleSettingsCss.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
+- 4-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/ImagesVisibilitySection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleVisibilityPanel.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
+- 4-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/ImagesVisibilitySection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/ImagesGifsPanel.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
+- 4-file cycle: `app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleSettingsSection.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/sections/BundleSettingsTemplate.tsx -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/useConfigureBundleFlow.ts -> app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/configure-flow-statics.ts`
 
 ## Hyperedges (group relationships)
 - **Ad-Ready Phase 1: Bundle Creation Price + Inventory Fix** — handlers_server_ts, service_pricing_calculation, service_inventory_sync, ad_ready_bundle_price_fix, ad_ready_inventory_mgmt [EXTRACTED 1.00]
@@ -3850,11 +3851,11 @@
 - **Analytics Redesign Bundle Revenue Components** — analytics_redesign_bundle_kpi_row, analytics_redesign_bundle_trend_chart, analytics_redesign_bundle_leaderboard, analytics_helpers_ts, route_app_attribution [EXTRACTED 1.00]
 - **Pixel Toggle Service + Action Chain** — analytics_pixel_toggle_getpixelstatus, analytics_pixel_toggle_deactivate, service_pixel_activation, route_app_attribution, shopify_server_ts [EXTRACTED 1.00]
 
-## Communities (3827 total, 566 thin omitted)
+## Communities (3827 total, 527 thin omitted)
 
 ### Community 0 - "Full-Page Bundle Widget (Bundled)"
-Cohesion: 0.06
-Nodes (39): BundleActionsButtons, shouldRenderDashboardActionMenu(), buildDashboardLocaleSearchParams(), shouldApplyDashboardLocaleSave(), DashboardInitialImagePreload, DashboardMediaState, DashboardMediaStateInput, getDashboardMediaState() (+31 more)
+Cohesion: 0.28
+Nodes (4): buildProductsQuery(), CORS_HEADERS, loader(), mockFetch
 
 ### Community 1 - "Product-Page Bundle Widget (Bundled)"
 Cohesion: 0.01
@@ -3865,12 +3866,12 @@ Cohesion: 0.04
 Nodes (56): 1. Create Your First Bundle, 2. Configure Bundle Steps, 3. Install Widget on Storefront, 4. Customize Appearance, 🙏 Acknowledgments, 📚 API Reference, App Configuration, Application Structure (+48 more)
 
 ### Community 3 - "Product-Page Bundle Widget (Source)"
-Cohesion: 0.03
-Nodes (58): OAuth Scope Changes Requiring Re-Authentication, Concept: Shopify App Proxy (/apps/product-bundles), Concept: use_legacy_install_flow = false (TOML), Concept: Webhook Worker (HTTP server on Render), GCP Pub/Sub Removal (@google-cloud/pubsub), 2026-02-28 22:00 - Starting Fix, 2026-02-28 22:15 - Initial Fix Attempt, 2026-02-28 22:30 - Fix Redirect Loop (+50 more)
+Cohesion: 0.08
+Nodes (24): OAuth Scope Changes Requiring Re-Authentication, Concept: Shopify App Proxy (/apps/product-bundles), Audit 1: Shopify App Proxy Usage, Audit 2: Widget Currency Handling, Audit 3: Cart Transform Currency Handling, Cart Transform's Actual Multi-Currency Behaviour, Configuration, 🔴 Critical: Mixed Units Bug in `fixed_amount_off` Discount (+16 more)
 
 ### Community 4 - "App State Service"
-Cohesion: 0.10
-Nodes (21): buildCartLineSourceProperties(), _createFooterPanel(), createStandardSidebarDiscountProgress(), CurrencyManager, getDiscountInfoWithSelectedAddonDiscount(), getDiscountProgressData(), getFormattedHeaderText(), normalizePercent() (+13 more)
+Cohesion: 0.07
+Nodes (44): areBundleConditionsMet(), buildCartLineSourceProperties(), bundleHasNoConditions(), calculateSelectedAddonDiscountAmount(), _createFooterBar(), _createFooterPanel(), createSidebarTierCta(), createStandardSidebarDiscountProgress() (+36 more)
 
 ### Community 5 - "Ad-Ready Bundles Feature Docs"
 Cohesion: 0.00
@@ -3893,23 +3894,16 @@ Cohesion: 0.02
 Nodes (103): 2026-06-01 15:07 - Captured Settings Language, Controls, and Integration route evidence, 2026-06-01 15:12 - Started FPB Bundle Settings visual parity cleanup, 2026-06-01 15:18 - Removed non-EB FPB Bundle Settings controls, 2026-06-01 15:18 - Started Settings landing copy parity fix, 2026-06-01 15:19 - Started Integrations landing copy parity fix, 2026-06-01 15:21 - Started Settings Design configure flow fix, 2026-06-01 15:22 - Fixed Settings landing card copy, 2026-06-01 15:23 - Started Settings Language configure flow fix (+95 more)
 
 ### Community 10 - "App Routes & Pages"
-Cohesion: 0.07
-Nodes (23): { getSelectedProductEntries }, currencyInfo, { PricingCalculator }, { TemplateManager }, { PricingCalculator }, {
-  addSelectedProduct,
-  removeSelectedProduct,
-}, { createBundleState }, {
-  getCurrentStep,
-  getSelectedQuantity,
-  getSelectedSubtotalCents,
-} (+15 more)
+Cohesion: 0.09
+Nodes (7): ConditionValidator, { PricingCalculator }, { PricingCalculator }, { getDisplayPrice }, { PricingCalculator }, getDisplayPrice(), PricingCalculator
 
 ### Community 11 - "Bundle Configuration Handlers"
 Cohesion: 0.04
 Nodes (52): Storefront Collections API Route (api.storefront-collections.tsx), Bottom-Sheet Panel DCP CSS Targeting Fix, component-product.server.ts — component_parents Writer, _createBecoBar() — Compact Sticky Bar, _createBecoPanel() — Expanding Product List Panel, createStepTimeline() — FPB Sidebar Tab Renderer, Floating Footer Pill Design (PDP Classic Modal), Floating Footer for Product-Page Bundle Widget (+44 more)
 
 ### Community 12 - "App State Hooks"
-Cohesion: 0.17
-Nodes (11): Configuration Evidence, Confirmed Gaps — Status After Phase 9, EB Full Data-Flow Investigation, Executive Summary, Full-Page Bundle, Full-Page Bundle Admin Flow, Gaps And Blockers, Product-Page Bundle (+3 more)
+Cohesion: 0.05
+Nodes (43): CLASSIC Design, Collection Pagination Architecture, COMPACT Design, Configuration Evidence, Confirmed Gaps — Status After Phase 9, `displayVariantsAsIndividualProducts` Field Placement, DOM Attributes That Initialize The Widget, EB Full Data-Flow Investigation (+35 more)
 
 ### Community 13 - "Bundle Widget Tests"
 Cohesion: 0.05
@@ -3932,8 +3926,8 @@ Cohesion: 0.18
 Nodes (11): Agentic Loop Contract, Agentic Loop Plan: FPB Mobile Storefront Footer CSS Parity, Implementation scope, Non-Goals, Primary Goal, Purpose, Required Browser Test Viewports, Required Footer States (+3 more)
 
 ### Community 18 - "Billing Service"
-Cohesion: 0.05
-Nodes (36): ensureExpiringOfflineSessionInBackground(), loader(), changeAdminI18nLanguage(), cloneLocaleCatalog(), isSupportedLocale(), loadAdminLocaleResources(), LocaleCatalog, LocaleLoader (+28 more)
+Cohesion: 0.03
+Nodes (82): loader(), sanitizeBundleType(), loader(), sanitizeBundleType(), BundleActionsButtons, shouldRenderDashboardActionMenu(), queueDashboardBackgroundTask(), buildDashboardLocaleSearchParams() (+74 more)
 
 ### Community 19 - "Test Runner"
 Cohesion: 0.14
@@ -3949,7 +3943,7 @@ Nodes (13): Additional Models, BundleAnalytics, ComplianceRecord, Database Schem
 
 ### Community 23 - "App Logger"
 Cohesion: 0.05
-Nodes (59): ConfigureBundleCanvas(), PpbBundleEmbedSection(), PpbBundleBannerSettings(), PpbBundleLevelCssSettings(), DefaultProductSelection, PpbDefaultProductsSettings(), CART_DISCOUNT_DISPLAY_OPTIONS, PpbCartDiscountDisplaySettings() (+51 more)
+Nodes (57): ConfigureBundleCanvas(), PpbBundleEmbedSection(), PpbBundleBannerSettings(), PpbBundleLevelCssSettings(), DefaultProductSelection, PpbDefaultProductsSettings(), CART_DISCOUNT_DISPLAY_OPTIONS, PpbCartDiscountDisplaySettings() (+49 more)
 
 ### Community 24 - "Attribution & Analytics"
 Cohesion: 0.03
@@ -3973,7 +3967,7 @@ Nodes (55): 2026-06-01 20:05 - PPB Take live EB/WPB audit, 2026-06-01 20:18 - PP
 
 ### Community 29 - "Cached Session Storage"
 Cohesion: 0.04
-Nodes (32): { fullPageInitialRenderMethods }, { fullPageProductProcessingMethods }, FakeElement, { fullPageInitialRenderMethods }, { fullPageProductCardFooterMethods }, { fullPageProductProcessingMethods }, { fullPageValidationAddonsMethods }, { shouldAutoAdvanceFullPageStep } (+24 more)
+Nodes (33): { fullPageInitialRenderMethods }, { fullPageProductProcessingMethods }, FakeElement, { fullPageInitialRenderMethods }, { fullPageProductCardFooterMethods }, { fullPageProductProcessingMethods }, { fullPageValidationAddonsMethods }, { shouldAutoAdvanceFullPageStep } (+25 more)
 
 ### Community 30 - "Metafield Cleanup Service"
 Cohesion: 0.18
@@ -4008,8 +4002,8 @@ Cohesion: 0.22
 Nodes (8): Common Beginner Mistakes to Avoid, Estimated Time to Complete, Prompt Engineering Guide, Recreate Wolfpack Product Bundles App Without Technical Knowledge, Support & Help, Table of Contents, Tips for Success, What You'll Learn
 
 ### Community 38 - "Pricing Utilities"
-Cohesion: 0.07
-Nodes (28): 1. One app embed as a loader, not one embed per type, 2. Bundle type is a config field, 3. Templates are renderer variants, 4. Complex features are plugins or slots, 5. A global SDK/state object supports both pre-built and custom UI, Architecture decisions needed, Bottom Line, BR questions (+20 more)
+Cohesion: 0.05
+Nodes (36): 1. One app embed as a loader, not one embed per type, 2. Bundle type is a config field, 3. Templates are renderer variants, 4. Complex features are plugins or slots, 5. A global SDK/state object supports both pre-built and custom UI, Architecture decisions needed, Bottom Line, BR questions (+28 more)
 
 ### Community 39 - "Feature Gate"
 Cohesion: 0.25
@@ -4036,8 +4030,8 @@ Cohesion: 0.15
 Nodes (11): **Cross-Reference with Code**, File Structure, **Future Translation Support**, Locale Translations Update, Overview, Related Documentation, Testing Checklist, Variable Placeholders (+3 more)
 
 ### Community 45 - "Community 45"
-Cohesion: 0.07
-Nodes (38): BillingPage(), FAQSection(), FAQSectionProps, FeatureComparisonTable(), FeatureComparisonTableProps, FreePlanCard(), FreePlanCardProps, GrowPlanCard() (+30 more)
+Cohesion: 0.06
+Nodes (33): DCP Modal Bugs & Dead Code Cleanup, DCP Storefront Iframe Preview — Sub-Plan 1 Infrastructure, DCP Preview — Option 3 App-Served Preview Page, DCP Preview Option 3 — App-Served Same-Origin Preview, DCP Mobile Preview Toggle - Architecture Decision Record, DCP Preview Fill Width Issue, 2026-03-26 15:00 - Starting implementation, 2026-03-26 15:30 - Completed all phases (+25 more)
 
 ### Community 46 - "Community 46"
 Cohesion: 0.07
@@ -4105,7 +4099,7 @@ Nodes (36): 2026-06-06 06:57 - Started Desktop Audit, 2026-06-06 07:07 - Desktop
 
 ### Community 62 - "Community 62"
 Cohesion: 0.07
-Nodes (46): handleSyncBundle(), handleSyncProduct(), CachedPrice, cacheStats, calculateBundlePrice(), calculateBundleTotalPrice(), cleanExpiredCache(), clearPriceCache() (+38 more)
+Nodes (28): 1. Bundle.liquid (Product Page Widget), 2. Bundle-full-page.liquid, 3. Files Created, 4. Files Removed, 5. Files Remaining, Benefits, Bundling Process, Changes Made (+20 more)
 
 ### Community 63 - "Community 63"
 Cohesion: 0.05
@@ -4300,8 +4294,8 @@ Cohesion: 0.07
 Nodes (26): Acceptance Criteria, Cart Messaging, Category Contracts, Dependency Gates, FPB Add-ons Contracts, FPB Admin Shell, FPB Bundle Settings Contracts, FPB Bundle Visibility Admin (+18 more)
 
 ### Community 112 - "Community 112"
-Cohesion: 0.07
-Nodes (62): addonTierToDraft(), buildAddonDraftFromPersonalizationData(), buildPersonalizationDataFromDraft(), createDefaultAddonDraftTier(), createDefaultAddonTierCondition(), normalizeAddonPickerProduct(), normalizeAddonTier(), toNumericShopifyId() (+54 more)
+Cohesion: 0.06
+Nodes (68): addonTierToDraft(), buildAddonDraftFromPersonalizationData(), buildPersonalizationDataFromDraft(), createDefaultAddonDraftTier(), createDefaultAddonTierCondition(), normalizeAddonPickerProduct(), normalizeAddonTier(), toNumericShopifyId() (+60 more)
 
 ### Community 113 - "Community 113"
 Cohesion: 0.08
@@ -4577,11 +4571,11 @@ Nodes (20): Code Size Reduction, Implementation Order, Legacy Removal Implementa
 
 ### Community 182 - "Community 182"
 Cohesion: 0.02
-Nodes (112): addSelectedProduct(), appendBannerImage(), applyBundleLevelCss(), applyCardLayoutSettings(), _applyCheckoutIntegrationDiscountCode(), attachProductEventHandlers(), buildBundleDetailsDisplayProperties(), buildCartLineDisplayProperties() (+104 more)
+Nodes (113): addSelectedProduct(), appendBannerImage(), applyBundleLevelCss(), applyCardLayoutSettings(), _applyCheckoutIntegrationDiscountCode(), applyPersonalizationAddonProducts(), buildAddonStepFromPersonalization(), buildBundleDetailsDisplayProperties() (+105 more)
 
 ### Community 183 - "Community 183"
 Cohesion: 0.04
-Nodes (55): Beco BYOB Bundle Page Design Analysis, Beco BYOB Design Alignment — FPB Widget, Beco Layout Transformation Plan, --bundle-drawer-bg CSS Variable, BundleFooterPreview.tsx, Card Dimming State (Step Full), Beco BYOB Layout as Design Reference, Concept: Design Control Panel (DCP) (+47 more)
+Nodes (46): Beco BYOB Bundle Page Design Analysis, Beco BYOB Design Alignment — FPB Widget, Beco Layout Transformation Plan, --bundle-drawer-bg CSS Variable, BundleFooterPreview.tsx, Card Dimming State (Step Full), Beco BYOB Layout as Design Reference, Concept: Design Control Panel (DCP) (+38 more)
 
 ### Community 184 - "Community 184"
 Cohesion: 0.10
@@ -4712,8 +4706,8 @@ Cohesion: 0.11
 Nodes (17): Business Requirement: Analytics Page Redesign, Executive Summary, Functional Requirements, In Scope (MVP), Non-Functional Requirements, Option A — Redesign page using existing `OrderAttribution` data only (Recommended MVP), Option B — Add widget event tracking to unlock funnel metrics, Option C — Third-party analytics integration (Amplitude, Segment, etc.) (+9 more)
 
 ### Community 216 - "Community 216"
-Cohesion: 0.01
-Nodes (191): Add-to-Bundle Button Selected-State Colour DCP Control, Connections, api.design-settings.$shopDomain.css.tsx (CSS API Generator), Connections, api.preview.$type.tsx (DCP Storefront Preview Route), Connections, API Route: api.bundle.$bundleId.json.tsx, Connections (+183 more)
+Cohesion: 0.02
+Nodes (93): Add-to-Bundle Button Selected Color BR, Connections, Add-to-Bundle Button Selected Color PO Requirements, Connections, app/constants/bundle.ts (Centralized Bundle Constants), Connections, app/constants/errors.ts (Centralized Error Messages), Connections (+85 more)
 
 ### Community 217 - "Community 217"
 Cohesion: 0.11
@@ -4724,7 +4718,7 @@ Cohesion: 0.11
 Nodes (17): Architecture Decision Record: Centralized Auth Layer for API Routes, Auth Tier Map (Final State), Constraints, Context, Decision: Option C — Auth Helper Functions, Design, Files to Create / Modify, Key Decision: `api.design-settings.$shopDomain` stays public (+9 more)
 
 ### Community 219 - "Community 219"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (17): 1. Step Setup, 2. Free Gift & Add Ons, 3. Messages, 4. Discount & Pricing, 5. Bundle Visibility / Publishing, 6. Bundle Settings, 7. Subscriptions, 8. Template / Design Picker (+9 more)
 
 ### Community 220 - "Community 220"
@@ -4792,8 +4786,8 @@ Cohesion: 0.11
 Nodes (17): Acceptance Criteria, BundleVisibilityQuickGuideContract, FullPageBundleSettingsSurfaceContract, FullPageBundleWidgetButtonTextDefault, FullPageBundleWidgetMultilanguageGate, ProductPageBundleEmbedCopy, ProductPageBundleSettingsSurfaceContract, ProductPageBundleSubscriptionsSetupGuide (+9 more)
 
 ### Community 236 - "Community 236"
-Cohesion: 0.08
-Nodes (42): resolveUniqueHandle(), ensureCustomPageBundleIdDefinition(), ensurePageBundleIdMetafieldDefinition(), mockAdmin, mockCreateFullPageBundle, mockGetPreviewPageUrl, mockPublishPreviewPage, mockRecordFirstBundlePreviewEvent (+34 more)
+Cohesion: 0.06
+Nodes (53): handleCreatePreviewPage(), handleRenamePageSlug(), handleValidateWidgetPlacement(), createProductPageRedirect(), resolveUniqueHandle(), slugify(), ensureCustomPageBundleIdDefinition(), ensurePageBundleIdMetafieldDefinition() (+45 more)
 
 ### Community 237 - "Community 237"
 Cohesion: 0.17
@@ -4869,11 +4863,11 @@ Nodes (16): Discount Messaging Data Flow (form → handler → metafield → wid
 
 ### Community 255 - "Community 255"
 Cohesion: 0.05
-Nodes (87): Props, useConfigureModalController(), ADDON_TEMPLATE_VARIABLES, buildVisibilityDisplayConfiguration(), buildVisibilitySelectionIds(), bundleSetupItems, bundleVisibilityChildItems, compactVisibilityCollectionPageReference() (+79 more)
+Nodes (50): BundlePricing, BundlePricing, createInitialPricingDisplayOptions(), UseBundlePricingProps, canUseSavedBundleQuantitySubtext(), containsPercentageValue(), getCompatibility(), getDefaultDiscountRuleSuccessMessage() (+42 more)
 
 ### Community 256 - "Community 256"
-Cohesion: 0.09
-Nodes (32): AssetsStep(), Props, ConfigurationStep(), Props, PricingStep(), StepSummary(), StepSummaryProps, ConditionDef (+24 more)
+Cohesion: 0.06
+Nodes (49): AssetsStep(), Props, ConfigurationStep(), Props, PricingStep(), StepSummary(), StepSummaryProps, ConditionDef (+41 more)
 
 ### Community 258 - "Community 258"
 Cohesion: 0.12
@@ -4996,26 +4990,26 @@ Cohesion: 0.16
 Nodes (16): Attribution API Route (api.attribution.tsx), Pixel Auto-Activate Logic (afterAuth + dashboard loader), Customer Events API (Shopify Web Pixel), OrderAttribution Records, Pixel On By Default, Last-Touch, Track All Bundle Revenue, pixelEnabled DB Flag (Shop/AppSettings model), UTM Pixel Fetch URL + CORS Headers Fix, UTM Last-Touch Attribution with localStorage (+8 more)
 
 ### Community 288 - "Community 288"
-Cohesion: 0.08
-Nodes (29): loader(), sanitizeBundleType(), handleSaveBundle(), handleUpdateBundleDesignTemplate(), bool(), int(), jsonObject(), normalizeIndividualSellingPlanSelection() (+21 more)
+Cohesion: 0.09
+Nodes (23): loader(), sanitizeBundleType(), handleSaveBundle(), bool(), int(), jsonObject(), normalizeIndividualSellingPlanSelection(), normalizeSellingPlanSelectionShowFor() (+15 more)
 
 ### Community 289 - "Community 289"
 Cohesion: 0.03
 Nodes (72): addSelectedProduct(), appendBannerImage(), _appendSlotIcon(), applyBundleLevelCss(), bsGetDiscountBadgeLabel(), bsIsDefaultStep(), buildBundleDetailsDisplayProperties(), _buildLimitText() (+64 more)
 
 ### Community 290 - "Community 290"
-Cohesion: 0.14
-Nodes (47): {
+Cohesion: 0.13
+Nodes (48): {
   hideLoadingOverlayElement,
   markLoadingOverlayVisible,
 }, { getDiscountProgressData }, { renderDiscountProgress }, { renderSelectedProductRow }, { renderSelectedProductSlots }, {
   getTimelineEntryState,
   shouldShowTimelineCompletedState,
-}, appendBannerImage(), createBundleBannerElement() (+39 more)
+}, appendBannerImage(), createBundleBannerElement() (+40 more)
 
 ### Community 291 - "Community 291"
-Cohesion: 0.09
-Nodes (30): useConfigureBundleController(), SubscriptionValidationResponse, usePpbBaseConfigureState(), Window, ConditionRule, useBundleConditions(), UseBundleConditionsProps, BundleData (+22 more)
+Cohesion: 0.14
+Nodes (9): PpbBundleVisibilitySection(), PpbSelectTemplateDialog(), AppEmbedBannerProps, AppEmbedGuideModal(), AppEmbedGuideModalProps, EnablePreviewModalProps, openThemeEditorInNewTab(), visibilityStyles (+1 more)
 
 ### Community 292 - "Community 292"
 Cohesion: 0.10
@@ -5109,12 +5103,12 @@ Cohesion: 0.13
 Nodes (14): 2026-03-01 14:00 - Attempt 1: Client-side redirect (no layout auth), 2026-03-01 16:00 - Attempt 2: Auth in app._index + server redirect, 2026-03-01 18:00 - Attempt 3: Auth in layout + client-side redirect, Attempt 1 — Client-side redirect without layout auth (FAILED), Attempt 2 — Auth in app._index only + server redirect (FAILED), Attempt 3 — Auth in layout + client-side redirect (CURRENT), Files Modified, Fix History (+6 more)
 
 ### Community 314 - "Community 314"
-Cohesion: 0.04
-Nodes (105): action(), action(), action(), handleSaveBundle(), asObjectArray(), buildStepCategoryCreateInput(), numberValue(), objectRecord() (+97 more)
+Cohesion: 0.03
+Nodes (121): action(), action(), prismaClientOptions, handleSaveBundle(), handleSyncBundle(), handleSyncProduct(), asObjectArray(), buildStepCategoryCreateInput() (+113 more)
 
 ### Community 315 - "Community 315"
 Cohesion: 0.05
-Nodes (50): buildConfigureBundleFlowContext(), useConfigureAddonState(), ConfigureBundleFlowContext, useConfigureBundleFlow(), useConfigureLocalizationState(), useConfigurePageSelectionController(), useConfigureSaveController(), useConfigureTemplatePricingController() (+42 more)
+Nodes (47): buildConfigureBundleFlowContext(), useConfigureActionController(), useConfigureAddonState(), ConfigureBundleFlowContext, useConfigureBundleFlow(), useConfigureContentState(), useConfigureLocalizationState(), useConfigurePageSelectionController() (+39 more)
 
 ### Community 316 - "Community 316"
 Cohesion: 0.13
@@ -5294,11 +5288,11 @@ Nodes (20): API Route: api.bundle.$bundleId.json.tsx, Concept: Pricing Tiers / T
 
 ### Community 360 - "Community 360"
 Cohesion: 0.07
-Nodes (26): ConditionValidator, { PricingCalculator }, ConditionValidator, ConditionValidator, { validateStep, validateBundle }, _stepIsCategoryRuleMode(), validateBundle(), validateStep() (+18 more)
+Nodes (31): ConditionValidator, ConditionValidator, { createState, addItem, removeItem, clearStep }, ConditionValidator, { validateStep, validateBundle }, addItem(), clearStep(), createState() (+23 more)
 
 ### Community 361 - "Community 361"
-Cohesion: 0.05
-Nodes (28): Ad-Ready Bundles Architecture Decision Record, Connections, Ad-Ready Bundles PO Requirements, Connections, Ad-Ready Bundles SDE Implementation Plan, Connections, api.inventory-sync.ts Route, Connections (+20 more)
+Cohesion: 0.02
+Nodes (62): Add-to-Bundle Button Selected-State Colour DCP Control, Connections, api.design-settings.$shopDomain.css.tsx (CSS API Generator), Connections, api.preview.$type.tsx (DCP Storefront Preview Route), Connections, app/lib/dcp-config/base.config.ts (DCP Navigation Config), Connections (+54 more)
 
 ### Community 362 - "Community 362"
 Cohesion: 0.07
@@ -5413,32 +5407,32 @@ Cohesion: 0.15
 Nodes (12): Confirmed This Slice, Controls, Create Guided Tour, Design, EB Bundle Edit Page Findings, EB Edit and Settings Gap Audit 2026-06-04, EB Settings Page Findings, Edit Visibility Modal (+4 more)
 
 ### Community 390 - "Community 390"
-Cohesion: 0.12
-Nodes (23): ConfigureBundleFlow(), asVisibilityArray(), getVisibilityDisplayTarget(), ppbConfigureFlowStaticExports, usePpbBundleSettingsState(), usePpbCategoryHandlers(), usePpbConfigureFlow(), usePpbDisplayOptionsState() (+15 more)
+Cohesion: 0.10
+Nodes (26): ConfigureBundleFlow(), asVisibilityArray(), getVisibilityDisplayTarget(), ppbConfigureFlowStaticExports, usePpbBundleSettingsState(), usePpbCategoryHandlers(), usePpbConfigureFlow(), usePpbDisplayOptionsState() (+18 more)
 
 ### Community 391 - "Community 391"
-Cohesion: 0.05
-Nodes (24): FAQS_AND_TUTORIALS, LATEST_EVENTS, FEATURES, STEP_TITLES, AttributionDashboard, generateThemeEditorLink(), handleOpenThemeEditor(), handleStepAction() (+16 more)
+Cohesion: 0.03
+Nodes (61): ensureExpiringOfflineSessionInBackground(), FAQS_AND_TUTORIALS, LATEST_EVENTS, FEATURES, loader(), STEP_TITLES, AttributionDashboard, generateThemeEditorLink() (+53 more)
 
 ### Community 392 - "Community 392"
-Cohesion: 0.06
-Nodes (56): Admin Tier Config Architecture Decision Record, Admin Tier Config BR, Admin Tier Config PO Requirements, PricingTiersSection UI Component, Rationale: Option C (tierConfig on Bundle DB + existing API) Selected, Admin Tier Config SDE Implementation Plan, Bundle.tierConfig JSON Field, validateTierConfig Server Function (+48 more)
+Cohesion: 0.04
+Nodes (73): Admin Tier Config Architecture Decision Record, Admin Tier Config BR, Admin Tier Config PO Requirements, PricingTiersSection UI Component, Rationale: Option C (tierConfig on Bundle DB + existing API) Selected, Admin Tier Config SDE Implementation Plan, Bundle.tierConfig JSON Field, validateTierConfig Server Function (+65 more)
 
 ### Community 393 - "Community 393"
 Cohesion: 0.03
-Nodes (79): loader(), action(), action(), loader(), action(), loader(), CORS_HEADERS, loader() (+71 more)
+Nodes (80): loader(), action(), action(), loader(), action(), loader(), CORS_HEADERS, loader() (+72 more)
 
 ### Community 394 - "Community 394"
-Cohesion: 0.05
-Nodes (60): Billing / Subscription Service, BroadcastChannel IPC for DCP Preview, Shared Bundle Formatter (bundle-formatter.server.ts), Bundle Configure Handlers (handlers.server.ts), CSS Variables / DCP CSS Variable System, Concept: Design Control Panel (DCP), Concept: Full-Page Bundle Widget (FPB), Free Gift Step in PDP Widget (+52 more)
+Cohesion: 0.08
+Nodes (47): Billing / Subscription Service, BroadcastChannel IPC for DCP Preview, Shared Bundle Formatter (bundle-formatter.server.ts), Bundle Configure Handlers (handlers.server.ts), CSS Variables / DCP CSS Variable System, Concept: Design Control Panel (DCP), Concept: Full-Page Bundle Widget (FPB), Free Gift Step in PDP Widget (+39 more)
 
 ### Community 395 - "Community 395"
 Cohesion: 0.10
 Nodes (18): headers(), links(), loader(), App(), addAddonTierCondition(), async(), buildBundleUpsellConfig(), handleDefaultProductPicker() (+10 more)
 
 ### Community 396 - "Community 396"
-Cohesion: 0.10
-Nodes (40): activateStepCategory(), applyFullPageDesignPresetMarker(), createActiveCategoryTitle(), createBundleBanners(), createCategorySectionRows(), createCategoryTabs(), createDefaultLoadingAnimation(), createFullPageProductGrid() (+32 more)
+Cohesion: 0.08
+Nodes (47): activateStepCategory(), applyFullPageDesignPresetMarker(), buildStepTimelineEntries(), createActiveCategoryTitle(), createBundleBanners(), createCategorySectionRows(), createCategoryTabs(), createDefaultLoadingAnimation() (+39 more)
 
 ### Community 397 - "Community 397"
 Cohesion: 0.17
@@ -5558,19 +5552,19 @@ Nodes (34): clearStepSelections(), closeModal(), createAddToCartButton(), create
 
 ### Community 426 - "Community 426"
 Cohesion: 0.04
-Nodes (48): BundleStep Prisma Model, Concept: ConditionValidator (Shared Module), Concept: Step Conditions (Bundle Widget), condition-validator.js, Test: condition-validator.test.ts, 2026-02-24 11:00 - Starting Investigation, 2026-02-24 12:00 - Bugs Found & Fixed, 2026-02-24 12:30 - Build, Verify & Commit (+40 more)
+Nodes (54): BundleStep Prisma Model, Concept: ConditionValidator (Shared Module), Concept: Step Conditions (Bundle Widget), condition-validator.js, Test: condition-validator.test.ts, 2026-02-22 01:30 - Starting implementation, Issue: Comprehensive Discount Condition Tests, Overview (+46 more)
 
 ### Community 427 - "Community 427"
-Cohesion: 0.04
-Nodes (51): 🧪 Admin LCP Debug Bridge Rule, 🗺️ App Navigation Map, Architecture and Gotcha Documentation, 🗜️ Asset Minification, 🧭 Chrome DevTools App Verification, 🖱️ Chrome DevTools — Shopify Admin Iframe Interaction, Claude Code Development Guidelines, 🔬 Competitor Parity Audit Rule (+43 more)
+Cohesion: 0.08
+Nodes (24): 🧪 Admin LCP Debug Bridge Rule, 🗺️ App Navigation Map, Architecture and Gotcha Documentation, 🗜️ Asset Minification, 🧭 Chrome DevTools App Verification, Claude Code Development Guidelines, 🔬 Competitor Parity Audit Rule, Core Operating Principles (+16 more)
 
 ### Community 428 - "Community 428"
 Cohesion: 0.06
 Nodes (35): action(), buildCorsHeaders(), CORS_HEADERS, EngagementPayload, isNonEmptyString(), loader(), sanitizeEventName(), sanitizeOptionalString() (+27 more)
 
 ### Community 429 - "Community 429"
-Cohesion: 0.05
-Nodes (49): loader(), sanitizeBundleType(), ActionResponse, BundleActionsButtonsProps, BundleWithPreview, CloneBundleResponse, CreateBundleResponse, DeleteBundleResponse (+41 more)
+Cohesion: 0.04
+Nodes (57): BundleTextOverrides, BundleUiConfig, BundleUiMessaging, BundleUiPricing, BundleUiPricingRule, BundleUiStep, ComponentParentsData, ComponentPricing (+49 more)
 
 ### Community 430 - "Community 430"
 Cohesion: 0.18
@@ -5605,16 +5599,16 @@ Cohesion: 0.18
 Nodes (10): Backward Compatibility Requirements, Data Persistence, Out of Scope (explicit), Product Owner Requirements: Centralized Auth Layer for API Routes, Story 1: Auth Helpers File, Story 2: Webhook Endpoint Protected, Story 3: All API Routes Use Helpers, Story 4: CI Enforcement Script (+2 more)
 
 ### Community 438 - "Community 438"
-Cohesion: 0.07
-Nodes (63): applyStandardExpandedVariantTitle(), areBundleConditionsMet(), attachProductCardListeners(), bundleHasNoConditions(), canCheckoutWithBoxSelection(), _createFooterBar(), _createMobileSummaryActionButton(), createProductCard() (+55 more)
+Cohesion: 0.11
+Nodes (29): canCheckoutWithBoxSelection(), createStandardSidebarSelectedRow(), getActiveBoxSelectionRule(), getBoxSelectionRules(), getBoxSelectionValidationState(), getBundleSummaryText(), getClassicSidebarSlotCount(), getDiscountProgressMilestones() (+21 more)
 
 ### Community 439 - "Community 439"
 Cohesion: 0.09
 Nodes (18): Document Index, EB | Easy Bundle Builder — Competitor Analysis Index, Key Competitive Highlights, Screenshots, Architectural Notes, Dashboard Home, Dashboard & Navigation, Hero Section (+10 more)
 
 ### Community 440 - "Community 440"
-Cohesion: 0.12
-Nodes (17): Checkout Extension Legacy Object Format Removal, Concept: Shopify urlRedirectCreate Mutation, Discount Messaging Templates Not Applied at Storefront Issue, Handler: full-page-bundle configure handlers.server.ts, FPB Preview URL Fix — shareablePreviewUrl Removed Issue, handleSyncBundle — Conditional Page Delete Guard Fix, 2026-03-31 03:00 - Implemented, Fix (+9 more)
+Cohesion: 0.07
+Nodes (20): Connections, Documentation Hub README, Connections, Free Plan (3 bundles max), Connections, Google Cloud Pub/Sub Setup Guide, Connections, Grow Plan (20 bundles, $9.99/month) (+12 more)
 
 ### Community 441 - "Community 441"
 Cohesion: 0.18
@@ -5805,12 +5799,12 @@ Cohesion: 0.20
 Nodes (10): Analytics Route /app/attribution, App API Routes Reference, Create Bundle Modal, Dashboard Route /app/dashboard, Design Control Panel Route /app/design-control-panel, FPB Bundle Configure Route, FPB DCP Customization Modal (3-column max overlay), App Navigation Map (+2 more)
 
 ### Community 488 - "Community 488"
-Cohesion: 0.04
-Nodes (53): Source: bundle-widget-components.js, Concept: CurrencyManager (Widget Module), Concept: Floating Footer (FPB Widget), 2026-04-02 14:00 - Starting fix, 2026-04-02 14:30 - Completed all four fixes, Bug 1: Footer counter shown when no step conditions are configured, Bug 2: Footer counter label says "Products" instead of "Steps", Bug 3: `totalRequired` denominator includes free gift steps (+45 more)
+Cohesion: 0.05
+Nodes (40): Concept: CurrencyManager (Widget Module), Concept: Floating Footer (FPB Widget), 2026-04-02 14:00 - Starting fix, 2026-04-02 14:30 - Completed all four fixes, Bug 1: Footer counter shown when no step conditions are configured, Bug 2: Footer counter label says "Products" instead of "Steps", Bug 3: `totalRequired` denominator includes free gift steps, Bug 4: Free gift price renders `$0.00` (hardcoded USD symbol) (+32 more)
 
 ### Community 489 - "Community 489"
-Cohesion: 0.12
-Nodes (23): buildPaidAddonProductDisplayData(), createFreeGiftStatusIcon(), createFreeGiftStatusText(), getAddonEligibilityState(), getAddonLineDiscount(), getAddonMessageEligibilityState(), getAddonMessageTierEvaluation(), getAddonSummaryEligibilityStates() (+15 more)
+Cohesion: 0.15
+Nodes (20): createFreeGiftStatusIcon(), createFreeGiftStatusText(), getAddonEligibilityState(), getAddonLineDiscount(), getAddonMessageEligibilityState(), getAddonMessageTierEvaluation(), getAddonSummaryEligibilityStates(), getAddonTierCandidatesWithState() (+12 more)
 
 ### Community 490 - "Community 490"
 Cohesion: 0.10
@@ -5821,8 +5815,8 @@ Cohesion: 0.07
 Nodes (54): addBundleToCart(), addItem(), applyBundleLevelCss(), _bootstrap(), buildBundleDetailsDisplayProperties(), buildCartItems(), _buildCartLineSourceProperties(), _buildLimitText() (+46 more)
 
 ### Community 492 - "Community 492"
-Cohesion: 0.17
-Nodes (11): generateButtonCSS(), generateFullPageVariables(), generateFooterCSS(), generateCSSFromSettings(), generateModalCSS(), generateProductCardCSS(), generateResponsiveCSS(), CSSDesignSettings (+3 more)
+Cohesion: 0.15
+Nodes (22): generateButtonCSS(), buildBadgePositionVars(), cssPx(), cssValue(), cssWeight(), designPath(), designPx(), designWeight() (+14 more)
 
 ### Community 493 - "Community 493"
 Cohesion: 0.06
@@ -6124,8 +6118,8 @@ Cohesion: 0.20
 Nodes (9): Build & Verification Checklist, Overview, Phase 1: Schema + Types + Defaults + Merge, Phase 2: CSS Variable Generation + API Route, Phase 3: Handler + Widget CSS + Widget JS, Phase 4: DCP UI — Settings Panel + Preview, Phase 5: Build + Lint + Commit, Rollback (+1 more)
 
 ### Community 567 - "Community 567"
-Cohesion: 0.18
-Nodes (10): Bundle Instance Tracking, BXY rounding, Cart Transform Function, Extension Config (authoritative), Language & Build, MERGE/EXPAND Pattern, Migration Note — Target Deprecation, Operation Names (2025-07+ API) (+2 more)
+Cohesion: 0.17
+Nodes (11): Bundle Instance Tracking, BXY rounding, Cart Transform Function, Component variant metafield owner IDs, Extension Config (authoritative), Language & Build, MERGE/EXPAND Pattern, Migration Note — Target Deprecation (+3 more)
 
 ### Community 568 - "Community 568"
 Cohesion: 0.20
@@ -6143,29 +6137,43 @@ Nodes (9): Acceptance Criteria, Chrome Verification, FPB Save Sanitization, PPB 
 Cohesion: 0.20
 Nodes (10): Compact Sticky Footer Bar (72px height, fixed to bottom of viewport), CSS is-open Class Toggle for Footer Expand/Collapse (no inline style manipulation), DCP CSS Variables Mapping for New Beco Footer Elements, Deal-Unlock Callout Banner (green, appears when bundle goal met), Expandable Product List Panel (upward-expanding, max-height 60vh), Beco BYOB Expandable Floating Footer — Architecture Decision Record, Beco BYOB Expandable Floating Footer — Business Requirement, Beco BYOB Expandable Floating Footer — PO Requirements (+2 more)
 
-### Community 573 - "Community 573"
+### Community 572 - "Community 572"
 Cohesion: 0.05
-Nodes (45): Bundle Variant Price Fix ($0 to Calculated), Ad-Ready Bundles Architecture Decision Record, Ad-Ready Bundles PO Requirements, Ad-Ready Bundles SDE Implementation Plan, Ad-Ready Bundle Infrastructure Feature Specification, Campaign Bundles (UNLISTED Status), OrderAttribution Prisma Model, Rationale: Option A (Direct GraphQL via unauthenticated.admin) Selected (+37 more)
+Nodes (26): bundle-formatter.server.ts (formatBundleForWidget), Connections, Connections, custom:bundle_config Shopify Page Metafield, Connections, FPB Config Metafield Cache - Architecture Decision Record, Connections, Handler: app.design-control-panel/handlers.server.ts (+18 more)
+
+### Community 573 - "Community 573"
+Cohesion: 0.14
+Nodes (15): Remove inventoryManagement from GraphQL variant inputs, Inngest Fallback Guard (INNGEST_AVAILABLE), inventoryManagement Field Removal (API 2025-10), 2026-03-13 — Implemented (all phases), Issue: Inngest Durable Webhook Queue, Overview, Phases Checklist, Progress Log (+7 more)
 
 ### Community 574 - "Community 574"
 Cohesion: 0.05
 Nodes (41): scripts, build, build-dev, build:sdk, build:widgets, build:widgets:full-page, build:widgets:product-page, bulk-sync (+33 more)
 
 ### Community 575 - "Community 575"
-Cohesion: 0.10
-Nodes (14): Concept: Shopify urlRedirectCreate Mutation, Connections, Connections, FPB Preview URL Fix — shareablePreviewUrl Removed Issue, Connections, Handler: full-page-bundle configure handlers.server.ts, Connections, handleSyncBundle — Conditional Page Delete Guard Fix (+6 more)
+Cohesion: 0.15
+Nodes (18): {
+  addSelectedProduct,
+  removeSelectedProduct,
+}, { createBundleState }, {
+  getCurrentStep,
+  getSelectedQuantity,
+  getSelectedSubtotalCents,
+}, {
+  buildProductPageCartFormData,
+  extractBundleDetailsSourceProperties,
+}, { shouldRenderInlineVariantSelector }, addSelectedProduct(), clearStepSelection(), ensureStep() (+10 more)
 
 ### Community 576 - "Community 576"
 Cohesion: 0.01
-Nodes (301): api.storefront-products Route, Connections, app/assets/widgets/shared/ — Shared Widget Component Modules, Connections, app/lib/dcp-config/base.config.ts (DCP Navigation Config), Connections, AppLogger (Structured Logger Utility), Connections (+293 more)
+Nodes (169): api.storefront-products Route, Connections, app/assets/widgets/shared/ — Shared Widget Component Modules, Connections, bundle-full-page.liquid Block, Connections, bundle-widget-full-page.css, Connections (+161 more)
 
 ### Community 577 - "Community 577"
-Cohesion: 0.17
-Nodes (7): AppEmbedBanner(), AppEmbedBannerProps, AppEmbedGuideModal(), AppEmbedGuideModalProps, openThemeEditorInNewTab(), visibilityStyles, FpbBundleVisibilityPanel()
+Cohesion: 0.18
+Nodes (8): BundlePricing.messages JSON Field, Connections, Connections, i18n Discount Messaging — Architecture ADR, Connections, i18n Discount Messaging — SDE Implementation Plan, Connections, LocalizedPricingMessages — Locale-Keyed Message Data Model
 
 ### Community 578 - "Community 578"
-Cohesion: 0.01
-Nodes (149): Ad-Ready Bundle Infrastructure — Feed-Ready Product Enhancement, Connections, Ad-Ready Bundles Business Requirement (BR), Connections, Ad-Ready Bundles (feed price + inventory sync), Connections, API Endpoints Reference, Connections (+141 more)
+Cohesion: 0.03
+Nodes (64): Ad-Ready Bundle Infrastructure — Feed-Ready Product Enhancement, Connections, Architecture Overview, Connections, Beco BYOB Bundle Page Design Analysis, Connections, Beco BYOB Layout as Design Reference, Connections (+56 more)
 
 ### Community 579 - "Community 579"
 Cohesion: 0.22
@@ -6468,8 +6476,8 @@ Cohesion: 0.13
 Nodes (11): LazyEngagementPulse, LazyRevenueAttribution, AttributionDashboardData, AttributionDashboardViewData, DateRangeSelector(), DateRangeSelectorProps, formatDateLabel(), formatRangeLabel() (+3 more)
 
 ### Community 652 - "Community 652"
-Cohesion: 0.03
-Nodes (74): bundle-modal-component.js, Cart Transform Extension (WASM), DCP Modal Bugs & Dead Code Cleanup, DCP Storefront Iframe Preview — Sub-Plan 1 Infrastructure, DCP Preview — Option 3 App-Served Preview Page, DCP Preview Option 3 — App-Served Same-Origin Preview, DCP Mobile Preview Toggle - Architecture Decision Record, DCP Mobile Preview Toggle - Business Requirement (+66 more)
+Cohesion: 0.05
+Nodes (53): bundle-modal-component.js, Cart Transform Extension (WASM), DCP Mobile Preview Toggle - Business Requirement, DCP Mobile Preview Toggle Feature, DCP Mobile Preview Toggle - PO Requirements, DCP Mobile Preview Toggle - SDE Implementation, DCP Phase 1 Additions - Architecture Decision Record, DCP Phase 1 Additions - Business Requirement (+45 more)
 
 ### Community 653 - "Community 653"
 Cohesion: 0.06
@@ -6477,7 +6485,7 @@ Nodes (32): dependencies, autoprefixer, crisp-sdk-web, @heymantle/client, @heyma
 
 ### Community 654 - "Community 654"
 Cohesion: 0.05
-Nodes (27): { authenticate }, makeAdmin(), makeDiscountData(), makeFormData(), makeStepsData(), makeStepWithProduct(), MOCK_ADMIN, MOCK_SESSION (+19 more)
+Nodes (36): action(), CachedPrice, cacheStats, calculateBundlePrice(), calculateBundleTotalPrice(), cleanExpiredCache(), clearPriceCache(), getCachedPrice() (+28 more)
 
 ### Community 655 - "Community 655"
 Cohesion: 0.06
@@ -6488,8 +6496,8 @@ Cohesion: 0.25
 Nodes (7): Architecture Decision Record: Cart Property Visibility Fix, Component Design, Context, Dashboard Placement, Decision, Files to Modify, Testing Strategy
 
 ### Community 657 - "Community 657"
-Cohesion: 0.20
-Nodes (4): Connections, Shopify 64KB Metafield Size Limit, Connections, Theme Editor Deep Link Generator
+Cohesion: 0.03
+Nodes (66): Admin Performance Optimization Report, Connections, App Proxy API (/apps/product-bundles/api/bundle/), Connections, App Store Compliance (No Theme Writes), Connections, Bundle.active Column (Redundant), Connections (+58 more)
 
 ### Community 658 - "Community 658"
 Cohesion: 0.05
@@ -6980,8 +6988,8 @@ Cohesion: 0.29
 Nodes (8): BundlePricing.messages JSON Field, i18n Discount Messaging — Architecture ADR, i18n Discount Messaging — Business Requirement, i18n Discount Messaging — PO Requirements, i18n Discount Messaging — Shopify i18n Research, i18n Discount Messaging — SDE Implementation Plan, LocalizedPricingMessages — Locale-Keyed Message Data Model, window.Shopify.locale — Storefront Locale Detection
 
 ### Community 780 - "Community 780"
-Cohesion: 0.14
-Nodes (14): loader(), CHECKOUT_INTEGRATION_OPTIONS, ControlsLayout, getIntegrationCardCount(), INTEGRATION_CATEGORIES, IntegrationCard, IntegrationCategory, LanguageConfiguration (+6 more)
+Cohesion: 0.05
+Nodes (28): Admin Tier Config Architecture Decision Record, Connections, Admin Tier Config SDE Implementation Plan, Connections, api.bundle.$bundleId[.]json.tsx Route, Connections, Bundle.tierConfig JSON Field, Connections (+20 more)
 
 ### Community 781 - "Community 781"
 Cohesion: 0.10
@@ -6992,24 +7000,24 @@ Cohesion: 0.08
 Nodes (27): App Proxy API (/apps/product-bundles/api/bundle/), App Store Compliance (No Theme Writes), BundleConfig Database Table, checkFullPageBundleInstallation() Method, createFullPageBundle() Function, Full-Page Bundle Unified Flow, Full-Page Bundle Add-to-Cart Button Removal, Full-Page Widget Detection Fix (+19 more)
 
 ### Community 783 - "Community 783"
-Cohesion: 0.05
-Nodes (39): Source: app/constants/api.ts (new), Source: app/constants/bundle.ts, Source: app/constants/errors.ts (new), Source: bundle-data-manager.js (Shared Widget Module), Concept: BundleStatus/BundleType Enums, Concept: Unlisted Bundle Status, Discount Condition Text Operator-Awareness Fix, Discount equal_to Condition Threshold Fix (+31 more)
+Cohesion: 0.08
+Nodes (22): Source: app/constants/api.ts (new), Source: app/constants/bundle.ts, Source: app/constants/errors.ts (new), Concept: BundleStatus/BundleType Enums, Concept: Unlisted Bundle Status, 2026-02-28 14:00 - Starting Implementation, 2026-02-28 16:00 - Completed Implementation, Files Created (+14 more)
 
 ### Community 784 - "Community 784"
 Cohesion: 0.07
 Nodes (30): 2026-06-02 01:21 - Goal started and fast-track architecture initiated, 2026-06-02 11:10 - FPB COMPACT card density parity slice, 2026-06-02 11:50 - PPB discount tier pill DTO parity slice completed, 2026-06-02 11:50 - Started PPB discount tier pill DTO parity slice, 2026-06-02 12:28 - Started PPB SDK cart contract parity slice, 2026-06-02 12:39 - PPB SDK cart contract parity slice completed, 2026-06-02 12:40 - Started PPB EB template body marker slice, 2026-06-02 12:55 - Started FPB promo discount-tier badge parity slice (+22 more)
 
 ### Community 785 - "Community 785"
-Cohesion: 0.12
-Nodes (18): buildStepTimelineEntries(), clearStepSelections(), closeModal(), createStandardStepTimeline(), createStepTimeline(), ensureTimelinePagingStyles(), getStandardTimelinePageSize(), getStandardTimelineVisibleEntries() (+10 more)
+Cohesion: 0.13
+Nodes (16): Bundle Variant Price Fix ($0 to Calculated), Ad-Ready Bundle Infrastructure Feature Specification, Campaign Bundles (UNLISTED Status), OrderAttribution Prisma Model, Web Pixel Extension for UTM Attribution, Analytics Pixel Toggle PO Requirements, Analytics Page Redesign PO Requirements, Critical Price Calculation Fix (January 2025) (+8 more)
 
 ### Community 786 - "Community 786"
 Cohesion: 0.04
-Nodes (50): File: bundle-full-page-embed.liquid (App Embed Block, target: body), File: bundle-product-page-embed.liquid (App Embed Block, target: body), Bottom-Sheet Product Selection Modal, Component: BundleFooterPreview.tsx (DCP Footer Preview), CSS: Bottom-Sheet Classes (.bw-bs-overlay, .bw-bs-panel, .bw-slot-card), Feature: Custom Polaris Delete Confirmation Modal (Dashboard), DCP CSS Custom Properties / Variables, Issue: DCP Discount Text & Progress Bar Preview Fix (dcp-discount-progress-fix-1) (+42 more)
+Nodes (49): File: bundle-full-page-embed.liquid (App Embed Block, target: body), File: bundle-product-page-embed.liquid (App Embed Block, target: body), Bottom-Sheet Product Selection Modal, Component: BundleFooterPreview.tsx (DCP Footer Preview), CSS: Bottom-Sheet Classes (.bw-bs-overlay, .bw-bs-panel, .bw-slot-card), Feature: Custom Polaris Delete Confirmation Modal (Dashboard), DCP CSS Custom Properties / Variables, Issue: DCP Discount Text & Progress Bar Preview Fix (dcp-discount-progress-fix-1) (+41 more)
 
 ### Community 787 - "Community 787"
 Cohesion: 0.04
-Nodes (58): CartLineDisplayProperties, CartLineMessagingSettings, CartLineMessagingValues, serializeCartLineDisplayProperties(), buildCategoryContract(), CategoryBundleType, CategoryCollectionContract, CategoryConditionContract (+50 more)
+Nodes (59): CartLineDisplayProperties, CartLineMessagingSettings, CartLineMessagingValues, serializeCartLineDisplayProperties(), buildCategoryContract(), CategoryBundleType, CategoryCollectionContract, CategoryConditionContract (+51 more)
 
 ### Community 788 - "Community 788"
 Cohesion: 0.06
@@ -7257,7 +7265,7 @@ Nodes (6): Baseline Matrix, Baseline Observations, Bundle Widget Refactor Baseli
 
 ### Community 850 - "Community 850"
 Cohesion: 0.09
-Nodes (19): Boundaries, Compatibility Layer, Provider, Slices, State Management, Bundle Status, Bundle Types, Full-Page Bundle (FPB) (+11 more)
+Nodes (19): Boundaries, Compatibility Layer, Provider, Slices, State Management, Bundle Instance Tracking, MERGE Deduplication, Problem (+11 more)
 
 ### Community 851 - "Community 851"
 Cohesion: 0.29
@@ -7392,16 +7400,16 @@ Cohesion: 0.13
 Nodes (12): Analytics Pixel Toggle Architecture, Connections, Connections, deactivateUtmPixel Service Function, Connections, getPixelStatus Service Function, Connections, pixel-activation.server.ts Service (+4 more)
 
 ### Community 884 - "Community 884"
-Cohesion: 0.14
-Nodes (14): defaultMetaState, metaSlice, defaultPreferencesState, preferencesSlice, ReduxProvider(), AppDispatch, AppStore, loadStoredPreferences() (+6 more)
+Cohesion: 0.11
+Nodes (16): defaultMetaState, metaSlice, defaultPreferencesState, preferencesSlice, subscriptionSlice, ReduxProvider(), AppDispatch, AppStore (+8 more)
 
 ### Community 885 - "Community 885"
 Cohesion: 0.03
-Nodes (65): custom:bundle_config Shopify Page Metafield, bundle-full-page.liquid Block, Custom Title / Description / Instruction Settings, data-bundle-config HTML Attribute (Liquid injection for zero-proxy load), data-tier-config Attribute, FPB Auto Widget Install - Architecture Decision Record, FPB Auto Widget Install - Business Requirement, FPB Auto Widget Install Feature (+57 more)
+Nodes (63): custom:bundle_config Shopify Page Metafield, bundle-full-page.liquid Block, Custom Title / Description / Instruction Settings, data-bundle-config HTML Attribute (Liquid injection for zero-proxy load), FPB Auto Widget Install - Architecture Decision Record, FPB Auto Widget Install - Business Requirement, FPB Auto Widget Install Feature, FPB Auto Widget Install - PO Requirements (+55 more)
 
 ### Community 886 - "Community 886"
-Cohesion: 0.20
-Nodes (12): collectCategoryProducts(), collectStepCollectionHandles(), collectStepProductIds(), enrichMissingProductDescriptions(), loadStepProducts(), mergeCategoryProductVariantAvailability(), _mergeDirectDefaultProductsIntoStep(), openModal() (+4 more)
+Cohesion: 0.06
+Nodes (24): Application Architecture Document, Connections, BillingService (app/services/billing.server.ts), Connections, BundleIsolationService, Connections, BundleProductManagerService, Connections (+16 more)
 
 ### Community 887 - "Community 887"
 Cohesion: 0.12
@@ -7416,20 +7424,20 @@ Cohesion: 0.11
 Nodes (19): LineItemInput, matchLineItemsToBundles(), normalizeToOrderGid(), orderIdMatchForms(), mockBundleFindMany, mockBundleStepFindMany, AdminClient, backfillOrderAttribution() (+11 more)
 
 ### Community 890 - "Community 890"
-Cohesion: 0.02
-Nodes (106): Add-to-Bundle Button Selected Color Architecture, Add-to-Bundle Button Selected-State Colour DCP Control, CSS Variable --bundle-button-added-bg, CSS Variable --bundle-button-added-text, buttonAddedBgColor / buttonAddedTextColor Prisma Fields, Add-to-Bundle Button Selected Color SDE Plan, api.design-settings.$shopDomain.tsx Route, Bottom-Sheet CSS Variable Output Fix in CSS Generator (+98 more)
+Cohesion: 0.04
+Nodes (64): Add-to-Bundle Button Selected Color Architecture, CSS Variable --bundle-button-added-bg, CSS Variable --bundle-button-added-text, buttonAddedBgColor / buttonAddedTextColor Prisma Fields, Add-to-Bundle Button Selected Color SDE Plan, Shopify afterAuth Hook (shopify.server.ts), Bottom-Sheet CSS Variable Output Fix in CSS Generator, BundleAnalytics Preservation During Sync (+56 more)
 
 ### Community 891 - "Community 891"
 Cohesion: 0.10
 Nodes (13): CachedSessionStorage, CacheEntry, isOfflineCredentialUnusable(), isTransientPrismaConnectionError(), SessionRow, SessionWithRefreshFields, sleep(), buildCompliantOfflineSession() (+5 more)
 
 ### Community 892 - "Community 892"
-Cohesion: 0.07
-Nodes (26): 2026-01-17 10:00 - Starting Implementation, 2026-01-17 10:30 - Completed Implementation, Files Modified, Issue: Dashboard Account Manager Update & Uninstall/Step Fixes, Overview, Phases Checklist, Progress Log, Related Documentation (+18 more)
+Cohesion: 0.14
+Nodes (13): 2026-01-17 10:00 - Starting Implementation, 2026-01-17 10:30 - Completed Implementation, Files Modified, Issue: Dashboard Account Manager Update & Uninstall/Step Fixes, Overview, Phases Checklist, Progress Log, Related Documentation (+5 more)
 
 ### Community 893 - "Community 893"
-Cohesion: 0.12
-Nodes (12): Bundle Type Separation Architecture Summary, Connections, bundleType Field (product_page | full_page), Connections, Connections, Full-Page Bundle Configure Route, Connections, Full-Page Bundle Implementation Plan (Original) (+4 more)
+Cohesion: 0.11
+Nodes (23): useConfigureBundleController(), SubscriptionValidationResponse, usePpbBaseConfigureState(), Window, ConditionRule, useBundleConditions(), UseBundleConditionsProps, BundleData (+15 more)
 
 ### Community 894 - "Community 894"
 Cohesion: 0.11
@@ -7471,9 +7479,13 @@ Nodes (24): _createModalSlotStepSection(), createStepBannerImageElement(), escap
 Cohesion: 0.17
 Nodes (8): Community 1467, Live Query (requires Dataview plugin), Members, Connections to other communities, Full-Page Modal (Bundled), Live Query (requires Dataview plugin), Members, Top bridge nodes
 
+### Community 903 - "Community 903"
+Cohesion: 0.02
+Nodes (95): Admin-Controlled Step Timeline Visibility for FPB, Connections, Billing / Subscription Service, Connections, BroadcastChannel IPC for DCP Preview, Connections, Bundle Configure Handlers (handlers.server.ts), Connections (+87 more)
+
 ### Community 904 - "Community 904"
 Cohesion: 0.04
-Nodes (58): app.billing.tsx Route, app.pricing.tsx Route, Billing returnUrl Embedded App Pattern, Service: billing.server.ts, Fix Session Loss During Billing Upgrade Redirect, Service: bundle-analytics.server.ts, Issue: Codebase Refactoring Plan — Separation of Concerns, Concept: Billing / Upgrade Flow (Free → Grow plan) (+50 more)
+Nodes (58): app.billing.tsx Route, app.pricing.tsx Route, Billing returnUrl Embedded App Pattern, Service: billing.server.ts, Fix Session Loss During Billing Upgrade Redirect, Service: bundle-analytics.server.ts, Source: bundle-widget-components.js, Issue: Codebase Refactoring Plan — Separation of Concerns (+50 more)
 
 ### Community 905 - "Community 905"
 Cohesion: 0.10
@@ -7484,40 +7496,40 @@ Cohesion: 0.08
 Nodes (26): Concept: Custom CSS Sanitization (XSS Prevention), Source: app/lib/css-sanitizer.ts, 2026-01-21 10:30 - Implementation Completed, Content Security Policy (CSP), Current Architecture Compatibility, Database Migration, Files Changed Summary, How Competitors Implement This Feature (+18 more)
 
 ### Community 907 - "Community 907"
-Cohesion: 0.10
-Nodes (14): cart-transform-run.test.ts, Connections, cart-transform-service.test.ts, Connections, Cart Transform Test Environment Variables, Connections, Connections, Prisma Client Mock (test setup) (+6 more)
+Cohesion: 0.06
+Nodes (24): Ad-Ready Bundles Business Requirement (BR), Connections, Ad-Ready Bundles (feed price + inventory sync), Connections, Bundle Prisma Model, Connections, BundlePricing Prisma Model, Connections (+16 more)
 
 ### Community 908 - "Community 908"
 Cohesion: 0.05
 Nodes (17): { fullPageMobileSummaryMethods }, { fullPageRuntimeCartSettingsMethods }, { fullPageStepFooterMethods }, { fullPageStepFooterMethods }, { fullPageBoxSelectionSidebarMethods }, FakeElement, { fullPageBoxSelectionSidebarMethods }, { fullPageMobileSummaryMethods } (+9 more)
 
 ### Community 909 - "Community 909"
-Cohesion: 0.09
-Nodes (29): loader(), DesignSettingsView(), DesignSettingsViewProps, PreviewBundle, getFieldValueKey(), getInitialControlFieldValues(), getInitialDesignFieldValues(), getInitialLanguageFieldValues() (+21 more)
+Cohesion: 0.07
+Nodes (43): loader(), loader(), DesignSettingsView(), DesignSettingsViewProps, PreviewBundle, getFieldValueKey(), getInitialControlFieldValues(), getInitialDesignFieldValues() (+35 more)
 
 ### Community 910 - "Community 910"
 Cohesion: 0.12
 Nodes (18): Analytics Pixel Toggle Architecture, deactivateUtmPixel Service Function, getPixelStatus Service Function, Remove Pixel Auto-Activation from afterAuth, App Proxy 504 / Render Cold-Start Issue, CachedSessionStorage (In-Memory TTL Session Cache), Issue: Dashboard Crash — CartPropertyFixContent Missing Import, Dashboard Route (route.tsx) (+10 more)
 
 ### Community 911 - "Community 911"
-Cohesion: 0.12
-Nodes (19): Shopify afterAuth Hook (shopify.server.ts), BundleAnalytics Preservation During Sync, Bundle Prisma Model, GET /api/design-settings/{shopDomain} CSS Endpoint, Free Plan Feature Gating, generateCSSFromSettings() CSS Generator Function, 6 Global Color Anchors (globalPrimaryButton, globalButtonText, etc.), handleSyncBundle Handler Function (+11 more)
+Cohesion: 0.10
+Nodes (19): 1. Product Search Within Steps, 2026-01-30 14:00 - Planning Phase, 2026-01-30 14:15 - Analysis Complete, 2026-01-30 - Implementation Complete, 2. Smarter Variant Selection UX, 3. Mobile Modal Improvements, Features to Implement, Implementation Plan (+11 more)
 
 ### Community 912 - "Community 912"
-Cohesion: 0.05
-Nodes (28): bundle-cart-transform-ts Extension (cart_transform_run.ts), Connections, Bundle Checkout UI Extension, Connections, Cart Transform safeParseFloat + NaN Clamp Fix, Connections, Checkout UI Extension Targets, Connections (+20 more)
+Cohesion: 0.12
+Nodes (12): Connections, Discount Messaging Templates Not Applied at Storefront Issue, Connections, FPB Preview URL Fix — shareablePreviewUrl Removed Issue, Connections, Handler: full-page-bundle configure handlers.server.ts, Connections, handleSyncBundle — Conditional Page Delete Guard Fix (+4 more)
 
 ### Community 913 - "Community 913"
 Cohesion: 0.13
 Nodes (13): Route: app.dashboard/route.tsx, Route: app._index.tsx (home/onboarding), 2026-04-09 09:00 - Starting Phase 1, Issue: Replace Cart Lines Property Fix Card with Bundle Setup Steps Card, Overview, Phases Checklist, Progress Log, 2026-02-23 00:00 - Phase 1: All Copy Changes Started (+5 more)
 
 ### Community 914 - "Community 914"
-Cohesion: 0.04
-Nodes (71): loader(), buildProductsQuery(), CORS_HEADERS, loader(), action(), categorizeWidgetError(), CORS_HEADERS, sanitizeOptionalString() (+63 more)
+Cohesion: 0.06
+Nodes (50): handler, calculateBundleInventory(), calculateMinInventory(), ComponentInventory, setInventoryLevel(), syncBundleInventory(), SyncResult, SubscriptionStatus (+42 more)
 
 ### Community 915 - "Community 915"
-Cohesion: 0.05
-Nodes (40): 2026-01-28 23:45 - Started Issue Tracking, 2026-01-29 00:30 - All Phases Complete, 2026-01-29 01:15 - Additional Bug Fixes, Build Output, Completed (Verification Only), Files to Modify, Integration Testing, Issue: Full-Page Bundle Widget Enhancements (+32 more)
+Cohesion: 0.09
+Nodes (21): 2026-01-28 23:45 - Started Issue Tracking, 2026-01-29 00:30 - All Phases Complete, 2026-01-29 01:15 - Additional Bug Fixes, Build Output, Completed (Verification Only), Files to Modify, Integration Testing, Issue: Full-Page Bundle Widget Enhancements (+13 more)
 
 ### Community 916 - "Community 916"
 Cohesion: 0.03
@@ -7528,11 +7540,8 @@ Cohesion: 0.22
 Nodes (9): bundleConfigureSlice, defaultBundleConfigureState, pricing, step, BundleConfigurationState, BundleStep, Collection, ConditionRule (+1 more)
 
 ### Community 918 - "Community 918"
-Cohesion: 0.08
-Nodes (14): { cogniveTemplateMethods }, { modalSlotTemplateMethods }, ProductPageWidget, {
-  PPB_TEMPLATE_CONFIGS,
-  resolveProductPageTemplateConfig,
-}, { modalSlotTemplateMethods }, ProductPageWidget, cogniveTemplateMethods, PPB_GRID_TEMPLATE_CONFIG (+6 more)
+Cohesion: 0.18
+Nodes (11): Concept: Webhook Worker (HTTP server on Render), 2026-02-22 00:00 - Analysis and Planning, 2026-02-22 00:00 - Completed, 2026-02-22 00:00 - Implementation (All Phases), Issue: Replace GCP Pub/Sub Worker with Direct HTTP Webhook Receiver, Manual Steps Required (Not automated), Overview, Phases Checklist (+3 more)
 
 ### Community 919 - "Community 919"
 Cohesion: 0.16
@@ -7551,8 +7560,8 @@ Cohesion: 0.22
 Nodes (6): Connections, Issue: DCP Storefront Iframe Preview — Extension Templates, Connections, Theme Template: page.full-page-bundle.json, Connections, Theme Template: product.product-page-bundle.json
 
 ### Community 923 - "Community 923"
-Cohesion: 0.10
-Nodes (16): Connections, Inngest — Managed Durable Event Queue, Connections, Inngest Remix Serve Route (api.inngest.tsx), Connections, Inngest Webhook Queue — Architecture ADR, Connections, Inngest Webhook Queue — Business Requirement (+8 more)
+Cohesion: 0.03
+Nodes (65): Ad-Ready Bundle Infrastructure Feature Specification, Connections, Ad-Ready Bundles Architecture Decision Record, Connections, Ad-Ready Bundles PO Requirements, Connections, Ad-Ready Bundles SDE Implementation Plan, Connections (+57 more)
 
 ### Community 924 - "Community 924"
 Cohesion: 0.20
@@ -7563,24 +7572,27 @@ Cohesion: 0.08
 Nodes (23): buildSettingsData() — DCP Settings Handler, Connections, Community 29, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes, Connections (+15 more)
 
 ### Community 926 - "Community 926"
-Cohesion: 0.21
-Nodes (10): AdminApiContext, PreviewEventBundle, recordFirstBundlePreviewEvent(), mockAdmin, mockRecordFirstBundlePreviewEvent, mockSession, defaultRouteFamily(), handleRecordBundlePreview() (+2 more)
+Cohesion: 0.09
+Nodes (16): API Endpoints Reference, Connections, Bug: Pub/Sub Topic Name Mismatch (wolfpack-only-bundles vs wolfpack-product-bundles), Connections, Cart Transform: cart-transform-currency-utils.ts (dead code), Connections, Concept: Shopify App Proxy (/apps/product-bundles), Connections (+8 more)
 
 ### Community 927 - "Community 927"
 Cohesion: 0.08
 Nodes (21): app/lib/auth-guards.server.ts — Centralized Auth Helper Functions, Connections, app/routes/api/api.webhooks.pubsub.tsx (unprotected, needs requireInternalSecret), Connections, Community 31, Connections to other communities, Live Query (requires Dataview plugin), Members (+13 more)
 
 ### Community 928 - "Community 928"
-Cohesion: 0.14
-Nodes (10): Bundle Configure Handlers (handlers.server.ts), Connections, Connections, FPB Bundle Config Metafield Cache, Connections, Handlers Simplification Audit and Refactor, Connections, Shared Bundle Formatter (bundle-formatter.server.ts) (+2 more)
+Cohesion: 0.08
+Nodes (14): { cogniveTemplateMethods }, { modalSlotTemplateMethods }, ProductPageWidget, {
+  PPB_TEMPLATE_CONFIGS,
+  resolveProductPageTemplateConfig,
+}, { modalSlotTemplateMethods }, ProductPageWidget, cogniveTemplateMethods, PPB_GRID_TEMPLATE_CONFIG (+6 more)
 
 ### Community 929 - "Community 929"
 Cohesion: 0.11
 Nodes (12): App Proxy Bundle API (/apps/product-bundles/api/bundle/{id}.json), Connections, Connections, FPB Bundle Config Metafield Cache Feature, Connections, FPB Config Metafield Cache - Business Requirement, Connections, FPB Config Metafield Cache - PO Requirements (+4 more)
 
 ### Community 930 - "Community 930"
-Cohesion: 0.16
-Nodes (19): createStepBannerImageElement(), escapeAttribute(), escapeHtml(), getDisplayTitle(), getStatusClasses(), getVariantDisplayText(), renderAddButton(), renderBadges() (+11 more)
+Cohesion: 0.09
+Nodes (23): buildPaidAddonProductDisplayData(), ComponentGenerator, createStepBannerImageElement(), escapeAttribute(), escapeHtml(), getDisplayTitle(), getProductImageUrls(), getStatusClasses() (+15 more)
 
 ### Community 931 - "Community 931"
 Cohesion: 0.06
@@ -7695,8 +7707,8 @@ Cohesion: 0.33
 Nodes (5): Architecture: Single Embed Bundle Architecture, Configure Pages, FPB Proxy Page, Rollout, Theme Extension
 
 ### Community 959 - "Community 959"
-Cohesion: 0.13
-Nodes (10): Concept: Full-Page Bundle Widget (FPB), Connections, Connections, Fix Product Card Layout in Full-Page Widget, Connections, Issue: UI Comparison — Floating Footer Layout, Connections, Move FPB Layout Selection to Creation Step (+2 more)
+Cohesion: 0.12
+Nodes (24): action(), categorizeWidgetError(), CORS_HEADERS, sanitizeOptionalString(), sanitizeShopDomain(), sanitizeWidgetMessage(), action(), handleSyncBundle() (+16 more)
 
 ### Community 960 - "Community 960"
 Cohesion: 0.17
@@ -8123,30 +8135,30 @@ Cohesion: 0.22
 Nodes (19): Condition, PriceAdjustmentConfig, PricingMethod, calculate_discount_percentage(), adj(), adj_with_condition(), buy_x_get_y_condition_not_met_returns_zero(), buy_x_get_y_discounted_quantity() (+11 more)
 
 ### Community 1066 - "Community 1066"
-Cohesion: 0.10
-Nodes (24): Application Architecture Document, BillingService (app/services/billing.server.ts), Shop-Level Bundle Index Metafield, BundleIsolationService, BundleProductManagerService, Concept: Cart Transform Extension, CartTransformService, Discount Methods: percentage_off, fixed_amount_off, fixed_bundle_price (+16 more)
+Cohesion: 0.07
+Nodes (20): Component: CartPropertyFixCard.tsx, Connections, Connections, Dashboard Route (app.dashboard.tsx), Connections, Google Cloud Pub/Sub Webhook Delivery Architecture, Connections, isStepCompleted() — FPB Step Validation (+12 more)
 
 ### Community 1067 - "Community 1067"
 Cohesion: 0.19
 Nodes (20): attachProductEventHandlers(), canUpdateProductQuantity(), _createInpageCategoryTabs(), _createInpageStepSection(), expandProductsByVariant(), getAllowedQuantityPerProduct(), _getProductPageDesignPreset(), _getProductPageTemplateType() (+12 more)
 
 ### Community 1068 - "Community 1068"
-Cohesion: 0.47
-Nodes (11): buildBadgePositionVars(), cssPx(), cssValue(), cssWeight(), designPath(), designPx(), designWeight(), generateCSSVariables() (+3 more)
+Cohesion: 0.08
+Nodes (18): component-product.server.ts — component_parents Writer, Connections, Connections, createStepTimeline() — FPB Sidebar Tab Renderer, Connections, FPB Widget Bundled JS (bundle-widget-full-page-bundled.js), Connections, FPB Widget JS Source (bundle-widget-full-page.js) (+10 more)
 
 ### Community 1069 - "Community 1069"
-Cohesion: 0.13
-Nodes (17): { renderSharedProductCard }, {
+Cohesion: 0.24
+Nodes (13): { renderSharedProductCard }, {
   getProductImageUrls,
-}, { shouldRenderInlineVariantSelector }, escapeAttribute(), escapeHtml(), formatPrice(), getDisplayTitle(), getProductImageUrls() (+9 more)
+}, escapeAttribute(), escapeHtml(), formatPrice(), getDisplayTitle(), getProductImageUrls(), getVariantDisplayText() (+5 more)
 
 ### Community 1070 - "Community 1070"
 Cohesion: 0.19
 Nodes (16): minifyCSS(), resolveCssImports(), minifyJS(), readQuoted(), removeJSBlockComments(), removeJSSingleLineComments(), stripLineComment(), fmtBytes() (+8 more)
 
 ### Community 1072 - "Community 1072"
-Cohesion: 0.17
-Nodes (12): 2026-01-29 21:30 - Starting Issue Analysis, 2026-01-29 22:00 - Phase 1: Remove variant banner from full-page modal, 2026-01-29 22:10 - Phase 2: Verify variant selector in full-page modal, 2026-01-29 22:15 - Phase 3: Implement footer products carousel, 2026-01-29 22:25 - Phase 4: Fix variant/quantity reset bug, 2026-01-29 22:30 - Phase 5: Fix promo banner and DCP connection, 2026-01-29 22:35 - Phase 6: Implement optional step products, 2026-01-29 22:40 - Phase 7: Center step tabs (+4 more)
+Cohesion: 0.06
+Nodes (30): 2026-01-29 21:30 - Starting Issue Analysis, 2026-01-29 22:00 - Phase 1: Remove variant banner from full-page modal, 2026-01-29 22:10 - Phase 2: Verify variant selector in full-page modal, 2026-01-29 22:15 - Phase 3: Implement footer products carousel, 2026-01-29 22:25 - Phase 4: Fix variant/quantity reset bug, 2026-01-29 22:30 - Phase 5: Fix promo banner and DCP connection, 2026-01-29 22:35 - Phase 6: Implement optional step products, 2026-01-29 22:40 - Phase 7: Center step tabs (+22 more)
 
 ### Community 1073 - "Community 1073"
 Cohesion: 0.10
@@ -8157,24 +8169,24 @@ Cohesion: 0.10
 Nodes (19): AddRemoveResult, BundleValidationResult, DiscountConfiguration, DiscountRule, DisplayPrice, Product, Step, ValidationResult (+11 more)
 
 ### Community 1075 - "Community 1075"
-Cohesion: 0.07
-Nodes (22): handler, inngest, fn, mockProcess, sampleData, webhookFunction, ShopifyWebhookEventData, ShopifyWebhookEvents (+14 more)
+Cohesion: 0.16
+Nodes (4): fn, mergeServerTimingHeaders(), ServerTiming, ServerTimingEntry
 
 ### Community 1076 - "Community 1076"
-Cohesion: 0.02
-Nodes (111): Bottom-Sheet Panel DCP CSS Targeting Fix, Connections, Bottom-Sheet Product Selection Modal, Connections, Change: Progress Bar Removed from Product-Page Widget, Connections, Community 5, Connections to other communities (+103 more)
+Cohesion: 0.06
+Nodes (27): Bottom-Sheet Panel DCP CSS Targeting Fix, Connections, Change: Progress Bar Removed from Product-Page Widget, Connections, Community 5, Connections to other communities, Live Query (requires Dataview plugin), Members (+19 more)
 
 ### Community 1077 - "Community 1077"
-Cohesion: 0.17
-Nodes (8): Add-to-Bundle Button Selected Color BR, Connections, Add-to-Bundle Button Selected Color PO Requirements, Connections, Connections, Design Control Panel types.ts, Connections, Rationale: Option B (Sub-section + Separate Preview) Selected for Added Button State
+Cohesion: 0.08
+Nodes (18): Connections, Feature: PromoBannerSettings (DCP CSS Variables), Connections, File: bundle-widget-full-page.js (FPB Widget Source), Connections, Fix: Remove Duplicate Bundle Title Headers, Connections, Fix: Undefined Discount Message (getNextDiscountRule nested structure) (+10 more)
 
 ### Community 1078 - "Community 1078"
 Cohesion: 0.07
 Nodes (29): 1. Create Test File, 1. Metafield Namespace Mismatch, 2. Add to Test Runner, 2. Invalid Product ID Format, 3. Add npm Script, 3. Discount Calculation Error, 4. Bundle Structure Validation, Adding New Tests (+21 more)
 
 ### Community 1079 - "Community 1079"
-Cohesion: 0.05
-Nodes (44): api.storefront-products Route, _bundle_components Cart Line Attribute, Fix _bundle_components JSON Exceeding Shopify Attribute Limit, bundle-product-page.liquid Block, calculateDiscountPercentage (Cart Transform Pricing), EXPAND Path calculateDiscountPercentage Arg Mismatch Bug, Cart Transform InstructionCountLimitExceededError, cart-transform-logger.ts (+36 more)
+Cohesion: 0.10
+Nodes (24): Application Architecture Document, BillingService (app/services/billing.server.ts), Shop-Level Bundle Index Metafield, BundleIsolationService, BundleProductManagerService, Concept: Cart Transform Extension, CartTransformService, Discount Methods: percentage_off, fixed_amount_off, fixed_bundle_price (+16 more)
 
 ### Community 1080 - "Community 1080"
 Cohesion: 0.18
@@ -8183,6 +8195,10 @@ Nodes (8): App Proxy 504 / Render Cold-Start Issue, Connections, cached-session-
 ### Community 1081 - "Community 1081"
 Cohesion: 0.17
 Nodes (12): Advanced Customization, Bundle Footer, Button Customization, Design Control Panel (DCP), Design Customization, Global Settings, Live Preview, Product Card Customization (+4 more)
+
+### Community 1082 - "Community 1082"
+Cohesion: 0.14
+Nodes (22): applyStandardExpandedVariantTitle(), attachProductCardListeners(), attachProductEventHandlers(), _createMobileSummaryActionButton(), createProductCard(), getFullPageDesignPreset(), getNoProductsAvailableMessage(), getProductAddButtonText() (+14 more)
 
 ### Community 1083 - "Community 1083"
 Cohesion: 0.40
@@ -8205,8 +8221,8 @@ Cohesion: 0.40
 Nodes (4): Checkout UI Extension, Prerequisites, Useful Links, Your new Extension
 
 ### Community 1088 - "Community 1088"
-Cohesion: 0.18
-Nodes (8): Billing / Subscription Service, Connections, Connections, DCP Paywall Enforcement and Owner Grant API, Connections, Enable Subscription UI and Fix Layout, Connections, Plan Gating / Paywall Middleware
+Cohesion: 0.10
+Nodes (14): 6 Global Color Anchors (globalPrimaryButton, globalButtonText, etc.), Connections, Connections, generateCSSFromSettings() CSS Generator Function, Connections, GET /api/design-settings/{shopDomain} CSS Endpoint, Connections, syncThemeColors() Service (theme-colors.server.ts) (+6 more)
 
 ### Community 1089 - "Community 1089"
 Cohesion: 0.40
@@ -8230,7 +8246,7 @@ Nodes (5): conditionOperator2 DB Column (Step model), conditionValue2 DB Column 
 
 ### Community 1095 - "Community 1095"
 Cohesion: 0.14
-Nodes (3): BundleProductModal, createModal(), BundleModalVariantMethods
+Nodes (5): BundleProductModal, createClassList(), createModal(), createModalForPopulate(), BundleModalVariantMethods
 
 ### Community 1096 - "Community 1096"
 Cohesion: 0.25
@@ -8240,9 +8256,13 @@ Nodes (15): ComponentParent, CartOperation, HashSet, Input, Option, String, Vec,
 Cohesion: 0.20
 Nodes (4): args, TestResult, TestRunner, TestSummary
 
+### Community 1098 - "Community 1098"
+Cohesion: 0.13
+Nodes (10): Connections, Locked Step Tooltip UX Component, Connections, Mobile-First Widget UI Improvements Issue, Connections, ToastManager.showWithUndo — Undo Toast on Product Removal, Connections, WCAG 44px Touch Target Compliance for Widget Buttons (+2 more)
+
 ### Community 1099 - "Community 1099"
-Cohesion: 0.18
-Nodes (8): Bundle.active Column (Redundant), Connections, Connections, Database Column Removal Analysis, Connections, Ready to Remove Columns Summary, Connections, Session User Fields (email, accountOwner, collaborator)
+Cohesion: 0.10
+Nodes (14): cart-transform-run.test.ts, Connections, cart-transform-service.test.ts, Connections, Cart Transform Test Environment Variables, Connections, Connections, Prisma Client Mock (test setup) (+6 more)
 
 ### Community 1100 - "Community 1100"
 Cohesion: 0.25
@@ -8295,8 +8315,8 @@ Cohesion: 0.07
 Nodes (28): **1. `discount-validation-test.js`**, **1. Enhanced Discount Calculation Logging**, **2. Fixed Qualification Validation**, **2. `percentage-off-amount-debug.js`**, **3. Improved Condition Data Calculation**, **3. `live-debug-test.js`**, **4. Enhanced Variable Creation**, **5. Comprehensive Cart Data Validation** (+20 more)
 
 ### Community 1116 - "Community 1116"
-Cohesion: 0.02
-Nodes (82): 1. Bundle.liquid (Product Page Widget), 2. Bundle-full-page.liquid, 3. Files Created, 4. Files Removed, 5. Files Remaining, Benefits, Bundling Process, Changes Made (+74 more)
+Cohesion: 0.03
+Nodes (72): api.storefront-products Route, _bundle_components Cart Line Attribute, Fix _bundle_components JSON Exceeding Shopify Attribute Limit, Source: bundle-data-manager.js (Shared Widget Module), bundle-widget-full-page.js Widget Source, calculateDiscountPercentage (Cart Transform Pricing), EXPAND Path calculateDiscountPercentage Arg Mismatch Bug, Cart Transform InstructionCountLimitExceededError (+64 more)
 
 ### Community 1117 - "Community 1117"
 Cohesion: 0.11
@@ -8308,7 +8328,7 @@ Nodes (6): buildPersonalizationData(), buildPersonalizationDataWithZeroThreshold
 
 ### Community 1119 - "Community 1119"
 Cohesion: 0.27
-Nodes (6): makeDiscountData(), makeFormData(), makeStep(), makeStepWithProduct(), MOCK_ADMIN, MOCK_SESSION
+Nodes (17): asArray(), asRecord(), compactCategories(), compactCategory(), compactCollection(), compactCollections(), compactImage(), compactImages() (+9 more)
 
 ### Community 1120 - "Community 1120"
 Cohesion: 0.17
@@ -9139,8 +9159,8 @@ Cohesion: 0.07
 Nodes (41): CartLinesDiscountsGenerateRunResult, FunctionRunResult, Option, String, Decimal, Input, Option, Result (+33 more)
 
 ### Community 1327 - "Community 1327"
-Cohesion: 0.27
-Nodes (4): BundleAnalyticsService, BundlePerformanceMetrics, BundleStats, ShopAnalyticsSummary
+Cohesion: 0.06
+Nodes (44): action(), BillingPage(), FAQSection(), FAQSectionProps, FeatureComparisonTable(), FeatureComparisonTableProps, FreePlanCard(), FreePlanCardProps (+36 more)
 
 ### Community 1328 - "Community 1328"
 Cohesion: 0.50
@@ -9339,8 +9359,8 @@ Cohesion: 0.33
 Nodes (3): Community 1209, Live Query (requires Dataview plugin), Members
 
 ### Community 1377 - "Community 1377"
-Cohesion: 0.06
-Nodes (26): applyPersonalizationAddonProducts(), attachEventListeners(), buildAddonStepFromPersonalization(), BundleProductModal, BundleWidgetFullPage, ComponentGenerator, createVariantSelectors(), hidePageLoadingContent() (+18 more)
+Cohesion: 0.14
+Nodes (6): attachEventListeners(), BundleProductModal, BundleWidgetFullPage, createVariantSelectors(), getSelectedQuantity(), resetVariantSelectionState()
 
 ### Community 1378 - "Community 1378"
 Cohesion: 0.33
@@ -9428,7 +9448,7 @@ Nodes (3): Community 1229, Live Query (requires Dataview plugin), Members
 
 ### Community 1399 - "Community 1399"
 Cohesion: 0.05
-Nodes (36): Concept: Bundle API Endpoint (/api/bundle/{id}.json), Bundle Config Metafield Cache (data-bundle-config), FPB Two-Stage Config Load Strategy, Concept: Render Server Cold Start, Concept: Shopify App Proxy (30s timeout), Concept: TemplateManager (Widget Module), 2026-03-17 12:00 - Planning Complete, Files to Modify (+28 more)
+Nodes (37): api.design-settings.$shopDomain.tsx Route, Concept: Bundle API Endpoint (/api/bundle/{id}.json), Bundle Config Metafield Cache (data-bundle-config), FPB Two-Stage Config Load Strategy, Concept: Render Server Cold Start, Concept: Shopify App Proxy (30s timeout), Concept: TemplateManager (Widget Module), 2026-03-17 12:00 - Planning Complete (+29 more)
 
 ### Community 1400 - "Community 1400"
 Cohesion: 0.33
@@ -10467,8 +10487,8 @@ Cohesion: 0.33
 Nodes (3): Community 1465, Live Query (requires Dataview plugin), Members
 
 ### Community 1659 - "Community 1659"
-Cohesion: 0.22
-Nodes (8): Concept: FPB Default Step (isDefault, defaultVariantId), 2026-04-09 16:30 - Phase 1 Completed, 2026-04-09 17:00 - All Phases Completed, Issue: FPB Default Product Selection — Grid, Footer & Tab UX, Overview, Phases Checklist, Progress Log, Root Cause (confirmed via Chrome DevTools)
+Cohesion: 0.03
+Nodes (64): Add-to-Bundle Button Selected-State Colour DCP Control, bundle-widget-full-page.css, Concept: FPB Default Step (isDefault, defaultVariantId), Concept: Sidebar Layout (footer_side), CurrencyManager.convertAndFormat (Multi-Currency Helper), css-variables-generator.ts (CSS Variable Generator), DCP Audit Medium Priority Fixes, DCP CSS Variable Generation Pipeline (+56 more)
 
 ### Community 1660 - "Community 1660"
 Cohesion: 0.06
@@ -10511,8 +10531,8 @@ Cohesion: 0.33
 Nodes (3): Community 1475, Live Query (requires Dataview plugin), Members
 
 ### Community 1670 - "Community 1670"
-Cohesion: 0.02
-Nodes (73): app.upload-store-file.tsx Action Route, Connections, bundle-product-page.liquid Block, Connections, Cache-Busting for Widget API + Page Layout UI Fix, Connections, Community 17, Connections to other communities (+65 more)
+Cohesion: 0.03
+Nodes (63): app.upload-store-file.tsx Action Route, Connections, Cache-Busting for Widget API + Page Layout UI Fix, Connections, Community 17, Connections to other communities, Live Query (requires Dataview plugin), Members (+55 more)
 
 ### Community 1671 - "Community 1671"
 Cohesion: 0.33
@@ -10523,8 +10543,8 @@ Cohesion: 0.33
 Nodes (3): Community 1478, Live Query (requires Dataview plugin), Members
 
 ### Community 1673 - "Community 1673"
-Cohesion: 0.33
-Nodes (5): Bundle Instance Tracking, MERGE Deduplication, Problem, Solution: EB `_wolfpackProductBundle:OfferId`, Why It Works
+Cohesion: 0.12
+Nodes (17): Checkout Extension Legacy Object Format Removal, Concept: Shopify urlRedirectCreate Mutation, Discount Messaging Templates Not Applied at Storefront Issue, Handler: full-page-bundle configure handlers.server.ts, FPB Preview URL Fix — shareablePreviewUrl Removed Issue, handleSyncBundle — Conditional Page Delete Guard Fix, 2026-03-31 03:00 - Implemented, Fix (+9 more)
 
 ### Community 1674 - "Community 1674"
 Cohesion: 0.33
@@ -10543,8 +10563,8 @@ Cohesion: 0.33
 Nodes (3): Community 1482, Live Query (requires Dataview plugin), Members
 
 ### Community 1678 - "Community 1678"
-Cohesion: 0.25
-Nodes (6): Admin Performance Optimization Report, Connections, Connections, Dashboard Route (app.dashboard.tsx), Connections, N+1 Query Issue in Bundle Cloning
+Cohesion: 0.11
+Nodes (12): API Route: api.bundle.$bundleId.json.tsx, Connections, Connections, Issue: Admin UI Tier Configuration for Full-Page Bundle Widget, Connections, Lib: tier-config-validator.server.ts, Connections, Pricing Tiers UI Fixes + Theme Editor Cleanup (+4 more)
 
 ### Community 1679 - "Community 1679"
 Cohesion: 0.33
@@ -10701,6 +10721,10 @@ Nodes (3): Community 1518, Live Query (requires Dataview plugin), Members
 ### Community 1717 - "Community 1717"
 Cohesion: 0.50
 Nodes (3): Community 1519, Live Query (requires Dataview plugin), Members
+
+### Community 1718 - "Community 1718"
+Cohesion: 0.13
+Nodes (5): currencyInfo, { PricingCalculator }, { TemplateManager }, { TemplateManager }, TemplateManager
 
 ### Community 1719 - "Community 1719"
 Cohesion: 0.33
@@ -12015,16 +12039,16 @@ Cohesion: 0.33
 Nodes (3): Community 310, Live Query (requires Dataview plugin), Members
 
 ### Community 2048 - "Community 2048"
-Cohesion: 0.20
-Nodes (6): App State Hooks, Live Query (requires Dataview plugin), Members, Community 311, Live Query (requires Dataview plugin), Members
+Cohesion: 0.33
+Nodes (3): Community 311, Live Query (requires Dataview plugin), Members
 
 ### Community 2049 - "Community 2049"
 Cohesion: 0.33
 Nodes (5): Acceptance Criteria, Purpose, SummaryHeaderText, Test Cases, Test Spec: FPB Summary Bundle Name Header
 
 ### Community 2050 - "Community 2050"
-Cohesion: 0.33
-Nodes (3): Community 313, Live Query (requires Dataview plugin), Members
+Cohesion: 0.20
+Nodes (6): App State Hooks, Live Query (requires Dataview plugin), Members, Community 313, Live Query (requires Dataview plugin), Members
 
 ### Community 2051 - "Community 2051"
 Cohesion: 0.33
@@ -13423,11 +13447,11 @@ Cohesion: 0.20
 Nodes (7): Community 63, Live Query (requires Dataview plugin), Members, Connections, Issue: Block Navigation Back to Landing Page for Authenticated Users, Connections, Route: root/_index/route.tsx
 
 ### Community 2400 - "Community 2400"
-Cohesion: 0.33
+Cohesion: 0.50
 Nodes (3): Community 630, Live Query (requires Dataview plugin), Members
 
 ### Community 2401 - "Community 2401"
-Cohesion: 0.50
+Cohesion: 0.33
 Nodes (3): Community 631, Live Query (requires Dataview plugin), Members
 
 ### Community 2402 - "Community 2402"
@@ -13519,8 +13543,8 @@ Cohesion: 0.67
 Nodes (3): **File Modified**, **Structure**, What Was Updated
 
 ### Community 2424 - "Community 2424"
-Cohesion: 0.05
-Nodes (41): 0. EB's Complete Bundle Editor — Section Map, 10. Select Template — Bundle Layout Themes, 11. Cart Transform Implications (Refined), 13. Wolfpack-Specific Differentiators (Updated), 14. Screenshots Index, 15. Summary, 3. Bundle Visibility Page (Full Detail), 4. Bundle Widget — Product Page Upsell (+33 more)
+Cohesion: 0.18
+Nodes (11): 8. Bundle Settings — Full Data, Bundle Banner, Bundle Cart, Bundle Level CSS, Bundle Status, Enable Quantity Validation, Pre-order & Subscription Integration, Pre Selected Product (+3 more)
 
 ### Community 2425 - "Community 2425"
 Cohesion: 0.50
@@ -13919,8 +13943,8 @@ Cohesion: 0.33
 Nodes (3): Community 742, Live Query (requires Dataview plugin), Members
 
 ### Community 2524 - "Community 2524"
-Cohesion: 0.33
-Nodes (3): Community 743, Live Query (requires Dataview plugin), Members
+Cohesion: 0.20
+Nodes (6): Bundle Configuration Handlers, Live Query (requires Dataview plugin), Members, Community 743, Live Query (requires Dataview plugin), Members
 
 ### Community 2525 - "Community 2525"
 Cohesion: 0.33
@@ -14003,8 +14027,8 @@ Cohesion: 0.33
 Nodes (3): Community 761, Live Query (requires Dataview plugin), Members
 
 ### Community 2545 - "Community 2545"
-Cohesion: 0.20
-Nodes (6): Bundle Configuration Handlers, Live Query (requires Dataview plugin), Members, Community 762, Live Query (requires Dataview plugin), Members
+Cohesion: 0.33
+Nodes (3): Community 762, Live Query (requires Dataview plugin), Members
 
 ### Community 2546 - "Community 2546"
 Cohesion: 0.33
@@ -14231,8 +14255,8 @@ Cohesion: 0.33
 Nodes (3): Community 813, Live Query (requires Dataview plugin), Members
 
 ### Community 2602 - "Community 2602"
-Cohesion: 0.08
-Nodes (36): action(), CORS_HEADERS, loader(), sanitizeBundleType(), CHECKOUT_INTEGRATION_PROVIDER_IDS, CHECKOUT_INTEGRATION_PROVIDER_LABELS, CHECKOUT_INTEGRATION_PROVIDER_OPTIONS, CHECKOUT_INTEGRATION_PROVIDERS (+28 more)
+Cohesion: 0.22
+Nodes (13): CHECKOUT_INTEGRATION_PROVIDER_IDS, CHECKOUT_INTEGRATION_PROVIDER_LABELS, CHECKOUT_INTEGRATION_PROVIDER_OPTIONS, CHECKOUT_INTEGRATION_PROVIDERS, CheckoutIntegrationCallbackMode, CheckoutIntegrationProvider, CheckoutIntegrationProviderId, getCheckoutIntegrationProvider() (+5 more)
 
 ### Community 2603 - "Community 2603"
 Cohesion: 0.50
@@ -15055,8 +15079,8 @@ Cohesion: 0.33
 Nodes (5): Acceptance Criteria, DashboardActionMenuState, Purpose, Test Cases, Test Spec: Dashboard Action Menu Deferral
 
 ### Community 2809 - "Community 2809"
-Cohesion: 0.25
-Nodes (6): Bundle Prisma Model, Connections, Connections, Full-Page Bundle Preview Fix, Connections, shopifyPageHandle & shopifyPageId DB Fields
+Cohesion: 0.12
+Nodes (12): Bottom-Sheet Product Selection Modal, Connections, Connections, CSS: Bottom-Sheet Classes (.bw-bs-overlay, .bw-bs-panel, .bw-slot-card), Connections, File: bundle-widget-product-page.js (PDP Widget Source), Connections, Fix: createFreeGiftSlotCard() Branch on widgetStyle for Classic Mode (+4 more)
 
 ### Community 2810 - "Community 2810"
 Cohesion: 0.33
@@ -15075,8 +15099,8 @@ Cohesion: 0.33
 Nodes (3): Live Query (requires Dataview plugin), Members, Pricing Types & Utilities
 
 ### Community 2814 - "Community 2814"
-Cohesion: 0.22
-Nodes (6): Concept: TemplateManager (Widget Module), Connections, Connections, Issue: Full-Page Footer Discount Message Uses Templates, Connections, Issue: Full-Page Footer Discount Messaging Not Using Merchant Templates
+Cohesion: 0.13
+Nodes (17): _buildLimitText(), calculateStepTotalAfterUpdate(), canUpdateQuantity(), _collectCategoryProductIds(), _evaluateCanUpdate(), evaluateCategoryRules(), _evaluateSatisfied(), _getSelectionAmount() (+9 more)
 
 ### Community 2815 - "Community 2815"
 Cohesion: 0.18
@@ -15095,8 +15119,8 @@ Cohesion: 0.33
 Nodes (3): Live Query (requires Dataview plugin), Members, Widget Build Pipeline
 
 ### Community 2819 - "Community 2819"
-Cohesion: 0.01
-Nodes (113): Bundle.fullPageLayout Prisma Field, Connections, Bundle.shopifyPreviewPageId/Handle Fields, Connections, _bundle_step_type Cart Line Attribute, Connections, BundleStep.isFreeGift/freeGiftName/isDefault/defaultVariantId Fields, Connections (+105 more)
+Cohesion: 0.02
+Nodes (96): Bundle.fullPageLayout Prisma Field, Connections, Bundle JSON API Endpoint (/api/bundle/:id.json), Connections, Bundle.showStepTimeline Nullable Boolean Field, Connections, _bundle_step_type Cart Line Attribute, Connections (+88 more)
 
 ### Community 2820 - "Community 2820"
 Cohesion: 0.50
@@ -15175,16 +15199,16 @@ Cohesion: 0.22
 Nodes (8): Acceptance Criteria, CartTransformPricing, FPBCheckoutLineProperties, MetafieldSync, Purpose, TemplateManager, Test Cases, Test Spec: FPB Storefront Discount Messaging
 
 ### Community 2841 - "Community 2841"
-Cohesion: 0.31
-Nodes (7): ConditionValidator, { createState, addItem, removeItem, clearStep }, addItem(), clearStep(), createState(), _findStep(), removeItem()
+Cohesion: 0.13
+Nodes (10): Beco-Style Pricing Tier Selection for FPB Widget, Connections, Connections, data-tier-config Attribute, Connections, initTierPills(), Connections, parseTierConfig() (+2 more)
 
 ### Community 2842 - "Community 2842"
 Cohesion: 0.22
 Nodes (6): Connections, DCP Storefront Iframe Preview — PDP Preview URL, Connections, Design Control Panel Route (app/routes/app/app.design-control-panel/route.tsx), Connections, PDP Preview URL Construction (product-page-bundle view)
 
 ### Community 2843 - "Community 2843"
-Cohesion: 0.18
-Nodes (11): Admin Controls, Admin Location, Complete Runtime Shape, Field Location in Runtime Data, Full `mixAndMatchBundleSettings` Schema, Gap 6 Resolution — `useSingleStepCategoriesAsBundleSteps` Admin Location and Storefront Effect ✅ RESOLVED, Gap 8 Resolution — `bundleTextConfig` Full Admin Shape ✅ RESOLVED, Note on FPB "Messages" Section (+3 more)
+Cohesion: 0.11
+Nodes (19): Admin Controls, Admin Controls (Two Separate Toggles), Admin Location, ATC Button DOM State, ATC Button Enforcement Logic (decompiled source), Box Tier Selector DOM Structure, Complete Runtime Shape, Field Location in Runtime Data (+11 more)
 
 ### Community 2844 - "Community 2844"
 Cohesion: 0.18
@@ -15218,13 +15242,21 @@ Nodes (10): 10. `$app:price_adjustment` (Legacy), 7. `$app:component_reference` 
 Cohesion: 0.20
 Nodes (9): After (Recommended), Appendix A: Metafield Comparison, Before (Current), Critical Decision Point, Decision Matrix, Executive Summary, Key Findings, Shopify Bundle Standards & Alignment Recommendations (+1 more)
 
+### Community 2852 - "Community 2852"
+Cohesion: 0.22
+Nodes (6): checkFullPageBundleInstallation() Method, Connections, Connections, Full-Page Widget Detection Fix, Connections, Page Template Detection (templates/page*.json)
+
 ### Community 2853 - "Community 2853"
 Cohesion: 0.18
 Nodes (10): compilerOptions, allowJs, checkJs, esModuleInterop, jsx, jsxImportSource, moduleResolution, skipLibCheck (+2 more)
 
+### Community 2854 - "Community 2854"
+Cohesion: 0.03
+Nodes (57): Connections, bundle-product-page.liquid Block, Connections, bundle-widget.css / bundle-widget-full-page.css, Connections, bundle-widget-product-page.js, Connections, BundleProductModal — Variant Selection UI Component (+49 more)
+
 ### Community 2855 - "Community 2855"
-Cohesion: 0.50
-Nodes (7): CartLineMessagingSettings, FunctionRunResult, Input, Result, result, cart_transform_run(), run()
+Cohesion: 0.26
+Nodes (14): buildSettingsControlsResponse(), buildSettingsControlsRuntime(), BundleCartLineMessagingRuntime, checked(), ControlsPayload, ControlsRedirectAction, getDiscountFormat(), getLandingCheckoutAction() (+6 more)
 
 ### Community 2856 - "Community 2856"
 Cohesion: 0.33
@@ -15375,8 +15407,8 @@ Cohesion: 0.33
 Nodes (5): Acceptance Criteria, CartTransformListRouteRemoval, Purpose, Test Cases, Test Spec: Cart Transform List Route Removal
 
 ### Community 2895 - "Community 2895"
-Cohesion: 0.02
-Nodes (97): 6 Global Color Anchors (globalPrimaryButton, globalButtonText, etc.), Connections, Bug: Pub/Sub Topic Name Mismatch (wolfpack-only-bundles vs wolfpack-product-bundles), Connections, Bundle Prisma Model, Connections, BundleAnalytics Preservation During Sync, Connections (+89 more)
+Cohesion: 0.04
+Nodes (41): Bundle Prisma Model, Connections, BundleAnalytics Preservation During Sync, Connections, Community 8, Connections to other communities, Live Query (requires Dataview plugin), Members (+33 more)
 
 ### Community 2896 - "Community 2896"
 Cohesion: 0.22
@@ -15403,8 +15435,8 @@ Cohesion: 0.29
 Nodes (6): Acceptance Criteria, AdminDataContract, Purpose, StorefrontRuntime, Test Cases, Test Spec: FPB Free Gift Add Ons Parity
 
 ### Community 2902 - "Community 2902"
-Cohesion: 0.54
-Nodes (7): Option, PriceAdjustmentConfig, calculate_buy_x_get_y_discount_percentage(), condition_is_met(), condition_threshold(), resolve_applicable_price_adjustment(), rounded_percentage()
+Cohesion: 0.13
+Nodes (10): Bundle Checkout UI Extension, Connections, Connections, Fix All Issues in bundle-checkout-ui Extension, Connections, Shopify Checkout UI API Version 2026-01 Migration, Connections, shopify.extension.toml (Checkout UI Extension Config) (+2 more)
 
 ### Community 2903 - "Community 2903"
 Cohesion: 0.33
@@ -15416,11 +15448,11 @@ Nodes (6): Connections, FPB Sidebar Step Tabs Position + Tier Pills Not Showing 
 
 ### Community 2905 - "Community 2905"
 Cohesion: 0.01
-Nodes (151): api.store-files.tsx Resource Route, Connections, Beco BYOB Design Alignment — FPB Widget, Connections, --bundle-drawer-bg CSS Variable, Connections, --bundle-promo-banner-bg-image CSS Variable, Connections (+143 more)
+Nodes (136): api.store-files.tsx Resource Route, Connections, Beco BYOB Design Alignment — FPB Widget, Connections, --bundle-drawer-bg CSS Variable, Connections, bundle-modal-component.js, Connections (+128 more)
 
 ### Community 2906 - "Community 2906"
-Cohesion: 0.29
-Nodes (6): Bundle Variant Price, `calculateDiscountPercentage`, Discount Methods, Notes, Pricing Pipeline, Unit Conversion Chain
+Cohesion: 0.13
+Nodes (10): Connections, _createBecoBar() — Compact Sticky Bar, Connections, _createBecoPanel() — Expanding Product List Panel, Connections, FPB Footer Expandable Tests, Connections, Issue: Beco BYOB Expandable Floating Footer (+2 more)
 
 ### Community 2907 - "Community 2907"
 Cohesion: 0.33
@@ -15439,44 +15471,48 @@ Cohesion: 0.29
 Nodes (6): Acceptance Criteria, CategoryRuntime, FullPageProductProcessing, Purpose, Test Cases, Test Spec: FPB Variant Option Normalization
 
 ### Community 2911 - "Community 2911"
-Cohesion: 0.43
-Nodes (6): CartLineDiscountDisplaySettings, Default, Self, CartLineDiscountDisplaySettings, CartLineMessagingSettings, default_amount_percentage()
+Cohesion: 0.13
+Nodes (10): Connections, bundle-widget-full-page-bundled.js, Connections, bundle-widget-product-page-bundled.js, Connections, Dynamic Script Injection Pattern, Connections, Shopify 10KB Theme Extension Asset Limit (+2 more)
 
 ### Community 2912 - "Community 2912"
-Cohesion: 0.04
-Nodes (37): Admin Tier Config Architecture Decision Record, Connections, Admin Tier Config BR, Connections, Admin Tier Config PO Requirements, Connections, Admin Tier Config SDE Implementation Plan, Connections (+29 more)
+Cohesion: 0.03
+Nodes (51): Add-to-Bundle Button Selected Color Architecture, Connections, Add-to-Bundle Button Selected Color SDE Plan, Connections, Admin Tier Config BR, Connections, Admin Tier Config PO Requirements, Connections (+43 more)
 
 ### Community 2913 - "Community 2913"
 Cohesion: 0.33
 Nodes (5): Acceptance Criteria, FullPageCategoryValidation, Purpose, Test Cases, Test Spec: FPB Category Collection Rule Validation
 
 ### Community 2914 - "Community 2914"
-Cohesion: 0.25
-Nodes (8): Layer 1: Storefront bootstrap, Layer 2: Normalized bundle config, Layer 3: Context adapters, Layer 4: Renderer registry, Layer 5: Feature modules, Layer 6: Design template system, Principle, Recommended Wolfpack Target Architecture
+Cohesion: 0.14
+Nodes (13): Issue: DCP Storefront Iframe Preview — Extension Templates, Issue: FPB templateSuffix Not Attached + Block UUID Discovery Fix, 2026-03-20 00:30 - Starting fix, 2026-03-20 00:45 - Completed, Issue: PDP Widget — Theme Template Write Fails with 404, Overview, Phases Checklist, Progress Log (+5 more)
 
 ### Community 2915 - "Community 2915"
-Cohesion: 0.07
-Nodes (32): 64-Test Suite (metafields, cart transform, bundle config, product IDs), Connections, Architecture #1: Per-Product Metafields (Recommended), Connections, Architecture #2: Optimized Shop Metafield, Connections, Architecture #3: Hybrid Per-Product + Shop Index, Connections (+24 more)
+Cohesion: 0.05
+Nodes (42): 64-Test Suite (metafields, cart transform, bundle config, product IDs), Connections, Architecture #1: Per-Product Metafields (Recommended), Connections, Architecture #2: Optimized Shop Metafield, Connections, Architecture #3: Hybrid Per-Product + Shop Index, Connections (+34 more)
 
 ### Community 2916 - "Community 2916"
 Cohesion: 0.40
 Nodes (5): 1. Bundle Management System, 2. Bundle Widget (Storefront), 3. Design Control Panel (DCP), 4. Cart Transform Function, Core Components
 
 ### Community 2917 - "Community 2917"
-Cohesion: 0.33
-Nodes (3): { getDisplayPrice }, { PricingCalculator }, getDisplayPrice()
+Cohesion: 0.15
+Nodes (13): 2026-02-16 14:00 - Starting Implementation, 2026-02-16 14:30 - Initial Fixes (Later Revised), 2026-02-16 15:00 - Consolidated on Pub/Sub + Cleanup, Files Summary, Fix Strategy, Issue: Webhook Server Consolidation & Fixes, Overview, Phases Checklist (+5 more)
 
 ### Community 2918 - "Community 2918"
 Cohesion: 0.33
 Nodes (6): Field Standardization Complete - Zero Legacy Fallbacks, Standardized Pricing Rule Fields (value, condition, discountValue, fixedBundlePrice), Final Verification - Build & Tests Passing, Pricing Configuration Structure (percentage_off, fixed_amount_off, fixed_bundle_price), Pricing Display Fix - Cents Multiplication Bug (Jan 2025), Verification Report - Fixed Bundle Price Implementation (2025-01-07)
 
 ### Community 2919 - "Community 2919"
-Cohesion: 0.25
-Nodes (8): Admin Controls (Two Separate Toggles), ATC Button DOM State, ATC Button Enforcement Logic (decompiled source), Box Tier Selector DOM Structure, Gap 2 Resolution — FPB Box Selection Enforcement Logic ✅ RESOLVED, `gbbBoxSelection.f` Function Inventory, `gbbBoxSelection.state` Full Runtime Schema, `overWriteDiscountMessagingBasedOnBoxSelection` Logic
+Cohesion: 0.18
+Nodes (8): Checkout UI Extension Targets, Connections, Checkout UI Thank-You Page Target Fix Issue, Connections, Concept: Shopify urlRedirectCreate Mutation, Connections, Connections, Issue: Full-Page Bundle Product Page Redirect
 
 ### Community 2920 - "Community 2920"
-Cohesion: 0.25
-Nodes (7): 2026-01-25 20:30 - Starting Changes, 2026-01-25 20:32 - Completed Changes, Issue: Update Product Grid Footer, Overview, Phases Checklist, Progress Log, Related Documentation
+Cohesion: 0.20
+Nodes (12): collectCategoryProducts(), collectStepCollectionHandles(), collectStepProductIds(), enrichMissingProductDescriptions(), loadStepProducts(), mergeCategoryProductVariantAvailability(), _mergeDirectDefaultProductsIntoStep(), openModal() (+4 more)
+
+### Community 2921 - "Community 2921"
+Cohesion: 0.17
+Nodes (8): bundle-cart-transform-ts Extension (cart_transform_run.ts), Connections, Cart Transform safeParseFloat + NaN Clamp Fix, Connections, Checkout UI NaN Guards (safeInt, safeFloat, formatMoney), Connections, Connections, NaN Propagation Safety in Cart Transform & Checkout UI
 
 ### Community 2922 - "Community 2922"
 Cohesion: 0.14
@@ -15526,17 +15562,21 @@ Nodes (5): Acceptance Criteria, FullPageWidgetHeader, Purpose, Test Cases, Test 
 Cohesion: 0.18
 Nodes (10): Billing Cycles, Feature List (all plans), Key Observations, Partner / Affiliate Pricing, Per-Plan Differentiators (support tier, not features), Plan Tiers, Pricing, Pricing Model (+2 more)
 
+### Community 2934 - "Community 2934"
+Cohesion: 0.17
+Nodes (11): Concept: use_legacy_install_flow = false (TOML), 2026-02-28 22:00 - Starting Fix, 2026-02-28 22:15 - Initial Fix Attempt, 2026-02-28 22:30 - Fix Redirect Loop, Fix Plan, Issue: iFrame Session Management — Login Screen Flash During Navigation, Overview, Phases Checklist (+3 more)
+
 ### Community 2935 - "Community 2935"
 Cohesion: 0.04
-Nodes (48): Admin Form Discount Implementation, Connections, Amount vs Quantity Condition Discount Logic, Connections, Backend Fix: Map discountOn to conditionType in Cart Transform Config, Connections, Bundle Widget Fixes Summary, Connections (+40 more)
+Nodes (50): Admin Form Discount Implementation, Connections, Amount vs Quantity Condition Discount Logic, Connections, Backend Fix: Map discountOn to conditionType in Cart Transform Config, Connections, Bundle Widget Fixes Summary, Connections (+42 more)
 
 ### Community 2936 - "Community 2936"
-Cohesion: 0.05
-Nodes (61): BundleData, BundlePricing, LoaderData, SaveBundleResponse, BundleData, BundlePricing, SaveBundleResponse, createInitialPricingDisplayOptions() (+53 more)
+Cohesion: 0.23
+Nodes (15): BundleData, LoaderData, SaveBundleResponse, BundleData, SaveBundleResponse, statusOptions, BUNDLE_STATUS_OPTIONS, ActionResponse (+7 more)
 
 ### Community 2937 - "Community 2937"
-Cohesion: 0.29
-Nodes (7): FPB Cart Add Flow, FPB JS Runtime State (`window.gbb.state`), FPB vs PPB Cart Add Comparison, Phase 2 — Extended Storefront Evidence (2026-05-22 session 2), PPB Cart Add Flow, PPB JS Runtime State (`window.gbbMix.gbbMixAndMatchBundle.state`), `window.easybundles_ext_data` Full Shape
+Cohesion: 0.17
+Nodes (8): Connections, buildCartItems(), Connections, expandProductsByVariant(), Connections, PPB State Cards & Cart Bugs, Connections, renderProductPageLayout()
 
 ### Community 2938 - "Community 2938"
 Cohesion: 0.09
@@ -15551,8 +15591,8 @@ Cohesion: 0.33
 Nodes (4): FPB Footer Expandable Tests, Live Query (requires Dataview plugin), Members, FakeElement
 
 ### Community 2941 - "Community 2941"
-Cohesion: 0.38
-Nodes (5): decideEnablePreviewGate(), EnablePreviewGateDecision, EnablePreviewGateInput, shouldAutoShowOnMount(), UseEnablePreviewGateOptions
+Cohesion: 0.18
+Nodes (8): Concept: Webhook Worker (HTTP server on Render), Connections, Connections, Issue: Replace GCP Pub/Sub Worker with Direct HTTP Webhook Receiver, Connections, Service: webhooks/processor.server.ts, Connections, webhook-worker.server.ts Service
 
 ### Community 2942 - "Community 2942"
 Cohesion: 0.33
@@ -15567,24 +15607,24 @@ Cohesion: 0.50
 Nodes (3): "public"."Bundle", "public"."BundleStep", "public"."Subscription"
 
 ### Community 2945 - "Community 2945"
-Cohesion: 0.22
-Nodes (8): 2026-03-26 16:45 - Starting implementation, 2026-03-26 17:00 - Completed, Fix, Issue: FPB Floating Footer Trash Icon Intercepted by Backdrop, Overview, Phases Checklist, Progress Log, Root Cause
+Cohesion: 0.17
+Nodes (8): Connections, DCP Quantity Selector CSS Variable Fix Issue, Connections, .inline-quantity-controls CSS Variable Wiring, Connections, PDP Bottom-Sheet CSS Specificity Fixes (overlay, panel, footer), Connections, PDP Widget Full UI Audit & Consistency Fix Issue
 
 ### Community 2947 - "Community 2947"
 Cohesion: 0.33
 Nodes (5): Acceptance Criteria, BundleConfigureLoader, Purpose, Test Cases, Test Spec: App Embed Status
 
 ### Community 2948 - "Community 2948"
-Cohesion: 0.33
-Nodes (6): 1. Theme Extension Banner, What "Enable here" does, What it looks like, What it means for Wolfpack, What the Theme Editor shows, When it appears
+Cohesion: 0.17
+Nodes (8): Connections, Feature: Custom Polaris Delete Confirmation Modal (Dashboard), Connections, Fix: Replace window.open(_top) with window.open(_blank) to Preserve Session, Connections, Fix: Widget Modal Error (this.steps → this.selectedBundle.steps), Connections, Issue: Session Breaking on Navigation (session-navigation-fix-1)
 
 ### Community 2949 - "Community 2949"
 Cohesion: 0.33
 Nodes (4): { fullPageAnalyticsConfigMethods }, { fullPageTierFloatingRuntimeMethods }, fullPageAnalyticsConfigMethods, fullPageTierFloatingRuntimeMethods
 
 ### Community 2950 - "Community 2950"
-Cohesion: 0.40
-Nodes (5): Community 22, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+Cohesion: 0.17
+Nodes (8): Connections, i18n Discount Messaging — Business Requirement, Connections, i18n Discount Messaging — PO Requirements, Connections, i18n Discount Messaging — Shopify i18n Research, Connections, window.Shopify.locale — Storefront Locale Detection
 
 ### Community 2951 - "Community 2951"
 Cohesion: 0.29
@@ -15615,20 +15655,24 @@ Cohesion: 0.17
 Nodes (8): App Architecture Overview (Cart Transform, Bundle System, Metafields), Connections, Bundle Widget Cart Transform Integration (_wolfpack_bundle_id), Connections, Connections, Shopify Cart Transform (MERGE Operation), Connections, _wolfpack_bundle_id Cart Attribute
 
 ### Community 2958 - "Community 2958"
-Cohesion: 0.33
-Nodes (6): DOM Attributes That Initialize The Widget, Implementation-Facing Target Shape, Persisted In Wolfpack DB, Serialized To Storefront, Transport And Theme Extension Plan, Widget Runtime Derivations
+Cohesion: 0.18
+Nodes (8): Bundle Config Metafield Cache (data-bundle-config), Connections, Concept: Render Server Cold Start, Connections, Connections, FPB Two-Stage Config Load Strategy, Connections, Rationale: Metafield Cache Prevents Cold-Start Failures
 
 ### Community 2964 - "Community 2964"
 Cohesion: 0.40
 Nodes (4): Acceptance Criteria, Purpose, Test Cases, Test Spec: FPB Free Gift Add Ons Cart-Line Parity
 
 ### Community 2965 - "Community 2965"
-Cohesion: 0.47
-Nodes (4): BundleTemplateInput, FpbTemplateSelection, normalizeTemplateValue(), resolveFpbTemplateSelection()
+Cohesion: 0.17
+Nodes (8): Concept: use_legacy_install_flow = false (TOML), Connections, Connections, Issue: iFrame Session Management — Login Screen Flash During Navigation, Connections, Route: auth.login/route.tsx, Connections, Route: root/_index/route.tsx
 
 ### Community 2966 - "Community 2966"
 Cohesion: 0.40
 Nodes (5): Community 24, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+
+### Community 2967 - "Community 2967"
+Cohesion: 0.33
+Nodes (9): Inngest — Managed Durable Event Queue, Inngest Remix Serve Route (api.inngest.tsx), Inngest Webhook Queue — Architecture ADR, Inngest Webhook Queue — Business Requirement, Inngest Webhook Queue — PO Requirements, Inngest Webhook Queue — SDE Implementation Plan, PubSubMessage Adapter Interface, WebhookEvent DB Table — Idempotency Logic (+1 more)
 
 ### Community 2968 - "Community 2968"
 Cohesion: 0.33
@@ -15639,16 +15683,16 @@ Cohesion: 0.22
 Nodes (6): Architecture Comparison - Hybrid Approach (3 Standard + 1 UI Config) Recommended, Connections, Architecture Comparison - Pure API Approach, Connections, Architecture Comparison - Widget Reconstructs from Minimal Data, Connections
 
 ### Community 2971 - "Community 2971"
-Cohesion: 0.29
-Nodes (7): CASCADE (Product List) — base layout, no template-id overrides, COGNIVE (Product Grid), Consolidated Design Token Bridge, CSS Custom Properties — PPB `:root` Defaults, MODAL (Horizontal Slots) — base layout, no template-id overrides, Phase 7 — PPB Template CSS (Static Analysis), SIMPLIFIED (Vertical Slots)
+Cohesion: 0.22
+Nodes (6): Checkout Extension Legacy Object Format Removal, Connections, Connections, Legacy Backwards-Compatibility Code Removal (Round 2), Connections, Widget pricing.messages Legacy Fallback Path Removal
 
 ### Community 2972 - "Community 2972"
 Cohesion: 0.04
-Nodes (31): FakeStyleElement, { ProductPageDefaultProductMethods }, { ProductPageProductDataMethods }, { ProductPageSelectionDataMethods }, { shouldDisableProductPageVariantOption }, StorefrontProduct, StorefrontVariant, WidgetStep (+23 more)
+Nodes (37): FakeStyleElement, BundleWidgetProductPage, { ProductPageDefaultProductMethods }, { ProductPageProductDataMethods }, { ProductPageSelectionDataMethods }, { ProductPageSelectionMethods }, { shouldDisableProductPageVariantOption }, StorefrontProduct (+29 more)
 
 ### Community 2973 - "Community 2973"
-Cohesion: 0.17
-Nodes (16): addUnique(), asArray(), buildProductPageThemeEditorDeepLink(), extractSellingPlanValidationSources(), normalizeCollectionId(), normalizeProductId(), ProductPageSetupItem, ProductPageThemeEditorDeepLinkInput (+8 more)
+Cohesion: 0.04
+Nodes (95): Props, useConfigureModalController(), ADDON_TEMPLATE_VARIABLES, buildVisibilityDisplayConfiguration(), buildVisibilitySelectionIds(), bundleSetupItems, bundleVisibilityChildItems, compactVisibilityCollectionPageReference() (+87 more)
 
 ### Community 2974 - "Community 2974"
 Cohesion: 0.40
@@ -15659,8 +15703,8 @@ Cohesion: 0.13
 Nodes (10): Asset: bundle-widget-full.js, Connections, Connections, Pricing Configuration Structure (percentage_off, fixed_amount_off, fixed_bundle_price), Connections, Pricing Display Fix - Cents Multiplication Bug (Jan 2025), Connections, Standardized Pricing Rule Fields (value, condition, discountValue, fixedBundlePrice) (+2 more)
 
 ### Community 2976 - "Community 2976"
-Cohesion: 0.40
-Nodes (5): Community 9, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+Cohesion: 0.22
+Nodes (6): Component: BundleFooterPreview.tsx (DCP Footer Preview), Connections, Connections, Feature: PDP Slide-Up Animation + Auto-Close Modal, Connections, Issue: PDP Classic Modal Enhancements (pdp-classic-modal-enhancements-1)
 
 ### Community 2977 - "Community 2977"
 Cohesion: 0.33
@@ -15683,12 +15727,12 @@ Cohesion: 0.33
 Nodes (5): Acceptance Criteria, FullPageStepFooterMethods, Purpose, Test Cases, Test Spec: FPB Checkout Line Properties
 
 ### Community 2982 - "Community 2982"
-Cohesion: 0.09
-Nodes (34): addBundleToCart(), buildCategoryRuleValidationStep(), canNavigateToStep(), canProceedToNextStep(), _emitStorefrontEvent(), _ensureWpbSessionId(), _formatStepLimitToast(), generateBundleSessionKey() (+26 more)
+Cohesion: 0.08
+Nodes (36): addBundleToCart(), buildCategoryRuleValidationStep(), canNavigateToStep(), canProceedToNextStep(), _emitStorefrontEvent(), _ensureWpbSessionId(), _formatStepLimitToast(), generateBundleSessionKey() (+28 more)
 
 ### Community 2983 - "Community 2983"
-Cohesion: 0.33
-Nodes (3): Live Query (requires Dataview plugin), Members, Test Runner
+Cohesion: 0.17
+Nodes (8): Connections, Default Lottie Loading Animation - Business Requirement, Connections, Default Lottie Loading Animation Feature, Connections, Default Lottie Loading Animation - PO Requirements, Connections, Rationale: Embedded SVG+CSS Keyframes Over Bundling lottie-web
 
 ### Community 2984 - "Community 2984"
 Cohesion: 0.33
@@ -15703,8 +15747,8 @@ Cohesion: 0.33
 Nodes (5): Acceptance Criteria, FullPageWidgetCategoryHydration, Purpose, Test Cases, Test Spec: FPB Standard Category Variant Hydration
 
 ### Community 2989 - "Community 2989"
-Cohesion: 0.33
-Nodes (4): BundlePricing Prisma Model, Connections, Connections, Unused Database Columns Analysis
+Cohesion: 0.22
+Nodes (6): Connections, messaging Top-Level Metafield Key, Connections, pricing.messages Legacy Fallback Path, Connections, updateMessagesFromBundle Method
 
 ### Community 2990 - "Community 2990"
 Cohesion: 1.00
@@ -15731,8 +15775,8 @@ Cohesion: 0.33
 Nodes (6): 2. Admin API - metafieldsSet Mutation, ✅ COMPLIANT, References, Shopify Standard, Validation, What We're Doing
 
 ### Community 3009 - "Community 3009"
-Cohesion: 0.33
-Nodes (4): Connections, Free Gift Step in PDP Widget, Connections, PDP Bundle Widget Audit — Free Gift and Core Flow
+Cohesion: 0.43
+Nodes (6): CartLineDiscountDisplaySettings, Default, Self, CartLineDiscountDisplaySettings, CartLineMessagingSettings, default_amount_percentage()
 
 ### Community 3012 - "Community 3012"
 Cohesion: 0.17
@@ -15759,52 +15803,56 @@ Cohesion: 0.22
 Nodes (6): Connections, Metafield Optimization - Remove Duplicate Metafields (66% reduction), Connections, Route: app.bundles.cart-transform.configure.$bundleId.tsx, Connections, Single Source of Truth: $app:bundle_config
 
 ### Community 3051 - "Community 3051"
-Cohesion: 0.40
-Nodes (5): 2. Readiness Score System, Observed values, Scoring breakdown (inferred from what changed), What it implies for Wolfpack, What the panel shows
+Cohesion: 0.50
+Nodes (7): CartLineMessagingSettings, FunctionRunResult, Input, Result, result, cart_transform_run(), run()
 
 ### Community 3052 - "Community 3052"
 Cohesion: 0.33
 Nodes (6): 5. Cart Transform Function - Input Query, ✅ COMPLIANT, References, Shopify Standard, Validation, What We're Doing
 
 ### Community 3053 - "Community 3053"
-Cohesion: 0.40
-Nodes (5): CLASSIC Design, COMPACT Design, HORIZONTAL Design, Phase 6 — FPB Template CSS (Static Analysis), STANDARD Design — base `.gbbMinimilisticLayout`
+Cohesion: 0.54
+Nodes (7): Option, PriceAdjustmentConfig, calculate_buy_x_get_y_discount_percentage(), condition_is_met(), condition_threshold(), resolve_applicable_price_adjustment(), rounded_percentage()
 
 ### Community 3054 - "Community 3054"
 Cohesion: 0.40
 Nodes (5): Community 20, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
 
 ### Community 3055 - "Community 3055"
-Cohesion: 0.40
-Nodes (5): Collection Pagination Architecture, Footer Transitions, JS State Changes (Step 1 → Step 2), Multi-step Navigation DOM Architecture, Phase 3 — Multi-step Navigation and Collection Pagination
+Cohesion: 0.25
+Nodes (7): Acceptance Criteria, ProductModal, Purpose, StorefrontProductPayloads, Test Cases, Test Spec: Product Modal Description HTML, WidgetNormalization
 
 ### Community 3056 - "Community 3056"
-Cohesion: 0.05
-Nodes (37): BundleUiStep Type (metafield-sync), Connections, canUpdateQuantity() Function, Connections, Community 25, Connections to other communities, Live Query (requires Dataview plugin), Members (+29 more)
+Cohesion: 0.06
+Nodes (32): BundleUiStep Type (metafield-sync), Connections, canUpdateQuantity() Function, Connections, conditionOperator2 DB Column (Step model), Connections, ConditionValidator (Widget JS), Connections (+24 more)
 
 ### Community 3057 - "Community 3057"
-Cohesion: 0.40
-Nodes (5): `displayVariantsAsIndividualProducts` Field Placement, FPB Full Update Payload Shape, FPB Two-Level Template System, Phase 2 — Extended Configuration (2026-05-22 session 2), PPB `boxSelection` Shape
+Cohesion: 0.29
+Nodes (7): CASCADE (Product List) — base layout, no template-id overrides, COGNIVE (Product Grid), Consolidated Design Token Bridge, CSS Custom Properties — PPB `:root` Defaults, MODAL (Horizontal Slots) — base layout, no template-id overrides, Phase 7 — PPB Template CSS (Static Analysis), SIMPLIFIED (Vertical Slots)
 
 ### Community 3058 - "Community 3058"
 Cohesion: 0.40
 Nodes (5): Cart Transform & Admin Fixes, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
 
 ### Community 3059 - "Community 3059"
-Cohesion: 0.40
-Nodes (5): Community 0, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+Cohesion: 0.05
+Nodes (39): Images & GIFs Section Minimal Card Revamp, bundle-product-page.liquid Block, Cache-Busting for Widget API + Page Layout UI Fix, Codebase Simplification Refactor, Full-Page Bundle Sidebar Layout Not Rendering + Admin Illustration, FPB Configure Route (route.tsx), FPB Sidebar Layout CSS Width Fix, handlePageSelection() — Theme Editor Deep Link Builder (+31 more)
 
 ### Community 3060 - "Community 3060"
-Cohesion: 0.40
-Nodes (5): Community 15, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+Cohesion: 0.05
+Nodes (41): 0. EB's Complete Bundle Editor — Section Map, 10. Select Template — Bundle Layout Themes, 11. Cart Transform Implications (Refined), 13. Wolfpack-Specific Differentiators (Updated), 14. Screenshots Index, 15. Summary, 1. Theme Extension Banner, 2. Readiness Score System (+33 more)
 
 ### Community 3061 - "Community 3061"
 Cohesion: 0.33
 Nodes (5): Acceptance Criteria, FullPageRuntimeCartSettingsMethods, Purpose, Test Cases, Test Spec: FPB Template Stylesheet Switch
 
 ### Community 3062 - "Community 3062"
-Cohesion: 0.33
-Nodes (3): Community 1466, Live Query (requires Dataview plugin), Members
+Cohesion: 0.29
+Nodes (7): GCP Pub/Sub Removal (@google-cloud/pubsub), Pub/Sub → Render Webhook Migration — Architecture ADR, Pub/Sub → Render Webhook Migration — Business Requirement, Pub/Sub → Render Webhook Migration — PO Requirements, Pub/Sub → Render Webhook Migration — SDE Implementation, Render Webhook Worker HTTP Server, Shopify HMAC-SHA256 Webhook Signature Validation
+
+### Community 3063 - "Community 3063"
+Cohesion: 0.29
+Nodes (6): 2026-07-06 Attribution LCP Follow-up, Admin Performance, Critical Path Rule, Embedded Admin LCP Findings, Removed Custom Telemetry, Web Vitals Source
 
 ### Community 3064 - "Community 3064"
 Cohesion: 0.25
@@ -15831,8 +15879,12 @@ Cohesion: 0.40
 Nodes (5): Community 23, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
 
 ### Community 3071 - "Community 3071"
-Cohesion: 0.50
-Nodes (4): FPB Template Architecture (Two-Field System), Phase 4 — Template Enumeration and Variant Display DOM, PPB `displayVariantsAsIndividualProducts: true` DOM Rendering, PPB Template Table (Complete)
+Cohesion: 0.33
+Nodes (6): Graph-Assisted Debugging & RCA, graphify, Impact Analysis — Mandatory Before Every Change, Keeping the Graph Current, Keeping the Vault Current, Mandatory Search Order
+
+### Community 3072 - "Community 3072"
+Cohesion: 0.33
+Nodes (5): Bundle Status, Bundle Types, Full-Page Bundle (FPB), Inventory Sync, Product-Page Bundle (PDP)
 
 ### Community 3073 - "Community 3073"
 Cohesion: 0.25
@@ -15849,6 +15901,10 @@ Nodes (3): Building the function, Dependencies, Shopify Function development wit
 ### Community 3077 - "Community 3077"
 Cohesion: 0.12
 Nodes (12): bundleParentVariantId (Critical Field for MERGE), Connections, Cart Transform 10KB Metafield Query Limit, Connections, Cart Transform Optimization - InstructionCountLimitExceededError (2025-10-06), Connections, Connections, InstructionCountLimitExceededError Fix (Oct 2025) (+4 more)
+
+### Community 3078 - "Community 3078"
+Cohesion: 0.33
+Nodes (5): Acceptance Criteria, ComponentVariantMetafields, Purpose, Test Cases, Test Spec: Component Variant GID Normalization
 
 ### Community 3080 - "Community 3080"
 Cohesion: 0.17
@@ -15871,8 +15927,12 @@ Cohesion: 0.33
 Nodes (6): `bundle_details` Cart Metafield, Cart Integration, FPB Cart Add Flow, FPB vs PPB Cart Add Comparison, PPB Cart Add Flow, `_wolfpackProductBundle:OfferId` Format
 
 ### Community 3089 - "Community 3089"
-Cohesion: 0.07
-Nodes (20): Add-to-Bundle Button Selected Color Architecture, Connections, Add-to-Bundle Button Selected Color SDE Plan, Connections, bundle-widget.css, Connections, buttonAddedBgColor / buttonAddedTextColor Prisma Fields, Connections (+12 more)
+Cohesion: 0.33
+Nodes (5): Acceptance Criteria, FpbSaveTransport, Purpose, Test Cases, Test Spec: FPB Save Transport Cleanup
+
+### Community 3090 - "Community 3090"
+Cohesion: 0.18
+Nodes (8): bundle-widget-full-page-bundled.js, Connections, bundle-widget-product-page-bundled.js, Connections, Concept: Widget Bundle Build Process, Connections, Connections, Widget Bundle Build System
 
 ### Community 3091 - "Community 3091"
 Cohesion: 0.33
@@ -15922,21 +15982,45 @@ Nodes (3): 8. Error Handling & Fallbacks, Debug Information:, Graceful Degradati
 Cohesion: 0.33
 Nodes (3): Live Query (requires Dataview plugin), Members, Template Manager (Widget Shared)
 
+### Community 3108 - "Community 3108"
+Cohesion: 0.22
+Nodes (6): Compact Array Component Format, Connections, Connections, Legacy Object Component Format, Connections, parseComponents Function (Checkout.tsx)
+
+### Community 3109 - "Community 3109"
+Cohesion: 0.33
+Nodes (3): Community 1466, Live Query (requires Dataview plugin), Members
+
 ### Community 3111 - "Community 3111"
-Cohesion: 0.40
-Nodes (5): Community 26, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+Cohesion: 0.33
+Nodes (3): Live Query (requires Dataview plugin), Members, Test Runner
 
 ### Community 3112 - "Community 3112"
 Cohesion: 0.40
 Nodes (5): Community 12, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
 
+### Community 3113 - "Community 3113"
+Cohesion: 0.07
+Nodes (18): Concept: BundleStatus/BundleType Enums, Connections, Concept: Unlisted Bundle Status, Connections, Connections, Issue: Centralize Constants & Mappings (Phase 2), Connections, Issue: Remove Console Logs from Widget Files (+10 more)
+
 ### Community 3115 - "Community 3115"
-Cohesion: 0.04
-Nodes (41): Ad-Ready Bundle Infrastructure Feature Specification, Connections, Analytics Page Redesign PO Requirements, Connections, Analytics Pixel Toggle PO Requirements, Connections, Bundle Variant Price Fix ($0 to Calculated), Connections (+33 more)
+Cohesion: 0.33
+Nodes (4): Connections, Feature: FPB Auto-Advance to Next Step on Condition Met (400ms delay), Connections, Issue: FPB Widget UX Improvements (fpb-widget-ux-1)
 
 ### Community 3116 - "Community 3116"
 Cohesion: 0.33
 Nodes (5): Acceptance Criteria, Purpose, StandardSidebarSlotTiles, Test Cases, Test Spec: FPB Standard Slots And Modal Reserved Controls
+
+### Community 3117 - "Community 3117"
+Cohesion: 0.33
+Nodes (4): Connections, OAuth Scope Changes Requiring Re-Authentication, Connections, shopify.app.toml
+
+### Community 3118 - "Community 3118"
+Cohesion: 0.14
+Nodes (10): App Navigation Map (docs/app-nav-map/), Connections, Claude Code Development Guidelines, Connections, Connections, No Backwards Compatibility Rule, Connections, Rationale: No Backwards Compatibility (Sync Bundle replaces it) (+2 more)
+
+### Community 3119 - "Community 3119"
+Cohesion: 0.50
+Nodes (5): Ad-Ready Bundles Architecture Decision Record, Ad-Ready Bundles PO Requirements, Ad-Ready Bundles SDE Implementation Plan, Rationale: Option A (Direct GraphQL via unauthenticated.admin) Selected, unauthenticated.admin() Offline Session Pattern
 
 ### Community 3121 - "Community 3121"
 Cohesion: 0.40
@@ -15962,29 +16046,73 @@ Nodes (3): 1. Overview, How It Works (Architecture Principle), Target Advertisin
 Cohesion: 0.67
 Nodes (3): 7. Bundle Selection Priority, Cart Transform Bundles:, Discount Function Bundles:
 
+### Community 3130 - "Community 3130"
+Cohesion: 0.40
+Nodes (5): 🚫 No UI Styling or Placement Unit Tests, 🧪 Test-Driven Development (TDD), Test file locations, Test Spec Files — Mandatory in TDD Sessions, What must be tested
+
+### Community 3133 - "Community 3133"
+Cohesion: 0.40
+Nodes (5): Feature Pipeline (BR→PO→Architect→SDE), Issue Tracking System (docs/issues-prod/), Test-Driven Development (Red-Green-Refactor), Rationale: Feature Pipeline Mandatory to Prevent Premature Coding, Rationale: TDD Ensures Correct Behavior Before Implementation
+
+### Community 3134 - "Community 3134"
+Cohesion: 0.40
+Nodes (5): Community 15, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+
 ### Community 3135 - "Community 3135"
 Cohesion: 0.33
 Nodes (5): C01 Category Pills Delta, EB Evidence, Source Decision, Verification, WPB Evidence
 
+### Community 3136 - "Community 3136"
+Cohesion: 0.40
+Nodes (5): Community 22, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+
+### Community 3139 - "Community 3139"
+Cohesion: 0.40
+Nodes (5): Community 4, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+
+### Community 3140 - "Community 3140"
+Cohesion: 0.67
+Nodes (3): 🖱️ Chrome DevTools — Shopify Admin Iframe Interaction, FALLBACK — `evaluate_script` via CDP target, PRIMARY METHOD — Keyboard Tab Navigation
+
+### Community 3141 - "Community 3141"
+Cohesion: 0.67
+Nodes (3): 🎯 EB Implementation Reference — Grounded Truth for Porting, Mandatory search order for EB porting questions, What it covers
+
 ### Community 3143 - "Community 3143"
-Cohesion: 0.11
-Nodes (14): Connections, Custom Brandable URL Slugs for Full-Page Bundles, Connections, FPB Widget Not Showing On Storefront, Connections, Full-Page Bundle Placeholder Fix, Connections, Full-Page Bundle Shopify Page Template (+6 more)
+Cohesion: 0.67
+Nodes (3): No Backwards Compatibility Rule, Sync Bundle Feature (merchant re-sync), Rationale: No Backwards Compatibility (Sync Bundle replaces it)
 
 ### Community 3145 - "Community 3145"
 Cohesion: 0.40
 Nodes (4): Admin Provider Flow, Gotcha, Mantle Integration, Verification
 
+### Community 3151 - "Community 3151"
+Cohesion: 0.25
+Nodes (7): Acceptance Criteria, ComponentVariantMetafields, FullPageRuntimePayload, PricingMetafieldSerialization, Purpose, Test Cases, Test Spec: Cart Transform Real Merchant Root Issue
+
 ### Community 3155 - "Community 3155"
 Cohesion: 0.40
 Nodes (5): Community 7, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+
+### Community 3156 - "Community 3156"
+Cohesion: 0.33
+Nodes (5): Acceptance Criteria, PreviewPromotion, Purpose, Test Cases, Test Spec: FPB Preview Promotion Page Name
+
+### Community 3157 - "Community 3157"
+Cohesion: 0.33
+Nodes (5): Acceptance Criteria, Purpose, StorefrontProductNormalization, Test Cases, Test Spec: OOS Product Card Price
 
 ### Community 3158 - "Community 3158"
 Cohesion: 0.50
 Nodes (4): 🔴 HIGH PRIORITY: Add Access Controls, 🟢 LOW PRIORITY: Documentation, 🟡 MEDIUM PRIORITY: Testing Checklist, Recommendations
 
 ### Community 3161 - "Community 3161"
-Cohesion: 0.02
-Nodes (77): api.install-pdp-widget Route, Connections, App Navigation Map (docs/app-nav-map/), Connections, Connections, buildCartItems(), Bundle Config Metafield Cache (data-bundle-config), Connections (+69 more)
+Cohesion: 0.17
+Nodes (8): Connections, ESLint Lint-Before-Commit Rule, Connections, Free Gift Step Support, Connections, freeGiftBadgeUrl DCP Setting, Connections, Rationale: Lint Before Commit Prevents ESLint Errors in PRs
+
+### Community 3162 - "Community 3162"
+Cohesion: 0.33
+Nodes (5): Acceptance Criteria, FullPageBundleSlugPersistence, Purpose, Test Cases, Test Spec: Page URL Slug Save
 
 ### Community 3164 - "Community 3164"
 Cohesion: 0.02
@@ -15994,17 +16122,53 @@ Nodes (87): bundle-checkout-ui Extension (Checkout UI), Connections, bundle-chec
 Cohesion: 0.33
 Nodes (5): Acceptance Criteria, AddonTierSummaryState, Purpose, Test Cases, Test Spec: FPB Classic Add-on Sidebar Stacking
 
-### Community 3166 - "Community 3166"
-Cohesion: 0.40
-Nodes (5): Connections to other communities, Live Query (requires Dataview plugin), Members, Metafield Architecture, Top bridge nodes
+### Community 3168 - "Community 3168"
+Cohesion: 0.04
+Nodes (38): api.install-pdp-widget Route, Connections, Bundle Toast CSS Variables, Connections, Connections, CSS Variables Generator (css-variables-generator.ts), Connections, DCP Handlers Server (handlers.server.ts) (+30 more)
 
 ### Community 3175 - "Community 3175"
 Cohesion: 0.67
 Nodes (3): 4. Cart Transform Integration, Bundle Instance ID Generation:, Cart Properties Added:
 
+### Community 3178 - "Community 3178"
+Cohesion: 0.33
+Nodes (4): Connections, Default Lottie Loading Animation - Architecture Decision Record, Connections, scripts/build-widget-bundles.js
+
+### Community 3180 - "Community 3180"
+Cohesion: 0.33
+Nodes (4): Connections, Issue: Full-Page Bundle Pre-Storefront Preview, Connections, Shopify Draft Page + shareablePreviewUrl
+
 ### Community 3181 - "Community 3181"
 Cohesion: 0.19
 Nodes (6): buildBundleTrendSeries Function (until param), Connections, BundleKpiRow Component, Connections, Connections, Rationale: Option B (Action on Attribution Route) Selected for Pixel Toggle
+
+### Community 3190 - "Community 3190"
+Cohesion: 0.40
+Nodes (5): Community 14, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+
+### Community 3191 - "Community 3191"
+Cohesion: 0.40
+Nodes (5): Community 25, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+
+### Community 3194 - "Community 3194"
+Cohesion: 0.40
+Nodes (5): Community 2, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+
+### Community 3196 - "Community 3196"
+Cohesion: 0.40
+Nodes (5): Community 3, Connections to other communities, Live Query (requires Dataview plugin), Members, Top bridge nodes
+
+### Community 3240 - "Community 3240"
+Cohesion: 0.22
+Nodes (6): Connections, Feature Pipeline (BR→PO→Architect→SDE), Connections, Issue Tracking System (docs/issues-prod/), Connections, Rationale: Feature Pipeline Mandatory to Prevent Premature Coding
+
+### Community 3252 - "Community 3252"
+Cohesion: 0.33
+Nodes (4): Connections, Rationale: TDD Ensures Correct Behavior Before Implementation, Connections, Test-Driven Development (Red-Green-Refactor)
+
+### Community 3253 - "Community 3253"
+Cohesion: 0.33
+Nodes (4): Connections, Rationale: WIDGET_VERSION Bump for CDN Cache Busting, Connections, WIDGET_VERSION Semantic Versioning Rule
 
 ### Community 3296 - "Community 3296"
 Cohesion: 0.13
@@ -16175,7 +16339,7 @@ Cohesion: 0.33
 Nodes (6): Exit criteria, Goal, Loop 15: Cross-Template Regression Matrix, Required state matrix, Required template matrix, Required viewport matrix
 
 ### Community 4391 - "Community 4391"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (5): Acceptance criteria, Actions, Chrome tests, Goal, Loop 10: Horizontal Template Mobile Footer
 
 ### Community 4392 - "Community 4392"
@@ -16319,7 +16483,7 @@ Cohesion: 0.40
 Nodes (5): Implementation Notes, Loop 0: Refactored Codebase Discovery, Loop 10: Horizontal Totals and CTA Area, Loop 1: EB/WPB Desktop Sidebar Evidence and First Horizontal Slice, Loop 2: Horizontal Selected Product Row Parity
 
 ### Community 6054 - "Community 6054"
-Cohesion: 0.33
+Cohesion: 0.40
 Nodes (5): Acceptance criteria, Actions, Goal, Loop 0: Discovery and Guardrail Setup, Rules
 
 ### Community 6055 - "Community 6055"
@@ -16339,7 +16503,7 @@ Cohesion: 0.40
 Nodes (5): Acceptance criteria, Breakpoint guard, Goal, Loop 11: Cross-Template Regression Matrix, Required matrix
 
 ### Community 6060 - "Community 6060"
-Cohesion: 0.40
+Cohesion: 0.50
 Nodes (4): Acceptance Criteria, Actions, Goal, Loop 0: Discovery And Ownership Map
 
 ### Community 6061 - "Community 6061"
@@ -16551,7 +16715,7 @@ Cohesion: 0.29
 Nodes (6): Acceptance Criteria, FullPagePersonalizationAddons, FullPageValidationAddons, Purpose, Test Cases, Test Spec: Add-ons / Gifting Step Separation
 
 ### Community 6154 - "Community 6154"
-Cohesion: 0.50
+Cohesion: 0.40
 Nodes (4): Acceptance Criteria, Goal, Loop 8: Text Button And Quantity Selector Parity, Required Behavior
 
 ### Community 6155 - "Community 6155"
@@ -16699,24 +16863,24 @@ Cohesion: 0.22
 Nodes (5): code, detectedSources, getGraphifyPythonFromUvTool(), getUvToolDir(), validFileTypes
 
 ## Knowledge Gaps
-- **22197 isolated node(s):** `CLEAR_CART_CONFIRMATION_COPY`, `CLOSE_ICON`, `DELETE_ICON`, `DEFAULT_CART_LINE_LABELS`, `AccordionItemProps` (+22192 more)
+- **22225 isolated node(s):** `CLEAR_CART_CONFIRMATION_COPY`, `CLOSE_ICON`, `DELETE_ICON`, `DEFAULT_CART_LINE_LABELS`, `AccordionItemProps` (+22220 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **566 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **527 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `_getStepRequiredQuantity()` connect `Community 182` to `Community 429`?**
-  _High betweenness centrality (0.004) - this node is a cross-community bridge._
-- **Why does `bundle-widget-full-page.js Widget Source` connect `Community 1116` to `Community 392`, `Community 904`, `Community 394`, `Bundle Configuration Handlers`, `Community 652`, `Community 782`, `Community 783`, `Community 658`, `Community 786`, `Community 915`, `Community 426`, `Community 1079`, `Community 183`, `Community 440`, `Community 331`, `Community 3068`, `Community 98`, `Community 359`, `Community 488`, `Community 2920`, `Community 2408`, `Community 885`, `Community 1399`, `Community 890`, `Community 1659`, `Community 1660`?**
-  _High betweenness centrality (0.004) - this node is a cross-community bridge._
 - **Why does `toNumber()` connect `Community 429` to `Community 182`?**
   _High betweenness centrality (0.004) - this node is a cross-community bridge._
+- **Why does `_getStepRequiredQuantity()` connect `Community 182` to `Community 429`?**
+  _High betweenness centrality (0.004) - this node is a cross-community bridge._
+- **Why does `bundle-widget-full-page.js Widget Source` connect `Community 1116` to `Community 392`, `Community 1673`, `Community 394`, `Bundle Configuration Handlers`, `Community 652`, `Community 904`, `Community 782`, `Community 911`, `Community 658`, `Community 786`, `Community 915`, `Community 426`, `Community 1072`, `Community 183`, `Community 62`, `Community 331`, `Community 3068`, `Community 98`, `Community 359`, `Community 488`, `Community 2408`, `Community 3059`, `Community 885`, `Community 1399`, `Community 1659`, `Community 1660`?**
+  _High betweenness centrality (0.003) - this node is a cross-community bridge._
 - **What connects `CLEAR_CART_CONFIRMATION_COPY`, `CLOSE_ICON`, `DELETE_ICON` to the rest of the system?**
-  _22197 weakly-connected nodes found - possible documentation gaps or missing edges._
-- **Should `Full-Page Bundle Widget (Bundled)` be split into smaller, more focused modules?**
-  _Cohesion score 0.059887005649717516 - nodes in this community are weakly interconnected._
+  _22225 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Product-Page Bundle Widget (Bundled)` be split into smaller, more focused modules?**
   _Cohesion score 0.005763688760806916 - nodes in this community are weakly interconnected._
 - **Should `Full-Page Bundle Widget (Source)` be split into smaller, more focused modules?**
   _Cohesion score 0.03571428571428571 - nodes in this community are weakly interconnected._
+- **Should `Product-Page Bundle Widget (Source)` be split into smaller, more focused modules?**
+  _Cohesion score 0.08333333333333333 - nodes in this community are weakly interconnected._

--- a/internal docs/Architecture/Cart Transform Function.md
+++ b/internal docs/Architecture/Cart Transform Function.md
@@ -71,6 +71,12 @@ The function groups cart lines by EB's public `_wolfpackProductBundle:OfferId` c
    - `title`: bundle name (must be **unique per instance** to prevent Shopify's automatic consolidation of duplicate merges — append `" (2)"`, `" (3)"`, etc. via `bundleNameCounts` Map)
 2. **EXPAND**: Breaks the merged line back into components at checkout for fulfillment
 
+### Component variant metafield owner IDs
+
+`component_parents` must be written to Shopify ProductVariant GIDs, not cached numeric variant IDs. A real merchant failure on 2026-07-07 had an active `cart.transform.run` object and correct cart line `_wolfpackProductBundle:OfferId` properties, but cart lines remained unmerged because cached `StepProduct.variants` contained numeric IDs such as `51659604984106`. Passing those numeric values as `metafieldsSet.ownerId` prevents Shopify from attaching `$app:component_parents`, so the Function input sees null component metadata and emits no `linesMerge` operation.
+
+Normalize every cached variant identifier into `gid://shopify/ProductVariant/{id}` before adding it to `component_reference.value` or using it as a metafield owner.
+
 ---
 
 ## Pricing

--- a/internal docs/Shopify Integration/Metafields.md
+++ b/internal docs/Shopify Integration/Metafields.md
@@ -25,6 +25,8 @@ data-bundle-config='{"v":2,"type":"full_page","bundleType":"full_page","id":"...
 
 The hidden `data-wpb-full-page-bundle` marker written by `app/services/widget-installation/widget-full-page-bundle.server.ts` uses the same compact payload. The template and preset fields are lightweight visual route hints only; the widget still hydrates current products, steps, rules, and pricing through the app-proxy bundle API before rendering.
 
+FPB runtime layout is template/preset-driven. `bundleDesignTemplate: "FBP_SIDE_FOOTER"` selects the full-page side-footer renderer and `bundleDesignPresetId` selects Standard, Classic, Compact, or Horizontal styling. The older `Bundle.fullPageLayout` database column is legacy storage only until a future schema migration; it must not be emitted in Admin save transport, app-proxy widget payloads, or FPB runtime metafield configs.
+
 ### Reader (Widget JS)
 `app/assets/bundle-widget-full-page.js` → `loadBundleData()`
 
@@ -47,6 +49,8 @@ Saving a placed FPB refreshes the hidden page-body marker before writing page me
 Shopify metafield values have a 64KB hard limit. The bundle variant `$app.bundle_ui_config` payload is especially sensitive for category-backed FPB/PPB bundles because category products can include rich product, image, option, and variant objects.
 
 Runtime category payloads must be compacted at `app/lib/bundle-config/category-runtime.ts` before they are written by `app/services/bundles/metafield-sync/operations/bundle-product.server.ts`. Preserve storefront-required fields only: product IDs/title/handle/image/price/weight, compact product options, and compact variants with ID/title/price/compare-at/weight/availability/inventory/options/image/selling-plan data. Strip admin/cache-only fields such as metafields, SKU, selectedOptions blobs, inventory policy, timestamps, and extra image metadata.
+
+Admin save transport should follow the same compact-field policy before posting `stepsData`. The route-level FPB save serializer is responsible for stripping picker/Admin graph data while preserving the product, variant, collection, category, and rule fields needed by persistence and storefront runtime generation.
 
 ## FPB Preview Cache Contract
 

--- a/internal docs/Shopify Integration/Storefront API.md
+++ b/internal docs/Shopify Integration/Storefront API.md
@@ -1,0 +1,17 @@
+---
+title: Shopify Storefront API Notes
+type: reference
+last_audited: 2026-07-07
+---
+
+# Shopify Storefront API Notes
+
+## Product descriptions
+
+Use `Product.descriptionHtml` when rendering merchant-authored product descriptions in storefront UI. Shopify documents `Product.description` as the plain string with HTML tags removed, while `Product.descriptionHtml` is the HTML scalar that preserves merchant formatting such as bold and italic text.
+
+For product detail modals, query and preserve both fields:
+
+- `descriptionHtml` is the primary render source.
+- `description` remains the plain-text fallback when HTML is absent.
+

--- a/internal docs/index.md
+++ b/internal docs/index.md
@@ -36,6 +36,7 @@ Full evidence record: `docs/competitor-analysis/16-eb-full-data-flow-investigati
 - [[Architecture/Widget Architecture]] — FPB + PDP widgets, load strategy, versioning
 - [[Architecture/State Management]] — Redux Toolkit slices, RTK Query endpoint boundaries, and AppStateService migration rules
 - [[Shopify Integration/Admin API]] — Rate limits, GraphQL patterns, session handling
+- [[Shopify Integration/Storefront API]] — Storefront GraphQL field gotchas, including product description HTML handling
 - [[Shopify Integration/Cart Transform API]] — Operations, targets, API versions (2025-10)
 - [[Shopify Integration/Checkout UI Extension]] — Preact targets, build rules
 - [[Shopify Integration/Metafields]] — Bundle config metafield sync strategy

--- a/scripts/build-widget-bundles.js
+++ b/scripts/build-widget-bundles.js
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT_DIR = join(__dirname, '..');
 
-const WIDGET_VERSION = '5.0.90';
+const WIDGET_VERSION = '5.0.92';
 
 // Shared component modules (in dependency order)
 const SHARED_MODULES = [

--- a/test-spec/component-variant-gid-normalization.spec.md
+++ b/test-spec/component-variant-gid-normalization.spec.md
@@ -1,0 +1,19 @@
+# Test Spec: Component Variant GID Normalization
+**Spec ID:** component-variant-gid-normalization  **Created:** 2026-07-07
+
+## Purpose
+Ensure component product metafield sync writes Shopify `component_parents` to valid ProductVariant GIDs even when cached bundle product variants are stored as numeric IDs.
+
+## Test Cases
+### ComponentVariantMetafields
+| # | Scenario | Input | Expected Output | Notes |
+|---|---|---|---|---|
+| 1 | Cached StepProduct variants are numeric | Variants `51659604984106` and `51658221388074` | `ownerId` and `component_reference.value` use `gid://shopify/ProductVariant/...` | Cart Transform can read `$app:component_parents` on selected variants |
+| 2 | Fixed bundle pricing is configured | `fixed_bundle_price` rule with `fixedBundlePrice: 770` | `price_adjustment` keeps method, value, and quantity condition | Keeps real merchant fixed-price bundles discountable after MERGE |
+
+## Acceptance Criteria
+- [x] Numeric cached variant IDs are normalized before metafield writes.
+- [x] Existing component-product metafield sync tests pass.
+- [x] Cart Transform input query still validates against Shopify schema.
+- [x] Rust Cart Transform tests still pass.
+

--- a/test-spec/fpb-save-transport.spec.md
+++ b/test-spec/fpb-save-transport.spec.md
@@ -1,0 +1,19 @@
+# Test Spec: FPB Save Transport Cleanup
+**Spec ID:** fpb-save-transport  **Created:** 2026-07-08
+
+## Purpose
+Ensure full-page bundle Admin saves use a compact step transport DTO and stop carrying the legacy `fullPageLayout` field outside the database.
+
+## Test Cases
+### FpbSaveTransport
+| # | Scenario | Input | Expected Output | Notes |
+|---|---|---|---|---|
+| 1 | Compact product/category transport | Step with bulky product picker fields, variants, category products, and collections | Serializer keeps save/runtime product, variant, image, option, category, and collection fields while dropping bulky unused fields | Behavior test for transport output |
+| 2 | Selected collection override | Step has stale collections and selectedCollections contains current step collections | Serialized step collections use selectedCollections for that step | Matches current save controller behavior |
+| 3 | Legacy layout omitted | Save FormData omits or includes fullPageLayout | Parser/handler does not expose or persist fullPageLayout | DB column remains untouched by this save path |
+| 4 | Widget payload layout contract | Formatted FPB bundle has template/preset fields | Runtime payload has no fullPageLayout | FPB layout is driven by template/preset |
+
+## Acceptance Criteria
+- [ ] All listed test cases pass.
+- [ ] Existing FPB save, category, runtime config, and formatter tests continue to pass.
+- [ ] Chrome dev verification confirms save request omits `fullPageLayout` and sends compact `stepsData`.

--- a/test-spec/product-modal-description-html.spec.md
+++ b/test-spec/product-modal-description-html.spec.md
@@ -1,0 +1,27 @@
+# Test Spec: Product Modal Description HTML
+**Spec ID:** product-modal-description-html  **Created:** 2026-07-07
+
+## Purpose
+Render Shopify product descriptions in the product modal using the HTML Shopify serves through Storefront API `descriptionHtml`, while preserving plain-text fallback descriptions.
+
+## Test Cases
+### StorefrontProductPayloads
+| # | Scenario | Input | Expected Output | Notes |
+| 1 | Direct product fetch includes rich description | Storefront API product node has `descriptionHtml` | `/api/storefront-products` response includes `descriptionHtml` | Shopify docs define `descriptionHtml` as HTML-bearing field |
+| 2 | Collection product fetch includes rich description | Collection product node has `descriptionHtml` | `/api/storefront-collections` response includes `descriptionHtml` | Required for category/collection bundles |
+
+### WidgetNormalization
+| # | Scenario | Input | Expected Output | Notes |
+| 1 | FPB product has `descriptionHtml` | Product processor normalizes product | `descriptionHtml` remains HTML and `description` remains text fallback | Modal can render HTML |
+| 2 | PPB product has `descriptionHtml` | Product processor normalizes product | `descriptionHtml` remains HTML | Shared modal can render HTML |
+| 3 | Missing description enrichment fetches HTML | Storefront API enrichment returns `descriptionHtml` | Cached product receives `descriptionHtml` | Fixes stale/incomplete metafield cache |
+
+### ProductModal
+| # | Scenario | Input | Expected Output | Notes |
+| 1 | Modal product has `descriptionHtml` | `<p>Copy <strong>bold</strong></p>` | Modal description renders HTML nodes | Do not use `textContent` for Shopify HTML |
+| 2 | Modal product has only plain `description` | `Plain copy` | Modal description renders plain text safely | Existing fallback remains |
+
+## Acceptance Criteria
+- [x] All listed test cases pass
+- [x] Storefront API GraphQL query validates against Shopify Storefront schema
+- [x] Widget bundles are rebuilt after JS changes

--- a/tests/unit/assets/bundle-widget-product-page-products.test.ts
+++ b/tests/unit/assets/bundle-widget-product-page-products.test.ts
@@ -37,6 +37,7 @@ interface StorefrontProduct {
   options?: Array<string | { name: string }>;
   images?: Array<{ src?: string }>;
   description?: string;
+  descriptionHtml?: string;
 }
 
 interface WidgetStep {
@@ -332,6 +333,29 @@ describe('Product Page widget product-level inventory tracking', () => {
       available: false,
       quantityAvailable: 0,
       currentlyNotInStock: false,
+    });
+  });
+
+  it('preserves Shopify descriptionHtml for the shared product modal', () => {
+    const products = processProductPageProductsForStep([
+      {
+        id: 'gid://shopify/Product/123',
+        title: 'Product with HTML',
+        description: 'Plain description',
+        descriptionHtml: '<p>Plain <strong>description</strong></p>',
+        imageUrl: 'https://cdn.example.test/product.jpg',
+        variants: [{
+          id: 'gid://shopify/ProductVariant/456',
+          title: 'Default Title',
+          price: '10.00',
+          available: true,
+        }],
+      },
+    ], { displayVariantsAsIndividual: false }, false);
+
+    expect(products[0]).toMatchObject({
+      description: 'Plain description',
+      descriptionHtml: '<p>Plain <strong>description</strong></p>',
     });
   });
 

--- a/tests/unit/assets/fpb-product-modal-readonly.test.ts
+++ b/tests/unit/assets/fpb-product-modal-readonly.test.ts
@@ -52,6 +52,43 @@ describe("FPB product modal read-only quick view", () => {
     return new TestModal(widget);
   }
 
+  async function createModalForPopulate(widget: ReturnType<typeof buildWidget>) {
+    await import("../../../app/assets/bundle-modal-component.js");
+    const Modal = ((globalThis as typeof globalThis & { window: { BundleProductModal: new (widget: unknown) => any } }).window)
+      .BundleProductModal;
+    const elements: Record<string, any> = {
+      "modal-product-title": { textContent: "" },
+      "modal-product-description": { textContent: "", innerHTML: "" },
+      "modal-qty-display": { textContent: "" },
+    };
+    (globalThis as typeof globalThis & { document: any }).document = {
+      body: {
+        classList: createClassList(),
+      },
+      getElementById: (id: string) => elements[id] ?? null,
+    };
+
+    class TestModal extends Modal {
+      init() {
+        this.modalElement = {
+          classList: createClassList(),
+          dataset: {},
+          querySelector: () => null,
+        };
+      }
+
+      loadImage() {}
+
+      createVariantSelectors() {}
+
+      updatePrice() {}
+
+      updateReadOnlyState() {}
+    }
+
+    return { modal: new TestModal(widget), elements };
+  }
+
   const product = {
     id: "product-1",
     variantId: "variant-1",
@@ -92,6 +129,41 @@ describe("FPB product modal read-only quick view", () => {
     expect(widget.updateProductSelection).toHaveBeenCalledWith(0, "variant-1", 1);
     const isActive = modal.modalElement.classList.contains("active");
     expect(isActive).toBe(false);
+  });
+
+  it("renders Shopify product descriptionHtml as modal HTML", async () => {
+    const widget = buildWidget();
+    const { modal, elements } = await createModalForPopulate(widget);
+
+    modal.currentProduct = {
+      ...product,
+      description: "Soft cotton product description.",
+      descriptionHtml: "<p>Soft <strong>cotton</strong> product description.</p>",
+    };
+    modal.selectedQuantity = 1;
+    modal.populateModal();
+
+    expect(elements["modal-product-description"].innerHTML).toBe(
+      "<p>Soft <strong>cotton</strong> product description.</p>",
+    );
+    expect(elements["modal-product-description"].textContent).toBe("");
+  });
+
+  it("renders plain product descriptions as text when descriptionHtml is missing", async () => {
+    const widget = buildWidget();
+    const { modal, elements } = await createModalForPopulate(widget);
+
+    modal.currentProduct = {
+      ...product,
+      description: "Plain <strong>text</strong> fallback.",
+    };
+    modal.selectedQuantity = 1;
+    modal.populateModal();
+
+    expect(elements["modal-product-description"].textContent).toBe(
+      "Plain <strong>text</strong> fallback.",
+    );
+    expect(elements["modal-product-description"].innerHTML).toBe("");
   });
 
   it("clears stale variant summary when opening a single-variant product", async () => {

--- a/tests/unit/assets/fpb-standard-variant-availability.test.ts
+++ b/tests/unit/assets/fpb-standard-variant-availability.test.ts
@@ -192,6 +192,33 @@ describe('FPB Standard variant availability', () => {
     expect(normalized[0].description).toBe('Soft cotton product description.');
   });
 
+  it('preserves Shopify descriptionHtml for the product detail modal', () => {
+    const normalized = fullPageProductProcessingMethods.processProductsForStep.call({
+      extractId: (id: string) => String(id || '').split('/').pop(),
+      shouldExpandStepProductsDuringLoad: () => false,
+      getFirstAvailableVariant: (product: any) => product.variants[0],
+      isVariantSelectableForInventory: () => true,
+      _getLandingPageControls: () => ({ trackInventoryOnAddToCart: false }),
+    }, [{
+      id: 'gid://shopify/Product/123',
+      title: 'Black Crew Neck T-Shirt',
+      description: 'Soft cotton product description.',
+      descriptionHtml: '<p>Soft <strong>cotton</strong> product description.</p>',
+      imageUrl: 'https://cdn.example.test/product.jpg',
+      variants: [
+        {
+          id: 'gid://shopify/ProductVariant/456',
+          title: 'S / Black',
+          price: '30.00',
+          available: true,
+        },
+      ],
+    }], { displayVariantsAsIndividual: false });
+
+    expect(normalized[0].description).toBe('Soft cotton product description.');
+    expect(normalized[0].descriptionHtml).toBe('<p>Soft <strong>cotton</strong> product description.</p>');
+  });
+
   it('keeps unavailable grouped products priced from their first variant', () => {
     const normalized = fullPageProductProcessingMethods.processProductsForStep.call({
       extractId: (id: string) => String(id || '').split('/').pop(),
@@ -240,6 +267,7 @@ describe('FPB Standard variant availability', () => {
         products: [{
           id: 'gid://shopify/Product/123',
           description: 'Fetched product description.',
+          descriptionHtml: '<p>Fetched <strong>product</strong> description.</p>',
         }],
       }),
     });
@@ -256,6 +284,7 @@ describe('FPB Standard variant availability', () => {
         expect.stringContaining('/apps/product-bundles/api/storefront-products'),
       );
       expect(enriched[0].description).toBe('Fetched product description.');
+      expect(enriched[0].descriptionHtml).toBe('<p>Fetched <strong>product</strong> description.</p>');
     } finally {
       (global as any).window = previousWindow;
       (global as any).fetch = previousFetch;

--- a/tests/unit/lib/bundle-formatter.test.ts
+++ b/tests/unit/lib/bundle-formatter.test.ts
@@ -62,10 +62,10 @@ describe("formatBundleForWidget", () => {
     expect(result.steps).toHaveLength(0);
   });
 
-  it("nullifies optional fields when absent", () => {
-    const bundle = makeBundle({ fullPageLayout: undefined });
+  it("omits the legacy fullPageLayout field from widget payloads", () => {
+    const bundle = makeBundle({ fullPageLayout: "footer_bottom" });
     const result = formatBundleForWidget(bundle as any);
-    expect(result.fullPageLayout).toBeNull();
+    expect(result).not.toHaveProperty("fullPageLayout");
   });
 
   it("defaults full-page bundles to Standard Design when template fields are absent", () => {

--- a/tests/unit/routes/fpb-metafield-runtime-config.test.ts
+++ b/tests/unit/routes/fpb-metafield-runtime-config.test.ts
@@ -121,5 +121,6 @@ describe("FPB runtime metafield config", () => {
       discountValue: 770,
       fixedBundlePrice: 4999,
     });
+    expect(config).not.toHaveProperty("fullPageLayout");
   });
 });

--- a/tests/unit/routes/fpb-save-bundle.test.ts
+++ b/tests/unit/routes/fpb-save-bundle.test.ts
@@ -289,6 +289,18 @@ describe("FPB handleSaveBundle — no shopifyProductId (skips metafields)", () =
     );
   });
 
+  it("does not persist legacy fullPageLayout from old save payloads", async () => {
+    await handleSaveBundle(
+      MOCK_ADMIN,
+      MOCK_SESSION,
+      "bundle-1",
+      makeFormData({ fullPageLayout: "footer_bottom" }),
+    );
+
+    const updateArgs = getDb().bundle.update.mock.calls[0][0];
+    expect(updateArgs.data).not.toHaveProperty("fullPageLayout");
+  });
+
   it("persists direct bundleUpsellConfig from current full-page visibility controls", async () => {
     const bundleUpsellConfig = makeBundleUpsellConfig();
     await handleSaveBundle(

--- a/tests/unit/routes/fpb-save-transport.test.ts
+++ b/tests/unit/routes/fpb-save-transport.test.ts
@@ -1,0 +1,144 @@
+import { serializeFpbSaveSteps } from "../../../app/routes/app/app.bundles.full-page-bundle.configure.$bundleId/fpb-save-transport";
+
+describe("serializeFpbSaveSteps", () => {
+  it("keeps the save/runtime fields and drops bulky picker-only fields", () => {
+    const steps = [
+      {
+        id: "step-1",
+        name: "Pick one",
+        pageTitle: "Choose your product",
+        minQuantity: "1",
+        maxQuantity: "3",
+        enabled: true,
+        displayVariantsAsIndividual: true,
+        multiLangData: { en: { name: "Pick one" } },
+        stepImage: "https://cdn.example.test/step.png",
+        filters: [{ label: "Featured", value: "featured" }],
+        products: [{ id: "gid://shopify/Product/legacy" }],
+        collections: [{ id: "gid://shopify/Collection/stale", title: "Stale" }],
+        StepProduct: [
+          {
+            id: "gid://shopify/Product/123",
+            graphqlId: "gid://shopify/Product/123",
+            handle: "test-product",
+            title: "Test Product",
+            descriptionHtml: "<p>Rich description</p>",
+            imageUrl: "https://cdn.example.test/product.jpg",
+            images: [
+              { originalSrc: "https://cdn.example.test/product.jpg", width: 1600, height: 1600 },
+              { originalSrc: "https://cdn.example.test/unused.jpg" },
+            ],
+            featuredImage: { url: "https://cdn.example.test/featured.jpg", altText: "Alt text" },
+            options: [{ name: "Size", values: ["S", "M"] }],
+            variants: [
+              {
+                id: "gid://shopify/ProductVariant/111",
+                title: "Small",
+                price: "19.99",
+                compareAtPrice: "24.99",
+                availableForSale: true,
+                selectedOptions: [{ name: "Size", value: "S" }],
+                image: { url: "https://cdn.example.test/variant.jpg", width: 1200 },
+                inventoryItem: { tracked: true },
+              },
+            ],
+            media: { nodes: [{ id: "media-1" }] },
+            metafields: { nodes: [{ key: "large" }] },
+            variantsConnection: { edges: [{ node: { id: "unused" } }] },
+          },
+        ],
+        StepCategory: [
+          {
+            id: "category-1",
+            name: "Category",
+            title: "Category",
+            subTitle: "Sub",
+            sortOrder: 0,
+            products: [{ id: "gid://shopify/Product/123" }],
+            selectedProducts: [{ id: "gid://shopify/Product/123", title: "Test Product" }],
+            collectionsSelectedData: [
+              {
+                id: "gid://shopify/Collection/222",
+                collectionId: "222",
+                admin_graphql_api_id: "gid://shopify/Collection/222",
+                handle: "collection",
+                title: "Collection",
+                rules: [{ column: "tag" }],
+              },
+            ],
+            conditions: [{ type: "quantity", operator: ">=", value: "1" }],
+            categoryBanner: "https://cdn.example.test/banner.jpg",
+            multiLangData: { en: { title: "Category" } },
+            productsConnection: { edges: [{ node: { id: "unused" } }] },
+          },
+        ],
+        addonLabel: "legacy add-on",
+        freeGiftName: "legacy gift",
+      },
+    ];
+
+    const result = serializeFpbSaveSteps(steps, {
+      "step-1": [{ id: "gid://shopify/Collection/999", handle: "fresh", title: "Fresh" }],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "step-1",
+      name: "Pick one",
+      pageTitle: "Choose your product",
+      minQuantity: "1",
+      maxQuantity: "3",
+      enabled: true,
+      displayVariantsAsIndividual: true,
+      isFreeGift: false,
+      freeGiftName: null,
+      addonLabel: null,
+      addonTitle: null,
+      addonIconUrl: null,
+      addonDisplayFree: false,
+      addonTiers: [],
+      collections: [{ id: "gid://shopify/Collection/999", handle: "fresh", title: "Fresh" }],
+    });
+    expect(result[0].StepProduct[0]).toMatchObject({
+      id: "gid://shopify/Product/123",
+      graphqlId: "gid://shopify/Product/123",
+      handle: "test-product",
+      title: "Test Product",
+      descriptionHtml: "<p>Rich description</p>",
+      imageUrl: "https://cdn.example.test/product.jpg",
+      images: [{ originalSrc: "https://cdn.example.test/product.jpg" }],
+      featuredImage: { url: "https://cdn.example.test/featured.jpg" },
+      options: [{ name: "Size", values: ["S", "M"] }],
+      variants: [
+        {
+          id: "gid://shopify/ProductVariant/111",
+          title: "Small",
+          price: "19.99",
+          compareAtPrice: "24.99",
+          available: true,
+          option1: "S",
+          image: { src: "https://cdn.example.test/variant.jpg" },
+        },
+      ],
+    });
+    expect(result[0].StepProduct[0]).not.toHaveProperty("media");
+    expect(result[0].StepProduct[0]).not.toHaveProperty("metafields");
+    expect(result[0].StepProduct[0]).not.toHaveProperty("variantsConnection");
+    expect(result[0].StepCategory[0]).toMatchObject({
+      id: "category-1",
+      title: "Category",
+      products: [{ id: "gid://shopify/Product/123" }],
+      selectedProducts: [{ id: "gid://shopify/Product/123", title: "Test Product" }],
+      collectionsSelectedData: [
+        {
+          id: "gid://shopify/Collection/222",
+          collectionId: "222",
+          admin_graphql_api_id: "gid://shopify/Collection/222",
+          handle: "collection",
+          title: "Collection",
+        },
+      ],
+    });
+    expect(result[0].StepCategory[0]).not.toHaveProperty("productsConnection");
+  });
+});

--- a/tests/unit/routes/fpb-show-text-on-add-button.test.ts
+++ b/tests/unit/routes/fpb-show-text-on-add-button.test.ts
@@ -29,6 +29,13 @@ describe("FPB Show Text on + Button persistence", () => {
     ).toBe(false);
   });
 
+  it("does not expose legacy fullPageLayout from FPB save form data", () => {
+    const formData = buildSaveForm(true);
+    formData.append("fullPageLayout", "footer_bottom");
+
+    expect(parseFpbSaveBundleForm(formData)).not.toHaveProperty("fullPageLayout");
+  });
+
   it("emits showTextOnAddButton to the storefront payload without requiring button copy", () => {
     const result = formatBundleForWidget({
       id: "bundle-1",
@@ -36,7 +43,6 @@ describe("FPB Show Text on + Button persistence", () => {
       description: null,
       status: "ACTIVE",
       bundleType: "full_page",
-      fullPageLayout: "FOOTER_BOTTOM",
       shopifyProductId: null,
       steps: [],
       pricing: null,

--- a/tests/unit/routes/storefront-collections.test.ts
+++ b/tests/unit/routes/storefront-collections.test.ts
@@ -57,6 +57,7 @@ describe("api.storefront-collections loader", () => {
                           title: "Ring",
                           handle: "ring",
                           description: "Ring product description",
+                          descriptionHtml: "<p>Ring <strong>product</strong> description</p>",
                           featuredImage: { url: "https://cdn.example/ring.jpg" },
                           variants: {
                             edges: [
@@ -99,6 +100,7 @@ describe("api.storefront-collections loader", () => {
       weightUnit: "OUNCES",
     });
     expect(body.products[0].description).toBe("Ring product description");
+    expect(body.products[0].descriptionHtml).toBe("<p>Ring <strong>product</strong> description</p>");
   });
 
   it("preserves variant option fields for grouped product variant selectors", async () => {

--- a/tests/unit/routes/storefront-products.test.ts
+++ b/tests/unit/routes/storefront-products.test.ts
@@ -56,6 +56,7 @@ describe("api.storefront-products loader", () => {
                 title: "Tracked Product",
                 handle: "tracked-product",
                 description: "Detailed product copy",
+                descriptionHtml: "<p>Detailed <strong>product</strong> copy</p>",
                 featuredImage: null,
                 variants: {
                   edges: [
@@ -98,5 +99,6 @@ describe("api.storefront-products loader", () => {
       currentlyNotInStock: false,
     });
     expect(body.products[0].description).toBe("Detailed product copy");
+    expect(body.products[0].descriptionHtml).toBe("<p>Detailed <strong>product</strong> copy</p>");
   });
 });

--- a/tests/unit/services/bundle-product-metafield.test.ts
+++ b/tests/unit/services/bundle-product-metafield.test.ts
@@ -614,6 +614,19 @@ describe("updateBundleProductMetafields", () => {
         operator: "gte",
         value: 3,
       },
+      rules: [{
+        method: "buy_x_get_y",
+        value: 100,
+        customerBuys: 2,
+        customerGets: 1,
+        discountType: "percentage",
+        applyDiscountTo: "lowest_priced",
+        conditions: {
+          type: "quantity",
+          operator: "gte",
+          value: 3,
+        },
+      }],
     });
   });
 });

--- a/tests/unit/services/component-product-metafield.test.ts
+++ b/tests/unit/services/component-product-metafield.test.ts
@@ -118,6 +118,49 @@ describe("updateComponentProductMetafields", () => {
     expect(mockBatchGetProductVariants).not.toHaveBeenCalled();
   });
 
+  it("normalizes numeric cached StepProduct variant IDs before writing component_parents", async () => {
+    const admin = makeAdmin();
+    const config = {
+      steps: [
+        {
+          minQuantity: 1,
+          StepProduct: [
+            {
+              productId: "gid://shopify/Product/123",
+              variants: [
+                { id: "51659604984106" },
+                { variantId: 51658221388074 },
+              ],
+            },
+          ],
+        },
+      ],
+      pricing: {
+        enabled: true,
+        method: "fixed_bundle_price",
+        rules: [{ conditionType: "quantity", conditionValue: 2, discountValue: 770, fixedBundlePrice: 770 }],
+      },
+    };
+
+    await updateComponentProductMetafields(admin as any, "gid://shopify/Product/999", config);
+
+    const writes = getMetafieldSetCalls(admin);
+    expect(writes.map((write: any) => write.ownerId).sort()).toEqual([
+      "gid://shopify/ProductVariant/51658221388074",
+      "gid://shopify/ProductVariant/51659604984106",
+    ]);
+    const parsed = JSON.parse(writes[0].value);
+    expect(parsed[0].component_reference.value).toEqual([
+      "gid://shopify/ProductVariant/51659604984106",
+      "gid://shopify/ProductVariant/51658221388074",
+    ]);
+    expect(parsed[0].price_adjustment).toMatchObject({
+      method: "fixed_bundle_price",
+      value: 770,
+      conditions: { type: "quantity", operator: "gte", value: 2 },
+    });
+  });
+
   it("falls back to batchGetProductVariants when StepProduct has no cached variants", async () => {
     mockBatchGetProductVariants.mockResolvedValue(
       new Map([["123", { success: true, variantIds: ["gid://shopify/ProductVariant/F1"] }]]),


### PR DESCRIPTION
Impact: touches FPB configure save transport, storefront widget product data, metafield sync, and generated widget assets.

Affected: FPB save form parsing, save controller, widget formatter payloads, Storefront product/collection APIs, component parent metafields, full-page/product-page widget bundles.

Tested by: npx jest tests/unit/assets/bundle-widget-product-page-products.test.ts tests/unit/assets/fpb-product-modal-readonly.test.ts tests/unit/assets/fpb-standard-variant-availability.test.ts tests/unit/lib/bundle-formatter.test.ts tests/unit/routes/fpb-metafield-runtime-config.test.ts tests/unit/routes/fpb-save-bundle.test.ts tests/unit/routes/fpb-save-transport.test.ts tests/unit/routes/fpb-show-text-on-add-button.test.ts tests/unit/routes/storefront-collections.test.ts tests/unit/routes/storefront-products.test.ts tests/unit/services/bundle-product-metafield.test.ts tests/unit/services/component-product-metafield.test.ts --runInBand; node --check modified widget JS files; npm run build:widgets; modified-file eslint 0 errors.

Note: full-project eslint still has pre-existing errors in app/routes/app/app.settings/SettingsFeedback.tsx; npm run graphify:rebuild is blocked locally by graphify Python Operation not permitted.